### PR TITLE
🐛(frontend) preserve line breaks and whitespace in chat messages

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/chat/Entry.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/chat/Entry.tsx
@@ -19,7 +19,6 @@ export const ChatEntry: (
   { entry, hideMetadata = false, messageFormatter, ...props }: ChatEntryProps,
   ref
 ) {
-  // Fixme - Livekit messageFormatter strips '\n' char
   const formattedMessage = React.useMemo(() => {
     return messageFormatter ? messageFormatter(entry.message) : entry.message
   }, [entry.message, messageFormatter])
@@ -58,6 +57,7 @@ export const ChatEntry: (
         variant="sm"
         margin={false}
         className={css({
+          whiteSpace: 'pre-wrap',
           '& .lk-chat-link': {
             color: 'blue',
             textDecoration: 'underline',


### PR DESCRIPTION
Add CSS styling to preserve return lines and whitespace in chat messages, fixing display issues that were causing broken line formatting.