### PR TITLE
lower hand autonomously for active speakers

### DIFF
--- a/src/frontend/src/features/notifications/MainNotificationToast.tsx
+++ b/src/frontend/src/features/notifications/MainNotificationToast.tsx
@@ -3,22 +3,10 @@ import { useRoomContext } from '@livekit/components-react'
 import { Participant, RemoteParticipant, RoomEvent } from 'livekit-client'
 import { ToastProvider, toastQueue } from './components/ToastProvider'
 import { NotificationType } from './NotificationType'
+import { NotificationDuration } from './NotificationDuration'
 import { Div } from '@/primitives'
 import { ChatMessage, isMobileBrowser } from '@livekit/components-core'
 import { useNotificationSound } from '@/features/notifications/hooks/useSoundNotification'
-
-enum ToastDuration {
-  SHORT = 3000,
-  MEDIUM = 4000,
-  LONG = 5000,
-}
-
-const NotificationDuration = {
-  ALERT: ToastDuration.SHORT,
-  MESSAGE: ToastDuration.LONG,
-  PARTICIPANT_JOINED: ToastDuration.LONG,
-  HAND_RAISED: ToastDuration.LONG,
-} as const
 
 export const MainNotificationToast = () => {
   const room = useRoomContext()

--- a/src/frontend/src/features/notifications/NotificationDuration.ts
+++ b/src/frontend/src/features/notifications/NotificationDuration.ts
@@ -1,0 +1,14 @@
+export enum ToastDuration {
+  SHORT = 3000,
+  MEDIUM = 4000,
+  LONG = 5000,
+  EXTRA_LONG = 7000,
+}
+
+export const NotificationDuration = {
+  ALERT: ToastDuration.SHORT,
+  MESSAGE: ToastDuration.LONG,
+  PARTICIPANT_JOINED: ToastDuration.LONG,
+  HAND_RAISED: ToastDuration.LONG,
+  LOWER_HAND: ToastDuration.EXTRA_LONG,
+} as const

--- a/src/frontend/src/features/notifications/NotificationType.ts
+++ b/src/frontend/src/features/notifications/NotificationType.ts
@@ -3,4 +3,5 @@ export enum NotificationType {
   HandRaised = 'handRaised',
   ParticipantMuted = 'participantMuted',
   MessageReceived = 'messageReceived',
+  LowerHand = 'lowerHand',
 }

--- a/src/frontend/src/features/notifications/components/ToastLowerHand.tsx
+++ b/src/frontend/src/features/notifications/components/ToastLowerHand.tsx
@@ -1,0 +1,45 @@
+import { useToast } from '@react-aria/toast'
+import { useRef } from 'react'
+
+import { StyledToastContainer, ToastProps } from './Toast'
+import { HStack } from '@/styled-system/jsx'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/primitives'
+
+export function ToastLowerHand({ state, ...props }: ToastProps) {
+  const { t } = useTranslation('notifications', { keyPrefix: 'lowerHand' })
+  const ref = useRef(null)
+  const { toastProps, contentProps } = useToast(props, state, ref)
+  const toast = props.toast
+
+  const handleDismiss = () => {
+    // Clear onClose handler to prevent lowering the hand when user dismisses
+    toast.onClose = undefined
+    state.close(toast.key)
+  }
+
+  return (
+    <StyledToastContainer {...toastProps} ref={ref}>
+      <HStack
+        justify="center"
+        alignItems="center"
+        {...contentProps}
+        padding={14}
+        gap={0}
+      >
+        <p>{t('auto')}</p>
+        <Button
+          size="sm"
+          variant="text"
+          style={{
+            color: '#60a5fa',
+            marginLeft: '0.5rem',
+          }}
+          onPress={() => handleDismiss()}
+        >
+          {t('dismiss')}
+        </Button>
+      </HStack>
+    </StyledToastContainer>
+  )
+}

--- a/src/frontend/src/features/notifications/components/ToastRegion.tsx
+++ b/src/frontend/src/features/notifications/components/ToastRegion.tsx
@@ -8,6 +8,7 @@ import { ToastData } from './ToastProvider'
 import { ToastRaised } from './ToastRaised'
 import { ToastMuted } from './ToastMuted'
 import { ToastMessageReceived } from './ToastMessageReceived'
+import { ToastLowerHand } from './ToastLowerHand'
 
 interface ToastRegionProps extends AriaToastRegionProps {
   state: ToastState<ToastData>
@@ -32,6 +33,9 @@ export function ToastRegion({ state, ...props }: ToastRegionProps) {
           return (
             <ToastMessageReceived key={toast.key} toast={toast} state={state} />
           )
+        }
+        if (toast.content?.type === NotificationType.LowerHand) {
+          return <ToastLowerHand key={toast.key} toast={toast} state={state} />
         }
         return <Toast key={toast.key} toast={toast} state={state} />
       })}

