### PR TITLE
🩹(frontend) fix screen sharing warnings browser compatibility

### DIFF
--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -200,7 +200,7 @@
     "fullScreen": "Full screen"
   },
   "fullScreenWarning": {
-    "message": "To avoid infinite loop display, do not share your entire screen or browser window. Instead, share a tab or another window.",
+    "message": "To avoid infinite loop display, do not share your entire screen. Instead, share a tab or another window.",
     "stop": "Stop presenting",
     "ignore": "Ignore"
   }

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -200,7 +200,7 @@
     "fullScreen": "Plein écran"
   },
   "fullScreenWarning": {
-    "message": "Pour éviter l'affichage en boucle infinie, ne partagez pas l'intégralité de votre écran ni de votre fenêtre de navigateur. Partagez plutôt un onglet ou une autre fenêtre.",
+    "message": "Pour éviter l'affichage en boucle infinie, ne partagez pas l'intégralité de votre écran. Partagez plutôt un onglet ou une autre fenêtre.",
     "stop": "Arrêter la présentation",
     "ignore": "Ignorer"
   }


### PR DESCRIPTION
This feature is far from perfect. Still not working on Safari. Also, we should display this warning when user shares the current opened window. Minor enhancement, I don't have time currently to prioritize these enhancements.

I've listed enhancements here : #355 

