### PR TITLE
🩹(frontend) fix missing key in reactions toolbar

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
@@ -69,8 +69,9 @@ export const ReactionsToggle = () => {
             display: 'flex',
           })}
         >
-          {EMOJIS.map((emoji) => (
+          {EMOJIS.map((emoji, index) => (
             <Button
+              key={index}
               onPress={() => sendReaction(emoji)}
               aria-label={t('send', { emoji })}
               variant="quaternaryText"


### PR DESCRIPTION
Emojis are a constant, so the reaction index remains stable, but using the index as a key isn't ideal.