--- a/src/frontend/src/features/notifications/components/ToastRegion.tsx
+++ b/src/frontend/src/features/notifications/components/ToastRegion.tsx
@@ -1,5 +1,5 @@
 import { AriaToastRegionProps, useToastRegion } from '@react-aria/toast'
-import type { ToastState } from '@react-stately/toast'
+import type { QueuedToast, ToastState } from '@react-stately/toast'
 import { Toast } from './Toast'
 import { useRef } from 'react'
 import { NotificationType } from '../NotificationType'
@@ -14,31 +14,39 @@ interface ToastRegionProps extends AriaToastRegionProps {
   state: ToastState<ToastData>
 }
 
+const renderToast = (
+  toast: QueuedToast<ToastData>,
+  state: ToastState<ToastData>
+) => {
+  switch (toast.content?.type) {
+    case NotificationType.ParticipantJoined:
+      return <ToastJoined key={toast.key} toast={toast} state={state} />
+
+    case NotificationType.HandRaised:
+      return <ToastRaised key={toast.key} toast={toast} state={state} />
+
+    case NotificationType.ParticipantMuted:
+      return <ToastMuted key={toast.key} toast={toast} state={state} />
+
+    case NotificationType.MessageReceived:
+      return (
+        <ToastMessageReceived key={toast.key} toast={toast} state={state} />
+      )
+
+    case NotificationType.LowerHand:
+      return <ToastLowerHand key={toast.key} toast={toast} state={state} />
+
+    default:
+      return <Toast key={toast.key} toast={toast} state={state} />
+  }
+}
+
 export function ToastRegion({ state, ...props }: ToastRegionProps) {
   const ref = useRef(null)
   const { regionProps } = useToastRegion(props, state, ref)
   return (
     <div {...regionProps} ref={ref} className="toast-region">
-      {state.visibleToasts.map((toast) => {
-        if (toast.content?.type === NotificationType.ParticipantJoined) {
-          return <ToastJoined key={toast.key} toast={toast} state={state} />
-        }
-        if (toast.content?.type === NotificationType.HandRaised) {
-          return <ToastRaised key={toast.key} toast={toast} state={state} />
-        }
-        if (toast.content?.type === NotificationType.ParticipantMuted) {
-          return <ToastMuted key={toast.key} toast={toast} state={state} />
-        }
-        if (toast.content?.type === NotificationType.MessageReceived) {
-          return (
-            <ToastMessageReceived key={toast.key} toast={toast} state={state} />
-          )
-        }
-        if (toast.content?.type === NotificationType.LowerHand) {
-          return <ToastLowerHand key={toast.key} toast={toast} state={state} />
-        }
-        return <Toast key={toast.key} toast={toast} state={state} />
-      })}
+      {state.visibleToasts.map((toast) => renderToast(toast, state))}
     </div>
   )
 }

--- a/src/frontend/src/features/notifications/utils.ts
+++ b/src/frontend/src/features/notifications/utils.ts
@@ -1,0 +1,28 @@
+import { toastQueue } from './components/ToastProvider'
+import { NotificationType } from './NotificationType'
+import { NotificationDuration } from './NotificationDuration'
+import { Participant } from 'livekit-client'
+
+export const showLowerHandToast = (
+  participant: Participant,
+  onClose: () => void
+) => {
+  toastQueue.add(
+    {
+      participant,
+      type: NotificationType.LowerHand,
+    },
+    {
+      timeout: NotificationDuration.LOWER_HAND,
+      onClose,
+    }
+  )
+}
+
+export const closeLowerHandToasts = () => {
+  toastQueue.visibleToasts.forEach((toast) => {
+    if (toast.content.type === NotificationType.LowerHand) {
+      toastQueue.close(toast.key)
+    }
+  })
+}

