### PR TITLE
🩹(sdk) notify iframe parent when room is gathered through callback

### DIFF
--- a/src/frontend/src/features/sdk/routes/CreateMeetingButton.tsx
+++ b/src/frontend/src/features/sdk/routes/CreateMeetingButton.tsx
@@ -48,6 +48,12 @@ export const CreateMeetingButton = () => {
     setRoom(data.room)
     setCallbackId(undefined)
     setIsPending(false)
+    popupManager.sendRoomData({
+      room: {
+        url: getRouteUrl('room', data.room.slug),
+        ...data.room,
+      },
+    })
   }, [data])
 
   useEffect(() => {

--- a/src/frontend/src/features/sdk/utils/PopupManager.ts
+++ b/src/frontend/src/features/sdk/utils/PopupManager.ts
@@ -39,6 +39,11 @@ export class PopupManager {
     this.messageParent(ClientMessageType.STATE_CLEAR, {})
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public sendRoomData(data: { room: any }) {
+    this.messageParent(ClientMessageType.ROOM_CREATED, data)
+  }
+
   public setupMessageListener(
     onCallbackId: (id: string) => void,
     onRoomData: (data: CallbackCreationRoomData) => void
@@ -54,7 +59,7 @@ export class PopupManager {
         case PopupMessageType.ROOM_DATA:
           if (!data?.room) return
           onRoomData(data.room)
-          this.messageParent(ClientMessageType.ROOM_CREATED, {
+          this.sendRoomData({
             room: {
               url: getRouteUrl('room', data.room.slug),
               ...data.room,


### PR DESCRIPTION
On the first room creation, the iframe wasn't properly messaging the parent. Fixed it. Send the room data in any of the two methods to acquire it.
