### PR TITLE
🐛(licence) fix the copyright years in licence

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2023 DINUM/Etalab
+Copyright (c) 2024-2025 DINUM/Etalab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The project has started in 2024 and it is still active in 2025.

Yeah, it is not the most important commit of the repository 😅. 
I just found a bit weird to have these dates in the LICENCE file, and I thought it might be interesting to fix them.
Feel free to close if you disagree, I won't bother.