### PR TITLE
🔇(backend) reduce noisy logs in Sentry

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -19,6 +19,7 @@ from django.utils.translation import gettext_lazy as _
 import sentry_sdk
 from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -574,6 +575,9 @@ class Base(Configuration):
             # Add the application name to the Sentry scope
             scope = sentry_sdk.get_global_scope()
             scope.set_tag("application", "backend")
+
+            # Ignore the logs added by the DockerflowMiddleware
+            ignore_logger("request.summary")
 
 
 class Build(Base):


### PR DESCRIPTION
Ignore logs from DockerflowMiddleware
and minimize unnecessary log submissions.

