### PR TITLE
Enhance Reactions Toolbar security

### DIFF
--- a/src/frontend/src/features/notifications/MainNotificationToast.tsx
+++ b/src/frontend/src/features/notifications/MainNotificationToast.tsx
@@ -7,7 +7,10 @@ import { NotificationDuration } from './NotificationDuration'
 import { Div } from '@/primitives'
 import { ChatMessage, isMobileBrowser } from '@livekit/components-core'
 import { useNotificationSound } from '@/features/notifications/hooks/useSoundNotification'
-import { Reaction } from '@/features/rooms/livekit/components/controls/ReactionsToggle'
+import {
+  EMOJIS,
+  Reaction,
+} from '@/features/rooms/livekit/components/controls/ReactionsToggle'
 import {
   ANIMATION_DURATION,
   ReactionPortals,
@@ -44,7 +47,7 @@ export const MainNotificationToast = () => {
   }, [room, triggerNotificationSound])
 
   const handleEmoji = (emoji: string, participant: Participant) => {
-    if (!emoji) return
+    if (!emoji || !EMOJIS.includes(emoji)) return
     const id = instanceIdRef.current++
     setReactions((prev) => [
       ...prev,

--- a/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
@@ -149,39 +149,3 @@ export const ReactionsToggle = () => {
     </>
   )
 }
-
-// export const ReactionsToolBar = () => {
-//   const { t } = useTranslation('rooms', { keyPrefix: 'controls.reactions' })
-//
-//   const [reactions, setReactions] = useState<Reaction[]>([])
-//   const instanceIdRef = useRef(0)
-//   const room = useRoomContext()
-//
-//   const sendReaction = async (emoji: string) => {
-//     const encoder = new TextEncoder()
-//     const payload: NotificationPayload = {
-//       type: NotificationType.ReactionReceived,
-//       data: {
-//         emoji: emoji,
-//       },
-//     }
-//     const data = encoder.encode(JSON.stringify(payload))
-//     await room.localParticipant.publishData(data, { reliable: true })
-//
-//     const newReaction = {
-//       id: instanceIdRef.current++,
-//       emoji,
-//       participant: room.localParticipant,
-//     }
-//     setReactions((prev) => [...prev, newReaction])
-//
-//     // Remove this reaction after animation
-//     setTimeout(() => {
-//       setReactions((prev) =>
-//         prev.filter((instance) => instance.id !== newReaction.id)
-//       )
-//     }, ANIMATION_DURATION)
-//   }
-//
-//   return <></>
-// }

--- a/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
@@ -13,7 +13,8 @@ import {
 import { Toolbar as RACToolbar } from 'react-aria-components'
 import { Participant } from 'livekit-client'
 
-const EMOJIS = ['👍', '👎', '👏', '❤️', '😂', '😮', '🎉']
+// eslint-disable-next-line react-refresh/only-export-components
+export const EMOJIS = ['👍', '👎', '👏', '❤️', '😂', '😮', '🎉']
 
 export interface Reaction {
   id: number
@@ -144,7 +145,6 @@ export const ReactionsToggle = () => {
           </div>
         )}
       </div>
-
       <ReactionPortals reactions={reactions} />
     </>
   )


### PR DESCRIPTION
A participant could send a forbidden emoji by using their LiveKit access token to obtain a LiveKit client and transmit data to other participants. Prevent this from happening.