### PR TITLE
✏️(frontend) fix minor typo

### DIFF
--- a/src/frontend/src/locales/fr/settings.json
+++ b/src/frontend/src/locales/fr/settings.json
@@ -41,7 +41,7 @@
   },
   "settingsButtonLabel": "Paramètres",
   "tabs": {
-    "account": "Profile",
+    "account": "Profil",
     "audio": "Audio",
     "general": "Général",
     "notifications": "Notifications"


### PR DESCRIPTION
Typo identified by Celine. No "e" in french.

