### PR TITLE
Add a fullscreen button on participant videos and screenshares

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
@@ -28,6 +28,7 @@ import { RiHand } from '@remixicon/react'
 import { useRaisedHand } from '@/features/rooms/livekit/hooks/useRaisedHand'
 import { HStack } from '@/styled-system/jsx'
 import { MutedMicIndicator } from '@/features/rooms/livekit/components/MutedMicIndicator'
+import { FullscreenToggle } from '@/features/rooms/livekit/components/controls/FullscreenToggle'
 
 export function TrackRefContextIfNeeded(
   props: React.PropsWithChildren<{
@@ -174,6 +175,7 @@ export const ParticipantTile: (
             </>
           )}
           {!disableMetadata && <FocusToggle trackRef={trackReference} />}
+          {!disableMetadata && <FullscreenToggle trackRef={trackReference} />}
         </ParticipantContextIfNeeded>
       </TrackRefContextIfNeeded>
     </div>

--- a/src/frontend/src/features/rooms/livekit/components/controls/FullscreenToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/FullscreenToggle.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import {
+  LayoutContext,
+  useMaybeTrackRefContext,
+} from '@livekit/components-react'
+import { RiFullscreenLine } from '@remixicon/react'
+import { useFullscreenToggle } from '@/features/rooms/livekit/hooks/useFullscreenToggle'
+import type { TrackReferenceOrPlaceholder } from '@livekit/components-core'
+
+export interface FullscreenToggleProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  trackRef?: TrackReferenceOrPlaceholder
+}
+
+export const FullscreenToggle = React.forwardRef<
+  HTMLButtonElement,
+  FullscreenToggleProps
+>(function FullscreenToggle(
+  { trackRef, ...props }: FullscreenToggleProps,
+  ref
+) {
+  const trackRefFromContext = useMaybeTrackRefContext()
+  const { enterFullscreen, isFullscreenAvailable } = useFullscreenToggle(
+    trackRef ?? trackRefFromContext
+  )
+
+  if (!isFullscreenAvailable) return null
+
+  return (
+    <LayoutContext.Consumer>
+      {(layoutContext) =>
+        layoutContext !== undefined && (
+          <button
+            ref={ref}
+            className="lk-button lk-focus-toggle-button lk-fullscreen-toggle-button"
+            onClick={enterFullscreen}
+            {...props}
+          >
+            <RiFullscreenLine size={16} />
+          </button>
+        )
+      }
+    </LayoutContext.Consumer>
+  )
+})

--- a/src/frontend/src/features/rooms/livekit/hooks/useFullscreenToggle.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useFullscreenToggle.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react'
+import { TrackReferenceOrPlaceholder } from '@livekit/components-core'
+
+export const useFullscreenToggle = (trackRef?: TrackReferenceOrPlaceholder) => {
+  const getFullscreenElement = useCallback(() => {
+    if (!trackRef?.publication?.track) return null
+    const elements = trackRef.publication.track.attachedElements
+
+    // Find the visible video element
+    const likeKitElement = elements.find((el) =>
+      el.classList.contains('lk-participant-media-video')
+    )
+
+    if (!likeKitElement) {
+      console.warn('Could not find LiveKit-managed video element')
+      return elements[0] || null
+    }
+
+    return likeKitElement
+  }, [trackRef])
+
+  const enterFullscreen = useCallback(async () => {
+    const element = getFullscreenElement()
+    if (!element) return
+
+    try {
+      if (element.requestFullscreen) {
+        await element.requestFullscreen()
+      } else if ((element as any).webkitRequestFullscreen) {
+        await (element as any).webkitRequestFullscreen()
+      } else if ((element as any).msRequestFullscreen) {
+        await (element as any).msRequestFullscreen()
+      }
+    } catch (e) {
+      console.error('Error requesting fullscreen:', e)
+    }
+  }, [getFullscreenElement])
+
+  return {
+    enterFullscreen,
+    isFullscreenAvailable: document.fullscreenEnabled,
+  }
+}

--- a/src/frontend/src/styles/index.css
+++ b/src/frontend/src/styles/index.css
@@ -38,3 +38,7 @@ body:has(.lk-video-conference) #crisp-chatbox > div > a {
     transform: translateY(0);
   }
 }
+
+.lk-fullscreen-toggle-button {
+  right: 2em !important;
+}


### PR DESCRIPTION
As suggested by @lebaudantoine. Fixes #131.

Needs to be reviewed and tested :-) I'm not sure how it behaves on all supported mobiles for instance.

Cheers!