### PR TITLE
🩹(frontend) fix visual regression on Ratings buttons

### DIFF
--- a/src/frontend/src/features/rooms/components/Rating.tsx
+++ b/src/frontend/src/features/rooms/components/Rating.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { styled, VStack } from '@/styled-system/jsx'
 import { usePostHog } from 'posthog-js/react'
 import { PostHog } from 'posthog-js'
+import { Button as RACButton } from 'react-aria-components'
 
 const Card = styled('div', {
   base: {
@@ -170,7 +171,7 @@ const RateQuality = ({
       <H lvl={3}>{t('question')}</H>
       <Bar>
         {[...Array(maxRating)].map((_, index) => (
-          <Button
+          <RACButton
             key={index}
             onPress={() => handleRatingClick(index + 1)}
             className={ratingButtonRecipe({
@@ -179,7 +180,7 @@ const RateQuality = ({
             })}
           >
             {index + 1}
-          </Button>
+          </RACButton>
         ))}
       </Bar>
       <div


### PR DESCRIPTION
Visual regression was introduced probably by a change on button style. As this button is quite different than the usual one, remove its inheritance from the primitive ones.