--- a/src/frontend/src/features/rooms/livekit/components/controls/HandToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/HandToggle.tsx
@@ -4,6 +4,13 @@ import { ToggleButton } from '@/primitives'
 import { css } from '@/styled-system/css'
 import { useRoomContext } from '@livekit/components-react'
 import { useRaisedHand } from '@/features/rooms/livekit/hooks/useRaisedHand'
+import { useEffect, useRef, useState } from 'react'
+import {
+  closeLowerHandToasts,
+  showLowerHandToast,
+} from '@/features/notifications/utils'
+
+const SPEAKING_DETECTION_DELAY = 3000
 
 export const HandToggle = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'controls.hand' })
@@ -12,6 +19,39 @@ export const HandToggle = () => {
   const { isHandRaised, toggleRaisedHand } = useRaisedHand({
     participant: room.localParticipant,
   })
+
+  const isSpeaking = room.localParticipant.isSpeaking
+  const speakingTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const [hasShownToast, setHasShownToast] = useState(false)
+
+  const resetToastState = () => {
+    setHasShownToast(false)
+  }
+
+  useEffect(() => {
+    if (isHandRaised) return
+    closeLowerHandToasts()
+  }, [isHandRaised])
+
+  useEffect(() => {
+    const shouldShowToast = isSpeaking && isHandRaised && !hasShownToast
+
+    if (shouldShowToast && !speakingTimerRef.current) {
+      speakingTimerRef.current = setTimeout(() => {
+        setHasShownToast(true)
+        const onClose = () => {
+          if (isHandRaised) toggleRaisedHand()
+          resetToastState()
+        }
+        showLowerHandToast(room.localParticipant, onClose)
+      }, SPEAKING_DETECTION_DELAY)
+    }
+    if ((!isSpeaking || !isHandRaised) && speakingTimerRef.current) {
+      clearTimeout(speakingTimerRef.current)
+      speakingTimerRef.current = null
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSpeaking, isHandRaised, hasShownToast, toggleRaisedHand])
 
   const tooltipLabel = isHandRaised ? 'lower' : 'raise'
 
@@ -28,7 +68,10 @@ export const HandToggle = () => {
         aria-label={t(tooltipLabel)}
         tooltip={t(tooltipLabel)}
         isSelected={isHandRaised}
-        onPress={() => toggleRaisedHand()}
+        onPress={() => {
+          toggleRaisedHand()
+          resetToastState()
+        }}
         data-attr={`controls-hand-${tooltipLabel}`}
       >
         <RiHand />

--- a/src/frontend/src/locales/de/notifications.json
+++ b/src/frontend/src/locales/de/notifications.json
@@ -8,5 +8,9 @@
     "cta": ""
   },
   "muted": "",
-  "openChat": ""
+  "openChat": "",
+  "lowerHand": {
+    "auto": "",
+    "dismiss": ""
+  }
 }

--- a/src/frontend/src/locales/en/notifications.json
+++ b/src/frontend/src/locales/en/notifications.json
@@ -8,5 +8,9 @@
     "cta": "Open waiting list"
   },
   "muted": "{{name}} has muted your microphone. No participant can hear you.",
-  "openChat": "Open chat"
+  "openChat": "Open chat",
+  "lowerHand": {
+    "auto": "It seems you have started speaking, so your hand will be lowered.",
+    "dismiss": "Keep hand raised"
+  }
 }

--- a/src/frontend/src/locales/fr/notifications.json
+++ b/src/frontend/src/locales/fr/notifications.json
@@ -8,5 +8,9 @@
     "cta": "Ouvrir la file d'attente"
   },
   "muted": "{{name}} a coupé votre micro. Aucun participant ne peut l'entendre.",
-  "openChat": "Ouvrir le chat"
+  "openChat": "Ouvrir le chat",
+  "lowerHand": {
+    "auto": "Il semblerait que vous ayez pris la parole, donc la main va être baissée.",
+    "dismiss": "Laisser la main levée"
+  }
 }


### PR DESCRIPTION
Users requested that their raised hands be lowered automatically if they become the active speaker. This change ensures a more natural experience during discussions, preventing users from forgetting to lower their hand while speaking.

[Demo](https://www.loom.com/share/6794f906df2149498f7ea4933237f0f5)