### PR TITLE
✨(helm) add pdbs to deployments

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -3,10 +3,8 @@ run-name: Release Chart
 
 on:
   push:
-    branches:
-      - 'main'
     paths:
-      - ./src/helm/meet/**
+      - src/helm/meet/**
 
 jobs:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/src/helm/meet/Chart.yaml
+++ b/src/helm/meet/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: meet
-version: 0.0.2
+version: 0.0.3

--- a/src/helm/meet/README.md
+++ b/src/helm/meet/README.md
@@ -82,6 +82,7 @@
 | `backend.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                         |                                                                                                                               |
 | `backend.extraVolumeMounts`                           | Additional volumes to mount on the backend.                                        | `[]`                                                                                                                          |
 | `backend.extraVolumes`                                | Additional volumes to mount on the backend.                                        | `[]`                                                                                                                          |
+| `backend.pdb.enabled`                                 | Enable pdb on backend                                                              | `true`                                                                                                                        |
 
 ### frontend
 
@@ -131,6 +132,7 @@
 | `frontend.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                          |                         |
 | `frontend.extraVolumeMounts`                           | Additional volumes to mount on the frontend.                                        | `[]`                    |
 | `frontend.extraVolumes`                                | Additional volumes to mount on the frontend.                                        | `[]`                    |
+| `frontend.pdb.enabled`                                 | Enable pdb on frontend                                                              | `true`                  |
 
 ### posthog
 
@@ -208,6 +210,7 @@
 | `summary.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                         |                    |
 | `summary.extraVolumeMounts`                           | Additional volumes to mount on the summary.                                        | `[]`               |
 | `summary.extraVolumes`                                | Additional volumes to mount on the summary.                                        | `[]`               |
+| `summary.pdb.enabled`                                 | Enable pdb on summary                                                              | `true`             |
 
 ### celery
 
@@ -255,3 +258,4 @@
 | `celery.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                        |             |
 | `celery.extraVolumeMounts`                           | Additional volumes to mount on the celery.                                        | `[]`        |
 | `celery.extraVolumes`                                | Additional volumes to mount on the celery.                                        | `[]`        |
+| `celery.pdb.enabled`                                 | Enable pdb on celery                                                              | `false`     |

--- a/src/helm/meet/templates/backend_deployment.yaml
+++ b/src/helm/meet/templates/backend_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.backend.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "meet.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/meet/templates/celery_deployment.yaml
+++ b/src/helm/meet/templates/celery_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.celery.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "meet.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/meet/templates/frontend_deployment.yaml
+++ b/src/helm/meet/templates/frontend_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.frontend.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "meet.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/meet/templates/summary_deployment.yaml
+++ b/src/helm/meet/templates/summary_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.summary.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "meet.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/meet/values.yaml
+++ b/src/helm/meet/values.yaml
@@ -120,8 +120,8 @@ backend:
     targetPort: 8000
     annotations: {}
 
- ## @param backend.migrate.command backend migrate command
- ## @param backend.migrate.restartPolicy backend migrate job restart policy
+  ## @param backend.migrate.command backend migrate command
+  ## @param backend.migrate.restartPolicy backend migrate job restart policy
   migrate:
     command:
       - "python"
@@ -130,8 +130,8 @@ backend:
       - "--no-input"
     restartPolicy: Never
 
- ## @param backend.createsuperuser.command backend migrate command
- ## @param backend.createsuperuser.restartPolicy backend migrate job restart policy
+  ## @param backend.createsuperuser.command backend migrate command
+  ## @param backend.createsuperuser.restartPolicy backend migrate job restart policy
   createsuperuser:
     command:
       - "/bin/sh"
@@ -184,6 +184,9 @@ backend:
   ## @param backend.extraVolumes Additional volumes to mount on the backend.
   extraVolumes: []
 
+  ## @param backend.pdb.enabled Enable pdb on backend
+  pdb:
+    enabled: true
 
 ## @section frontend
 
@@ -278,6 +281,10 @@ frontend:
 
   ## @param frontend.extraVolumes Additional volumes to mount on the frontend.
   extraVolumes: []
+
+  ## @param frontend.pdb.enabled Enable pdb on frontend
+  pdb:
+    enabled: true
 
 ## @section posthog
 
@@ -443,6 +450,9 @@ summary:
   ## @param summary.extraVolumes Additional volumes to mount on the summary.
   extraVolumes: []
 
+  ## @param summary.pdb.enabled Enable pdb on summary
+  pdb:
+    enabled: true
 
 ## @section celery
 
@@ -533,3 +543,6 @@ celery:
   ## @param celery.extraVolumes Additional volumes to mount on the celery.
   extraVolumes: []
 
+  ## @param celery.pdb.enabled Enable pdb on celery
+  pdb:
+    enabled: false


### PR DESCRIPTION
In order to avoid a service interruption during a Kubernetes (k8s) upgrade, we add a Pod Disruption Budget (PDB) to deployments.
