### PR TITLE
🩹(backend) invert operation order in participant handling

### DIFF
--- a/src/backend/core/services/lobby.py
+++ b/src/backend/core/services/lobby.py
@@ -221,18 +221,18 @@ class LobbyService:
             color=color,
         )
 
+        try:
+            self.notify_participants(room_id=room_id)
+        except LobbyNotificationError:
+            # If room not created yet, there is no participants to notify
+            pass
+
         cache_key = self._get_cache_key(room_id, participant_id)
         cache.set(
             cache_key,
             participant.to_dict(),
             timeout=settings.LOBBY_WAITING_TIMEOUT,
         )
-
-        try:
-            self.notify_participants(room_id=room_id)
-        except LobbyNotificationError:
-            # If room not created yet, there is no participants to notify
-            pass
 
         return participant
 


### PR DESCRIPTION
Invert operation sequence to first notify people in room before setting participant in cache. Fixes infinite loop issue caused by 3s cache timeout for waiting participants when requests take too long. Problem only occurred when notifications were delayed, as faster notification delivery masked the race condition.
