### PR TITLE
🔒️(frontend) update meet-frontend image to address security vulnerabilities

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -38,7 +38,7 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:1.26-alpine AS frontend-production
 
 USER root
-RUN apk update && apk upgrade libssl3 libcrypto3 libxml2>=2.12.7-r2
+RUN apk update && apk upgrade libssl3 libcrypto3 libxml2>=2.12.7-r2 libxslt>=1.1.39-r2
 
 USER nginx
 


### PR DESCRIPTION

Fixed two HIGH severity vulnerabilities in libxslt:
- CVE-2024-55549: Use-After-Free in libxslt (xsltGetInheritedNsList)
- CVE-2025-24855: Use-After-Free in libxslt numbers.c

The image was manually updated as no more recent unprivileged nginx-based images were available. This addresses the security scan failures from Trivy.
