### PR TITLE
🐛(frontend) fix effect menu scroll

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/effects/Effects.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/effects/Effects.tsx
@@ -13,6 +13,7 @@ export const Effects = () => {
     <div
       className={css({
         padding: '0 1.5rem',
+        overflowY: 'scroll',
       })}
     >
       <EffectsConfiguration


### PR DESCRIPTION
Since refactoring, the effect side panel, was not scrollable anymore. Fixed it.