### PR TITLE
⚡️(tilt) clean automatically old images

### DIFF
--- a/bin/Tiltfile
+++ b/bin/Tiltfile
@@ -1,6 +1,10 @@
 load('ext://uibutton', 'cmd_button', 'bool_input', 'location')
 load('ext://namespace', 'namespace_create', 'namespace_inject')
 namespace_create('meet')
+
+def clean_old_images(image_name):
+    local('docker images -q %s | tail -n +2 | xargs -r docker rmi' % image_name)
+
 docker_build(
     'localhost:5001/meet-backend:latest',
     context='..',
@@ -15,6 +19,7 @@ docker_build(
         )
     ]
 )
+clean_old_images('localhost:5001/meet-backend')
 
 docker_build(
     'localhost:5001/meet-frontend:latest',
@@ -26,6 +31,7 @@ docker_build(
         sync('../src/frontend', '/home/frontend'),
     ]
 )
+clean_old_images('localhost:5001/meet-frontend')
 
 docker_build(
     'localhost:5001/meet-summary:latest',
@@ -37,6 +43,7 @@ docker_build(
         sync('../src/summary', '/home/summary'),
     ]
 )
+clean_old_images('localhost:5001/meet-summary')
 
 k8s_yaml(local('cd ../src/helm && helmfile -n meet -e ${DEV_ENV:-dev} template .'))
 


### PR DESCRIPTION
Tilt live updates generate a new image for each change, ending up storing a lot of images when you are really developing with Tilt.

I have not found a built-in way of cleaning old images from Tilt documentation, I create a utility doing the dirty work.