### PR TITLE
✨(backend) add env variable to configure marketing service timeout

### DIFF
--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -121,7 +121,9 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
             contact_data = ContactData(
                 email=email, attributes={"VISIO_SOURCE": ["SIGNIN"]}
             )
-            marketing_service.create_contact(contact_data, timeout=1)
+            marketing_service.create_contact(
+                contact_data, timeout=settings.BREVO_API_TIMEOUT
+            )
         except (ContactCreationError, ImproperlyConfigured, ImportError):
             pass
 

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -498,6 +498,9 @@ class Base(Configuration):
         converter=lambda x: int(x),  # pylint: disable=unnecessary-lambda
     )
     BREVO_API_CONTACT_ATTRIBUTES = values.DictValue({"VISIO_USER": True})
+    BREVO_API_TIMEOUT = values.PositiveIntegerValue(
+        1, environ_name="BREVO_API_TIMEOUT", environ_prefix=None
+    )
 
     # Lobby configurations
     LOBBY_KEY_PREFIX = values.Value(


### PR DESCRIPTION
This change allows the marketing service timeout to be easily adjusted via an environment variable, eliminating the need for a new software release. Additionally, the update makes the code more explicit and easier to maintain.
