### PR TITLE
✨(front) turn on camera when applying effects

### DIFF
--- a/src/frontend/panda.config.ts
+++ b/src/frontend/panda.config.ts
@@ -121,6 +121,32 @@ const config: Config = {
         '50%': { opacity: '0.65' },
         '100%': { opacity: '1' },
       },
+      rotate: {
+        '0%': {
+          transform: 'rotate(0deg)',
+        },
+        '100%': {
+          transform: 'rotate(360deg)',
+        },
+      },
+      prixClipFix: {
+        '0%': {
+          clipPath: 'polygon(50% 50%, 0 0, 0 0, 0 0, 0 0, 0 0)',
+        },
+        '25%': {
+          clipPath: 'polygon(50% 50%, 0 0, 100% 0, 100% 0, 100% 0, 100% 0)',
+        },
+        '50%': {
+          clipPath:
+            'polygon(50% 50%, 0 0, 100% 0, 100% 100%, 100% 100%, 100% 100%)',
+        },
+        '75%': {
+          clipPath: 'polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 100%)',
+        },
+        '100%': {
+          clipPath: 'polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 0)',
+        },
+      },
     },
     tokens: defineTokens({
       /* we take a few things from the panda preset but for now we clear out some stuff.

--- a/src/frontend/src/features/rooms/livekit/components/effects/EffectsConfiguration.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/effects/EffectsConfiguration.tsx
@@ -12,6 +12,8 @@ import { styled } from '@/styled-system/jsx'
 import { BackgroundOptions } from '@livekit/track-processors'
 import { BlurOn } from '@/components/icons/BlurOn'
 import { BlurOnStrong } from '@/components/icons/BlurOnStrong'
+import { Loader } from '@/primitives/Loader'
+import { useSyncAfterDelay } from '@/hooks/useSyncAfterDelay'
 
 enum BlurRadius {
   NONE = 0,
@@ -44,6 +46,7 @@ export const EffectsConfiguration = ({
   const videoRef = useRef<HTMLVideoElement>(null)
   const { t } = useTranslation('rooms', { keyPrefix: 'effects' })
   const [processorPending, setProcessorPending] = useState(false)
+  const processorPendingReveal = useSyncAfterDelay(processorPending)
 
   useEffect(() => {
     const videoElement = videoRef.current
@@ -134,6 +137,7 @@ export const EffectsConfiguration = ({
         className={css({
           width: '100%',
           aspectRatio: 16 / 9,
+          position: 'relative',
         })}
       >
         {videoTrack && !videoTrack.isMuted ? (
@@ -168,6 +172,17 @@ export const EffectsConfiguration = ({
             >
               {t('activateCamera')}
             </P>
+          </div>
+        )}
+        {processorPendingReveal && (
+          <div
+            className={css({
+              position: 'absolute',
+              right: '8px',
+              bottom: '8px',
+            })}
+          >
+            <Loader />
           </div>
         )}
       </div>
@@ -212,7 +227,7 @@ export const EffectsConfiguration = ({
                     tooltip={tooltipLabel(ProcessorType.BLUR, {
                       blurRadius: BlurRadius.LIGHT,
                     })}
-                    isDisabled={processorPending}
+                    isDisabled={processorPendingReveal}
                     onChange={async () =>
                       await toggleEffect(ProcessorType.BLUR, {
                         blurRadius: BlurRadius.LIGHT,
@@ -232,7 +247,7 @@ export const EffectsConfiguration = ({
                     tooltip={tooltipLabel(ProcessorType.BLUR, {
                       blurRadius: BlurRadius.NORMAL,
                     })}
-                    isDisabled={processorPending}
+                    isDisabled={processorPendingReveal}
                     onChange={async () =>
                       await toggleEffect(ProcessorType.BLUR, {
                         blurRadius: BlurRadius.NORMAL,
@@ -280,7 +295,7 @@ export const EffectsConfiguration = ({
                         tooltip={tooltipLabel(ProcessorType.VIRTUAL, {
                           imagePath,
                         })}
-                        isDisabled={processorPending}
+                        isDisabled={processorPendingReveal}
                         onChange={async () =>
                           await toggleEffect(ProcessorType.VIRTUAL, {
                             imagePath,

--- a/src/frontend/src/hooks/useSyncAfterDelay.ts
+++ b/src/frontend/src/hooks/useSyncAfterDelay.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * If value stays truthy for more than waitFor ms, syncValue takes the value of value.
+ * @param value
+ * @param waitFor
+ * @returns
+ */
+export function useSyncAfterDelay<T>(value: T, waitFor: number = 300) {
+  const valueRef = useRef(value)
+  const timeoutRef = useRef<NodeJS.Timeout>()
+  const [syncValue, setSyncValue] = useState<T>()
+
+  useEffect(() => {
+    valueRef.current = value
+    if (value) {
+      if (!timeoutRef.current) {
+        timeoutRef.current = setTimeout(() => {
+          setSyncValue(valueRef.current)
+          timeoutRef.current = undefined
+        }, waitFor)
+      }
+    } else {
+      setSyncValue(value)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+
+  return syncValue
+}

--- a/src/frontend/src/primitives/Loader.tsx
+++ b/src/frontend/src/primitives/Loader.tsx
@@ -1,0 +1,45 @@
+import { cva } from '@/styled-system/css'
+
+const loader = cva({
+  base: {
+    borderRadius: '50%',
+    position: 'relative',
+    animation: 'rotate 1s linear infinite',
+    '&:before, &:after': {
+      content: '""',
+      boxSizing: 'border-box',
+      position: 'absolute',
+      inset: '0',
+      borderRadius: '50%',
+      borderStyle: 'solid',
+      borderColor: 'white',
+    },
+    _before: {
+      animation: 'prixClipFix 2s linear infinite',
+    },
+    _after: {
+      borderColor: 'white',
+      animation:
+        'prixClipFix 2s linear infinite, rotate 0.5s linear infinite reverse',
+      inset: 6,
+    },
+  },
+  variants: {
+    size: {
+      small: {
+        width: '24px',
+        height: '24px',
+        '&:before, &:after': {
+          borderWidth: '2px',
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'small',
+  },
+})
+
+export const Loader = () => {
+  return <div className={loader()}></div>
+}

--- a/src/frontend/src/primitives/buttonRecipe.ts
+++ b/src/frontend/src/primitives/buttonRecipe.ts
@@ -101,6 +101,11 @@ export const buttonRecipe = cva({
         '&[data-selected]': {
           boxShadow: 'token(colors.primary.400) 0px 0px 0px 3px inset',
         },
+        '&[data-disabled]': {
+          backgroundColor: 'greyscale.100',
+          color: 'greyscale.400',
+          opacity: '0.7',
+        },
       },
       tertiary: {
         backgroundColor: 'primary.100',


### PR DESCRIPTION
## Enable camera when applying effects

https://github.com/user-attachments/assets/ecda3e64-56a5-4090-8f72-8718652b1f04




## Show loader if it takes times

`useSyncAfterDelay` allows to enable loading indicators only if the loading takes more than a specific time. It prevent blinking effect when the loading time is nearly instant. 

Loading effects:
- Loader on video
- Disable effect on effects buttons

Please see below

https://github.com/user-attachments/assets/43642734-d2dd-40d6-b46e-7ab59502ae13

