### PR TITLE
Support media link to download recording

### DIFF
--- a/.github/workflows/meet.yml
+++ b/.github/workflows/meet.yml
@@ -135,6 +135,9 @@ jobs:
       STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
       LIVEKIT_API_SECRET: secret
       LIVEKIT_API_KEY: devkey
+      AWS_S3_ENDPOINT_URL: http://localhost:9000
+      AWS_S3_ACCESS_KEY_ID: meet
+      AWS_S3_SECRET_ACCESS_KEY: password
 
     steps:
       - name: Checkout repository
@@ -151,6 +154,33 @@ jobs:
         with:
           path: "src/backend/core/templates/mail"
           key: mail-templates-${{ hashFiles('src/mail/mjml') }}
+
+      - name: Start MinIO
+        run: |
+          docker pull minio/minio
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e "MINIO_ACCESS_KEY=meet" \
+            -e "MINIO_SECRET_KEY=password" \
+            -v /data/media:/data \
+            minio/minio server --console-address :9001 /data
+
+      # Tool to wait for a service to be ready
+      - name: Install Dockerize
+        run: |
+          curl -sSL https://github.com/jwilder/dockerize/releases/download/v0.8.0/dockerize-linux-amd64-v0.8.0.tar.gz | sudo tar -C /usr/local/bin -xzv
+
+      - name: Wait for MinIO to be ready
+        run: |
+          dockerize -wait tcp://localhost:9000 -timeout 10s
+
+      - name: Configure MinIO
+        run: |
+          MINIO=$(docker ps | grep minio/minio | sed -E 's/.*\s+([a-zA-Z0-9_-]+)$/\1/')
+          docker exec ${MINIO} sh -c \
+            "mc alias set meet http://localhost:9000 meet password && \
+            mc alias ls && \
+            mc mb meet/meet-media-storage"
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,37 @@ services:
     ports:
       - "1081:1080"
 
+  minio:
+    user: ${DOCKER_USER:-1000}
+    image: minio/minio
+    environment:
+      - MINIO_ROOT_USER=meet
+      - MINIO_ROOT_PASSWORD=password
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    healthcheck:
+      test: [ "CMD", "mc", "ready", "local" ]
+      interval: 1s
+      timeout: 20s
+      retries: 300
+    entrypoint: ""
+    command: minio server --console-address :9001 /data
+    volumes:
+      - ./data/media:/data
+
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+        restart: true
+    entrypoint: >
+      sh -c "
+      /usr/bin/mc alias set meet http://minio:9000 meet password && \
+      /usr/bin/mc mb meet/meet-media-storage && \
+      exit 0;"
+
   app-dev:
     build:
       context: .
@@ -40,6 +71,7 @@ services:
         - redis
         - nginx
         - livekit
+        - createbuckets
   
   celery-dev:
     user: ${DOCKER_USER:-1000}
@@ -73,6 +105,7 @@ services:
       - postgresql
       - redis
       - livekit
+      - minio
 
   celery:
     user: ${DOCKER_USER:-1000}

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -18,6 +18,9 @@ MEET_BASE_URL="http://localhost:8072"
 
 # Media
 STORAGES_STATICFILES_BACKEND=django.contrib.staticfiles.storage.StaticFilesStorage
+AWS_S3_ENDPOINT_URL=http://minio:9000
+AWS_S3_ACCESS_KEY_ID=meet
+AWS_S3_SECRET_ACCESS_KEY=password
 
 # OIDC
 OIDC_OP_JWKS_ENDPOINT=http://nginx:8083/realms/meet/protocol/openid-connect/certs

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -156,7 +156,7 @@ class RecordingSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Recording
-        fields = ["id", "room", "created_at", "updated_at", "status"]
+        fields = ["id", "room", "created_at", "updated_at", "status", "mode"]
         read_only_fields = fields
 
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -2,6 +2,7 @@
 
 import uuid
 from logging import getLogger
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.db.models import Q
@@ -20,7 +21,8 @@ from rest_framework import (
     status as drf_status,
 )
 
-from core import models, utils
+from core import enums, models, utils
+from core.recording.enums import FileExtension
 from core.recording.event.authentication import StorageEventAuthentication
 from core.recording.event.exceptions import (
     InvalidBucketError,
@@ -618,3 +620,85 @@ class RecordingViewSet(
         return drf_response.Response(
             {"message": "Event processed."},
         )
+
+    def _auth_get_original_url(self, request):
+        """
+        Extracts and parses the original URL from the "HTTP_X_ORIGINAL_URL" header.
+        Raises PermissionDenied if the header is missing.
+        The original url is passed by nginx in the "HTTP_X_ORIGINAL_URL" header.
+        See corresponding ingress configuration in Helm chart and read about the
+        nginx.ingress.kubernetes.io/auth-url annotation to understand how the Nginx ingress
+        is configured to do this.
+        Based on the original url and the logged-in user, we must decide if we authorize Nginx
+        to let this request go through (by returning a 200 code) or if we block it (by returning
+        a 403 error). Note that we return 403 errors without any further details for security
+        reasons.
+        """
+        # Extract the original URL from the request header
+        original_url = request.META.get("HTTP_X_ORIGINAL_URL")
+        if not original_url:
+            logger.debug("Missing HTTP_X_ORIGINAL_URL header in subrequest")
+            raise drf_exceptions.PermissionDenied()
+
+        logger.debug("Original url: '%s'", original_url)
+        return urlparse(original_url)
+
+    def _auth_get_url_params(self, pattern, fragment):
+        """
+        Extracts URL parameters from the given fragment using the specified regex pattern.
+        Raises PermissionDenied if parameters cannot be extracted.
+        """
+
+        match = pattern.search(fragment)
+
+        try:
+            return match.groupdict()
+        except (ValueError, AttributeError) as exc:
+            logger.debug("Failed to extract parameters from subrequest URL: %s", exc)
+            raise drf_exceptions.PermissionDenied() from exc
+
+    @decorators.action(detail=False, methods=["get"], url_path="media-auth")
+    def media_auth(self, request, *args, **kwargs):
+        """
+        This view is used by an Nginx subrequest to control access to a recording's
+        media file.
+        When we let the request go through, we compute authorization headers that will be added to
+        the request going through thanks to the nginx.ingress.kubernetes.io/auth-response-headers
+        annotation. The request will then be proxied to the object storage backend who will
+        respond with the file after checking the signature included in headers.
+        """
+
+        parsed_url = self._auth_get_original_url(request)
+
+        url_params = self._auth_get_url_params(
+            enums.RECORDING_STORAGE_URL_PATTERN, parsed_url.path
+        )
+
+        user = request.user
+        recording_id = url_params["recording_id"]
+
+        extension = url_params["extension"]
+        if extension not in [item.value for item in FileExtension]:
+            raise drf_exceptions.ValidationError({"detail": "Unsupported extension."})
+
+        try:
+            recording = models.Recording.objects.get(id=recording_id)
+        except models.Recording.DoesNotExist as e:
+            raise drf_exceptions.NotFound("No recording found for this event.") from e
+
+        if extension != recording.extension:
+            raise drf_exceptions.NotFound("No recording found with this extension.")
+
+        abilities = recording.get_abilities(user)
+
+        if not abilities["retrieve"]:
+            logger.debug("User '%s' lacks permission for attachment", user.id)
+            raise drf_exceptions.PermissionDenied()
+
+        if not recording.is_saved:
+            logger.debug("Recording '%s' has not been saved", recording)
+            raise drf_exceptions.PermissionDenied()
+
+        request = utils.generate_s3_authorization_headers(recording.key)
+
+        return drf_response.Response("authorized", headers=request.headers, status=200)

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -544,6 +544,7 @@ class ResourceAccessViewSet(
 class RecordingViewSet(
     mixins.DestroyModelMixin,
     mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
     viewsets.GenericViewSet,
 ):
     """

--- a/src/backend/core/enums.py
+++ b/src/backend/core/enums.py
@@ -2,8 +2,20 @@
 Core application enums declaration
 """
 
+import re
+
 from django.conf import global_settings, settings
 from django.utils.translation import gettext_lazy as _
+
+UUID_REGEX = (
+    r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+)
+FILE_EXT_REGEX = r"[a-zA-Z0-9]{1,10}"
+
+# pylint: disable=line-too-long
+RECORDING_STORAGE_URL_PATTERN = re.compile(
+    f"/media/{settings.RECORDING_OUTPUT_FOLDER}/(?P<recording_id>{UUID_REGEX:s}).(?P<extension>{FILE_EXT_REGEX:s})"
+)
 
 # Django sets `LANGUAGES` by default with all supported languages. We can use it for
 # the choice of languages which should not be limited to the few languages active in

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -579,6 +579,11 @@ class Recording(BaseModel):
         }
 
     @property
+    def is_saved(self) -> bool:
+        """Check if the recording is in a saved state."""
+        return self.status == RecordingStatusChoices.SAVED
+
+    @property
     def extension(self):
         """Get recording extension based on its mode."""
         extensions = {

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -18,6 +18,8 @@ from django.utils.translation import gettext_lazy as _
 
 from timezone_field import TimeZoneField
 
+from .recording.enums import FileExtension
+
 logger = getLogger(__name__)
 
 
@@ -575,6 +577,21 @@ class Recording(BaseModel):
             RecordingStatusChoices.ACTIVE,
             RecordingStatusChoices.STOPPED,
         }
+
+    @property
+    def extension(self):
+        """Get recording extension based on its mode."""
+        extensions = {
+            RecordingModeChoices.TRANSCRIPT: FileExtension.OGG.value,
+            RecordingModeChoices.SCREEN_RECORDING: FileExtension.MP4.value,
+        }
+        return extensions.get(self.mode, FileExtension.MP4.value)
+
+    @property
+    def key(self):
+        """Generate the file key based on recording mode."""
+
+        return f"{settings.RECORDING_OUTPUT_FOLDER}/{self.id}.{self.extension}"
 
 
 class RecordingAccess(BaseAccess):

--- a/src/backend/core/recording/enums.py
+++ b/src/backend/core/recording/enums.py
@@ -1,0 +1,10 @@
+"""Enums related to recordings."""
+
+from enum import Enum
+
+
+class FileExtension(Enum):
+    """Enum for file extensions used in recordings."""
+
+    OGG = "ogg"
+    MP4 = "mp4"

--- a/src/backend/core/recording/event/notification.py
+++ b/src/backend/core/recording/event/notification.py
@@ -57,10 +57,8 @@ class NotificationService:
             logger.error("No owner found for recording %s", recording.id)
             return False
 
-        key = f"{settings.RECORDING_OUTPUT_FOLDER}/{recording.id}.ogg"
-
         payload = {
-            "filename": key,
+            "filename": recording.key,
             "email": owner_access.user.email,
             "sub": owner_access.user.sub,
         }

--- a/src/backend/core/recording/worker/services.py
+++ b/src/backend/core/recording/worker/services.py
@@ -7,6 +7,7 @@ from asgiref.sync import async_to_sync
 from livekit import api as livekit_api
 from livekit.api.egress_service import EgressService
 
+from ..enums import FileExtension
 from .exceptions import WorkerConnectionError, WorkerResponseError
 from .factories import WorkerServiceConfig
 
@@ -89,7 +90,9 @@ class VideoCompositeEgressService(BaseEgressService):
 
         # Save room's recording as a mp4 video file.
         file_type = livekit_api.EncodedFileType.MP4
-        filepath = self._get_filepath(filename=recording_id, extension="mp4")
+        filepath = self._get_filepath(
+            filename=recording_id, extension=FileExtension.MP4.value
+        )
 
         file_output = livekit_api.EncodedFileOutput(
             file_type=file_type,
@@ -120,7 +123,9 @@ class AudioCompositeEgressService(BaseEgressService):
 
         # Save room's recording as an ogg audio file.
         file_type = livekit_api.EncodedFileType.OGG
-        filepath = self._get_filepath(filename=recording_id, extension="ogg")
+        filepath = self._get_filepath(
+            filename=recording_id, extension=FileExtension.OGG.value
+        )
 
         file_output = livekit_api.EncodedFileOutput(
             file_type=file_type,

--- a/src/backend/core/tests/recording/test_api_recordings_list.py
+++ b/src/backend/core/tests/recording/test_api_recordings_list.py
@@ -22,6 +22,27 @@ def test_api_recordings_list_anonymous():
     assert response.status_code == 401
 
 
+def test_api_recordings_list_authenticated_no_recording():
+    """
+    Authenticated users listing recordings should only
+    see recordings to which they have access.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    other_user = factories.UserFactory()
+    factories.UserRecordingAccessFactory(user=other_user)
+
+    response = client.get(
+        "/api/v1.0/recordings/",
+    )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results == []
+
+
 @pytest.mark.parametrize(
     "role",
     ["administrator", "member", "owner"],

--- a/src/backend/core/tests/recording/test_api_recordings_list.py
+++ b/src/backend/core/tests/recording/test_api_recordings_list.py
@@ -58,6 +58,7 @@ def test_api_recordings_list_authenticated_direct(role):
     assert results[0] == {
         "id": str(recording.id),
         "created_at": recording.created_at.isoformat().replace("+00:00", "Z"),
+        "mode": recording.mode,
         "room": {
             "access_level": str(room.access_level),
             "id": str(room.id),

--- a/src/backend/core/tests/recording/test_api_recordings_media_auth.py
+++ b/src/backend/core/tests/recording/test_api_recordings_media_auth.py
@@ -1,0 +1,284 @@
+"""
+Test media-auth authorization API endpoint in docs core app.
+"""
+
+from io import BytesIO
+from urllib.parse import urlparse
+from uuid import uuid4
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.utils import timezone
+
+import pytest
+import requests
+from rest_framework.test import APIClient
+
+from core import models
+from core.factories import RecordingFactory, UserFactory, UserRecordingAccessFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_documents_media_auth_unauthenticated():
+    """
+    Test that unauthenticated requests to download media are rejected
+    """
+    original_url = f"http://localhost/media/recordings/{uuid4()!s}.mp4"
+
+    response = APIClient().get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 401
+
+
+def test_api_documents_media_auth_wrong_path():
+    """
+    Test that media URLs with incorrect path structures are rejected
+    """
+    user = UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    original_url = f"http://localhost/media/wrong-path/{uuid4()!s}.mp4"
+
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 403
+
+
+def test_api_documents_media_auth_unknown_recording():
+    """
+    Test that requests for non-existent recordings are properly handled
+    """
+    user = UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    original_url = f"http://localhost/media/recordings/{uuid4()!s}.mp4"
+
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 404
+
+
+def test_api_documents_media_auth_no_abilities():
+    """
+    Test that users without any access permissions cannot download recordings
+    """
+    user = UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    recording = RecordingFactory(status=models.RecordingStatusChoices.SAVED)
+    original_url = f"http://localhost/media/recordings/{recording.id!s}.mp4"
+
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 403
+
+
+def test_api_documents_media_auth_wrong_abilities():
+    """
+    Test that users with insufficient role permissions cannot download recordings
+    """
+    user = UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    recording = RecordingFactory(status=models.RecordingStatusChoices.SAVED)
+
+    UserRecordingAccessFactory(user=user, recording=recording, role="member")
+
+    original_url = f"http://localhost/media/recordings/{recording.id!s}.mp4"
+
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize("wrong_status", ["initiated", "active", "failed_to_stop"])
+def test_api_documents_media_auth_unsaved(wrong_status):
+    """
+    Test that recordings that aren't in 'saved' status cannot be downloaded
+    """
+    user = UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    recording = RecordingFactory(status=wrong_status)
+    UserRecordingAccessFactory(user=user, recording=recording, role="owner")
+
+    original_url = f"http://localhost/media/recordings/{recording.id!s}.mp4"
+
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 403
+
+
+def test_api_documents_media_auth_mismatched_extension():
+    """
+    Test that requests with mismatched file extensions are rejected
+    """
+    user = UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    recording = RecordingFactory(
+        status=models.RecordingStatusChoices.SAVED,
+        mode=models.RecordingModeChoices.TRANSCRIPT,
+    )
+    UserRecordingAccessFactory(user=user, recording=recording, role="owner")
+
+    original_url = f"http://localhost/media/recordings/{recording.id!s}.mp4"
+
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No recording found with this extension."}
+
+
+@pytest.mark.parametrize(
+    "wrong_extension", ["jpg", "txt", "mp3"], ids=["image", "text", "audio"]
+)
+def test_api_documents_media_auth_wrong_extension(wrong_extension):
+    """
+    Trying to download a recording with an unsupported extension should return
+    a validation error (400) with details about allowed extensions.
+    """
+    user = UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    recording = RecordingFactory(status=models.RecordingStatusChoices.SAVED)
+    UserRecordingAccessFactory(user=user, recording=recording, role="owner")
+
+    original_url = (
+        f"http://localhost/media/recordings/{recording.id!s}.{wrong_extension}"
+    )
+
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Unsupported extension."}
+
+
+@pytest.mark.parametrize("mode", ["screen_recording", "transcript"])
+def test_api_documents_media_auth_success_owner(mode):
+    """
+    Test downloading a recording when logged in and authorized.
+    Verifies S3 authentication headers and successful file retrieval.
+    """
+    user = UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    recording = RecordingFactory(status=models.RecordingStatusChoices.SAVED, mode=mode)
+    UserRecordingAccessFactory(user=user, recording=recording, role="owner")
+
+    default_storage.connection.meta.client.put_object(
+        Bucket=default_storage.bucket_name,
+        Key=recording.key,
+        Body=BytesIO(b"my prose"),
+        ContentType="text/plain",
+    )
+
+    original_url = f"http://localhost/media/{recording.key:s}"
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 200
+
+    authorization = response["Authorization"]
+    assert "AWS4-HMAC-SHA256 Credential=" in authorization
+    assert (
+        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature="
+        in authorization
+    )
+    assert response["X-Amz-Date"] == timezone.now().strftime("%Y%m%dT%H%M%SZ")
+
+    s3_url = urlparse(settings.AWS_S3_ENDPOINT_URL)
+    file_url = f"{settings.AWS_S3_ENDPOINT_URL:s}/meet-media-storage/{recording.key:s}"
+    response = requests.get(
+        file_url,
+        headers={
+            "authorization": authorization,
+            "x-amz-date": response["x-amz-date"],
+            "x-amz-content-sha256": response["x-amz-content-sha256"],
+            "Host": f"{s3_url.hostname:s}:{s3_url.port:d}",
+        },
+        timeout=1,
+    )
+    assert response.content.decode("utf-8") == "my prose"
+
+
+@pytest.mark.parametrize("mode", ["screen_recording", "transcript"])
+def test_api_documents_media_auth_success_administrator(mode):
+    """
+    Test downloading a recording when logged in and authorized.
+    Verifies S3 authentication headers and successful file retrieval.
+    """
+    user = UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    recording = RecordingFactory(status=models.RecordingStatusChoices.SAVED, mode=mode)
+    UserRecordingAccessFactory(user=user, recording=recording, role="administrator")
+
+    default_storage.connection.meta.client.put_object(
+        Bucket=default_storage.bucket_name,
+        Key=recording.key,
+        Body=BytesIO(b"my prose"),
+        ContentType="text/plain",
+    )
+
+    original_url = f"http://localhost/media/{recording.key:s}"
+    response = client.get(
+        "/api/v1.0/recordings/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 200
+
+    authorization = response["Authorization"]
+    assert "AWS4-HMAC-SHA256 Credential=" in authorization
+    assert (
+        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature="
+        in authorization
+    )
+    assert response["X-Amz-Date"] == timezone.now().strftime("%Y%m%dT%H%M%SZ")
+
+    s3_url = urlparse(settings.AWS_S3_ENDPOINT_URL)
+    file_url = f"{settings.AWS_S3_ENDPOINT_URL:s}/meet-media-storage/{recording.key:s}"
+    response = requests.get(
+        file_url,
+        headers={
+            "authorization": authorization,
+            "x-amz-date": response["x-amz-date"],
+            "x-amz-content-sha256": response["x-amz-content-sha256"],
+            "Host": f"{s3_url.hostname:s}:{s3_url.port:d}",
+        },
+        timeout=1,
+    )
+    assert response.content.decode("utf-8") == "my prose"

--- a/src/backend/core/tests/recording/test_api_recordings_retrieve.py
+++ b/src/backend/core/tests/recording/test_api_recordings_retrieve.py
@@ -1,0 +1,153 @@
+"""
+Test recordings API endpoints in the Meet core app: retrieve.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from ...factories import RecordingFactory, UserFactory, UserRecordingAccessFactory
+from ...models import RecordingStatusChoices
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_recording_retrieve_anonymous():
+    """Anonymous users should not be able to retrieve recordings."""
+    recording = RecordingFactory()
+    client = APIClient()
+    response = client.get(f"/api/v1.0/recordings/{recording.id!s}/")
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": "Authentication credentials were not provided."
+    }
+
+
+def test_api_recording_retrieve_authenticated():
+    """Authenticated users without access receive 404 when requesting recordings.
+
+    The API returns 404 instead of 403 to avoid revealing the existence of
+    resources the user doesn't have permission to access.
+    """
+    user = UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    other_user = UserFactory()
+    recording = UserRecordingAccessFactory(user=other_user).recording
+
+    response = client.get(f"/api/v1.0/recordings/{recording.id!s}/")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No Recording matches the given query."}
+
+
+def test_api_recording_retrieve_members():
+    """
+    A user who is a member of a recording should not be able to retrieve it.
+    """
+    user = UserFactory()
+    recording = RecordingFactory()
+
+    UserRecordingAccessFactory(recording=recording, user=user, role="member")
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get(f"/api/v1.0/recordings/{recording.id!s}/")
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
+
+
+def test_api_recording_retrieve_administrators():
+    """A user who is an administrator of a recording should be able to retrieve it."""
+
+    user = UserFactory()
+    recording = RecordingFactory()
+
+    UserRecordingAccessFactory(recording=recording, user=user, role="administrator")
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get(f"/api/v1.0/recordings/{recording.id!s}/")
+
+    assert response.status_code == 200
+    content = response.json()
+    room = recording.room
+
+    assert content == {
+        "id": str(recording.id),
+        "room": {
+            "access_level": str(room.access_level),
+            "id": str(room.id),
+            "name": room.name,
+            "slug": room.slug,
+        },
+        "created_at": recording.created_at.isoformat().replace("+00:00", "Z"),
+        "updated_at": recording.updated_at.isoformat().replace("+00:00", "Z"),
+        "status": str(recording.status),
+        "mode": str(recording.mode),
+    }
+
+
+def test_api_recording_retrieve_owners():
+    """A user who is an owner of a recording should be able to retrieve it."""
+    user = UserFactory()
+    recording = RecordingFactory()
+
+    UserRecordingAccessFactory(recording=recording, user=user, role="owner")
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get(f"/api/v1.0/recordings/{recording.id!s}/")
+
+    assert response.status_code == 200
+    content = response.json()
+    room = recording.room
+
+    assert content == {
+        "id": str(recording.id),
+        "room": {
+            "access_level": str(room.access_level),
+            "id": str(room.id),
+            "name": room.name,
+            "slug": room.slug,
+        },
+        "created_at": recording.created_at.isoformat().replace("+00:00", "Z"),
+        "updated_at": recording.updated_at.isoformat().replace("+00:00", "Z"),
+        "status": str(recording.status),
+        "mode": str(recording.mode),
+    }
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        RecordingStatusChoices.INITIATED,
+        RecordingStatusChoices.ACTIVE,
+        RecordingStatusChoices.SAVED,
+        RecordingStatusChoices.FAILED_TO_START,
+        RecordingStatusChoices.FAILED_TO_STOP,
+        RecordingStatusChoices.ABORTED,
+    ],
+)
+def test_api_recording_retrieve_any_status(status):
+    """Test that recordings with any status can be retrieved."""
+    user = UserFactory()
+    recording = RecordingFactory(status=status)
+
+    UserRecordingAccessFactory(recording=recording, user=user, role="owner")
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get(f"/api/v1.0/recordings/{recording.id!s}/")
+
+    assert response.status_code == 200
+    content = response.json()
+    assert content["id"] == str(recording.id)
+    assert content["status"] == status

--- a/src/backend/core/tests/test_models_recording.py
+++ b/src/backend/core/tests/test_models_recording.py
@@ -250,3 +250,38 @@ def test_models_recording_key_for_unknown_mode(settings):
     recording.mode = "unknown_mode"
     expected_path = f"/custom/path/{recording.id}.{FileExtension.MP4.value}"
     assert recording.key == expected_path
+
+
+# Test is_saved method
+
+
+def test_models_recording_is_saved_true():
+    """Test is_saved property returns True for SAVED status."""
+    recording = RecordingFactory(status=RecordingStatusChoices.SAVED)
+    assert recording.is_saved is True
+
+
+def test_models_recording_is_saved_false_active():
+    """Test is_saved property returns False for ACTIVE status."""
+    recording = RecordingFactory(status=RecordingStatusChoices.ACTIVE)
+    assert recording.is_saved is False
+
+
+def test_models_recording_is_saved_false_initiated():
+    """Test is_saved property returns False for INITIATED status."""
+    recording = RecordingFactory(status=RecordingStatusChoices.INITIATED)
+    assert recording.is_saved is False
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        RecordingStatusChoices.FAILED_TO_STOP,
+        RecordingStatusChoices.FAILED_TO_START,
+        RecordingStatusChoices.ABORTED,
+    ],
+)
+def test_models_recording_is_saved_false_error_states(status):
+    """Test is_saved property returns False for error statuses."""
+    recording = RecordingFactory(status=status)
+    assert recording.is_saved is False

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -11,7 +11,9 @@ from typing import Optional
 from uuid import uuid4
 
 from django.conf import settings
+from django.core.files.storage import default_storage
 
+import botocore
 from livekit.api import AccessToken, VideoGrants
 
 
@@ -110,3 +112,33 @@ def generate_livekit_config(
             room=room_id, user=user, username=username, color=color
         ),
     }
+
+
+def generate_s3_authorization_headers(key):
+    """
+    Generate authorization headers for an s3 object.
+    These headers can be used as an alternative to signed urls with many benefits:
+    - the urls of our files never expire and can be stored in our recording' metadata
+    - we don't leak authorized urls that could be shared (file access can only be done
+      with cookies)
+    - access control is truly realtime
+    - the object storage service does not need to be exposed on internet
+    """
+
+    url = default_storage.unsigned_connection.meta.client.generate_presigned_url(
+        "get_object",
+        ExpiresIn=0,
+        Params={"Bucket": default_storage.bucket_name, "Key": key},
+    )
+
+    request = botocore.awsrequest.AWSRequest(method="get", url=url)
+
+    s3_client = default_storage.connection.meta.client
+    # pylint: disable=protected-access
+    credentials = s3_client._request_signer._credentials  # noqa: SLF001
+    frozen_credentials = credentials.get_frozen_credentials()
+    region = s3_client.meta.region_name
+    auth = botocore.auth.S3SigV4Auth(frozen_credentials, "s3", region)
+    auth.add_auth(request)
+
+    return request

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -25,7 +25,7 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "boto3==1.37.18",
+    "boto3==1.37.24",
     "Brotli==1.1.0",
     "brevo-python==1.1.2",
     "celery[redis]==5.4.0",

--- a/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
@@ -195,3 +195,17 @@ celery:
     - "worker"
     - "--pool=solo"
     - "--loglevel=info"
+
+ingressMedia:
+  enabled: true
+  host: meet.127.0.0.1.nip.io
+
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: https://meet.127.0.0.1.nip.io/api/v1.0/recordings/media-auth/
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
+    nginx.ingress.kubernetes.io/upstream-vhost: minio.meet.svc.cluster.local:9000
+    nginx.ingress.kubernetes.io/rewrite-target: /meet-media-storage/$1
+
+serviceMedia:
+  host: minio.meet.svc.cluster.local
+  port: 9000

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -223,3 +223,17 @@ celery:
     - "worker"
     - "--pool=solo"
     - "--loglevel=info"
+
+ingressMedia:
+  enabled: true
+  host: meet.127.0.0.1.nip.io
+
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: https://meet.127.0.0.1.nip.io/api/v1.0/recordings/media-auth/
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
+    nginx.ingress.kubernetes.io/upstream-vhost: minio.meet.svc.cluster.local:9000
+    nginx.ingress.kubernetes.io/rewrite-target: /meet-media-storage/$1
+
+serviceMedia:
+  host: minio.meet.svc.cluster.local
+  port: 9000

--- a/src/helm/meet/README.md
+++ b/src/helm/meet/README.md
@@ -4,34 +4,50 @@
 
 ### General configuration
 
-| Name                                       | Description                                          | Value                  |
-| ------------------------------------------ | ---------------------------------------------------- | ---------------------- |
-| `image.repository`                         | Repository to use to pull meet's container image     | `lasuite/meet-backend` |
-| `image.tag`                                | meet's container tag                                 | `latest`               |
-| `image.pullPolicy`                         | Container image pull policy                          | `IfNotPresent`         |
-| `image.credentials.username`               | Username for container registry authentication       |                        |
-| `image.credentials.password`               | Password for container registry authentication       |                        |
-| `image.credentials.registry`               | Registry url for which the credentials are specified |                        |
-| `image.credentials.name`                   | Name of the generated secret for imagePullSecrets    |                        |
-| `nameOverride`                             | Override the chart name                              | `""`                   |
-| `fullnameOverride`                         | Override the full application name                   | `""`                   |
-| `ingress.enabled`                          | whether to enable the Ingress or not                 | `false`                |
-| `ingress.className`                        | IngressClass to use for the Ingress                  | `nil`                  |
-| `ingress.host`                             | Host for the Ingress                                 | `meet.example.com`     |
-| `ingress.path`                             | Path to use for the Ingress                          | `/`                    |
-| `ingress.hosts`                            | Additional host to configure for the Ingress         | `[]`                   |
-| `ingress.tls.enabled`                      | Weather to enable TLS for the Ingress                | `true`                 |
-| `ingress.tls.additional[].secretName`      | Secret name for additional TLS config                |                        |
-| `ingress.tls.additional[].hosts[]`         | Hosts for additional TLS config                      |                        |
-| `ingress.customBackends`                   | Add custom backends to ingress                       | `[]`                   |
-| `ingressAdmin.enabled`                     | whether to enable the Ingress or not                 | `false`                |
-| `ingressAdmin.className`                   | IngressClass to use for the Ingress                  | `nil`                  |
-| `ingressAdmin.host`                        | Host for the Ingress                                 | `meet.example.com`     |
-| `ingressAdmin.path`                        | Path to use for the Ingress                          | `/admin`               |
-| `ingressAdmin.hosts`                       | Additional host to configure for the Ingress         | `[]`                   |
-| `ingressAdmin.tls.enabled`                 | Weather to enable TLS for the Ingress                | `true`                 |
-| `ingressAdmin.tls.additional[].secretName` | Secret name for additional TLS config                |                        |
-| `ingressAdmin.tls.additional[].hosts[]`    | Hosts for additional TLS config                      |                        |
+| Name                                                                         | Description                                          | Value                                                             |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+| `image.repository`                                                           | Repository to use to pull meet's container image     | `lasuite/meet-backend`                                            |
+| `image.tag`                                                                  | meet's container tag                                 | `latest`                                                          |
+| `image.pullPolicy`                                                           | Container image pull policy                          | `IfNotPresent`                                                    |
+| `image.credentials.username`                                                 | Username for container registry authentication       |                                                                   |
+| `image.credentials.password`                                                 | Password for container registry authentication       |                                                                   |
+| `image.credentials.registry`                                                 | Registry url for which the credentials are specified |                                                                   |
+| `image.credentials.name`                                                     | Name of the generated secret for imagePullSecrets    |                                                                   |
+| `nameOverride`                                                               | Override the chart name                              | `""`                                                              |
+| `fullnameOverride`                                                           | Override the full application name                   | `""`                                                              |
+| `ingress.enabled`                                                            | whether to enable the Ingress or not                 | `false`                                                           |
+| `ingress.className`                                                          | IngressClass to use for the Ingress                  | `nil`                                                             |
+| `ingress.host`                                                               | Host for the Ingress                                 | `meet.example.com`                                                |
+| `ingress.path`                                                               | Path to use for the Ingress                          | `/`                                                               |
+| `ingress.hosts`                                                              | Additional host to configure for the Ingress         | `[]`                                                              |
+| `ingress.tls.enabled`                                                        | Weather to enable TLS for the Ingress                | `true`                                                            |
+| `ingress.tls.additional[].secretName`                                        | Secret name for additional TLS config                |                                                                   |
+| `ingress.tls.additional[].hosts[]`                                           | Hosts for additional TLS config                      |                                                                   |
+| `ingress.customBackends`                                                     | Add custom backends to ingress                       | `[]`                                                              |
+| `ingressAdmin.enabled`                                                       | whether to enable the Ingress or not                 | `false`                                                           |
+| `ingressAdmin.className`                                                     | IngressClass to use for the Ingress                  | `nil`                                                             |
+| `ingressAdmin.host`                                                          | Host for the Ingress                                 | `meet.example.com`                                                |
+| `ingressAdmin.path`                                                          | Path to use for the Ingress                          | `/admin`                                                          |
+| `ingressAdmin.hosts`                                                         | Additional host to configure for the Ingress         | `[]`                                                              |
+| `ingressAdmin.tls.enabled`                                                   | Weather to enable TLS for the Ingress                | `true`                                                            |
+| `ingressAdmin.tls.additional[].secretName`                                   | Secret name for additional TLS config                |                                                                   |
+| `ingressAdmin.tls.additional[].hosts[]`                                      | Hosts for additional TLS config                      |                                                                   |
+| `ingressMedia.enabled`                                                       | whether to enable the Ingress or not                 | `false`                                                           |
+| `ingressMedia.className`                                                     | IngressClass to use for the Ingress                  | `nil`                                                             |
+| `ingressMedia.host`                                                          | Host for the Ingress                                 | `meet.example.com`                                                |
+| `ingressMedia.path`                                                          | Path to use for the Ingress                          | `/media/(.*)`                                                     |
+| `ingressMedia.hosts`                                                         | Additional host to configure for the Ingress         | `[]`                                                              |
+| `ingressMedia.tls.enabled`                                                   | Weather to enable TLS for the Ingress                | `true`                                                            |
+| `ingressMedia.tls.secretName`                                                | Secret name for TLS config                           | `nil`                                                             |
+| `ingressMedia.tls.additional[].secretName`                                   | Secret name for additional TLS config                |                                                                   |
+| `ingressMedia.tls.additional[].hosts[]`                                      | Hosts for additional TLS config                      |                                                                   |
+| `ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-url`              |                                                      | `https://meet.example.com/api/v1.0/recordings/media-auth/`        |
+| `ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-response-headers` |                                                      | `Authorization, X-Amz-Date, X-Amz-Content-SHA256`                 |
+| `ingressMedia.annotations.nginx.ingress.kubernetes.io/upstream-vhost`        |                                                      | `minio.meet.svc.cluster.local:9000`                               |
+| `ingressMedia.annotations.nginx.ingress.kubernetes.io/configuration-snippet` |                                                      | `add_header Content-Security-Policy "default-src 'none'" always;` |
+| `serviceMedia.host`                                                          |                                                      | `minio.meet.svc.cluster.local`                                    |
+| `serviceMedia.port`                                                          |                                                      | `9000`                                                            |
+| `serviceMedia.annotations`                                                   |                                                      | `{}`                                                              |
 
 ### backend
 

--- a/src/helm/meet/templates/ingress_media.yaml
+++ b/src/helm/meet/templates/ingress_media.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.ingressMedia.enabled -}}
+{{- $fullName := include "meet.fullname" . -}}
+{{- if and .Values.ingressMedia.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingressMedia.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingressMedia.annotations "kubernetes.io/ingress.class" .Values.ingressMedia.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-media
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "meet.labels" . | nindent 4 }}
+  {{- with .Values.ingressMedia.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingressMedia.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingressMedia.className }}
+  {{- end }}
+  {{- if .Values.ingressMedia.tls.enabled }}
+  tls:
+    {{- if .Values.ingressMedia.host }}
+    - secretName: {{ .Values.ingressMedia.tls.secretName | default (printf "%s-tls" $fullName) | quote }}
+      hosts:
+        - {{ .Values.ingressMedia.host | quote }}
+    {{- end }}
+    {{- range .Values.ingressMedia.tls.additional }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingressMedia.host }}
+    - host: {{ .Values.ingressMedia.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingressMedia.path | quote }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: ImplementationSpecific
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-media
+                port:
+                  number: {{ .Values.serviceMedia.port }}
+              {{- else }}
+              serviceName: {{ $fullName }}-media
+              servicePort: {{ .Values.serviceMedia.port }}
+            {{- end }}
+    {{- end }}
+    {{- range .Values.ingressMedia.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $.Values.ingressMedia.path | quote }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: ImplementationSpecific
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-media
+                port:
+                  number: {{ .Values.serviceMedia.port }}
+              {{- else }}
+              serviceName: {{ $fullName }}-media
+              servicePort: {{ .Values.serviceMedia.port }}
+            {{- end }}
+    {{- end }}
+{{- end }}

--- a/src/helm/meet/templates/media_svc.yaml
+++ b/src/helm/meet/templates/media_svc.yaml
@@ -1,0 +1,14 @@
+{{- $fullName := include "meet.fullname" . -}}
+{{- $component := "media" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-media
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "meet.common.labels" (list . $component) | nindent 4 }}
+  annotations:
+    {{- toYaml $.Values.serviceMedia.annotations | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ $.Values.serviceMedia.host }}

--- a/src/helm/meet/values.yaml
+++ b/src/helm/meet/values.yaml
@@ -69,6 +69,48 @@ ingressAdmin:
     enabled: true
     additional: []
 
+## @param ingressMedia.enabled whether to enable the Ingress or not
+## @param ingressMedia.className IngressClass to use for the Ingress
+## @param ingressMedia.host Host for the Ingress
+## @param ingressMedia.path Path to use for the Ingress
+ingressMedia:
+  enabled: false
+  className: null
+  host: meet.example.com
+  path: /media/(.*)
+  ## @param ingressMedia.hosts Additional host to configure for the Ingress
+  hosts: [ ]
+  #  - chart-example.local
+  ## @param ingressMedia.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressMedia.tls.secretName Secret name for TLS config
+  ## @skip ingressMedia.tls.additional
+  ## @extra ingressMedia.tls.additional[].secretName Secret name for additional TLS config
+  ## @extra ingressMedia.tls.additional[].hosts[] Hosts for additional TLS config
+  tls:
+    enabled: true
+    secretName: null
+    additional: []
+
+  ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-url
+  ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-response-headers
+  ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/upstream-vhost
+  ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/configuration-snippet
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: https://meet.example.com/api/v1.0/recordings/media-auth/
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
+    nginx.ingress.kubernetes.io/upstream-vhost: minio.meet.svc.cluster.local:9000
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      add_header Content-Security-Policy "default-src 'none'" always;
+
+## @param serviceMedia.host
+## @param serviceMedia.port
+## @param serviceMedia.annotations
+serviceMedia:
+  host: minio.meet.svc.cluster.local
+  port: 9000
+  annotations: {}
+
+
 
 ## @section backend
 


### PR DESCRIPTION
# Purpose
Enable users to download their recordings seamlessly.

# Proposal
Taking inspiration from the approach used in Docs, this proposal introduces a new endpoint to support recording downloads. To enable the frontend to render a complete information page, additional metadata has been added to the recording serializer.

Looking ahead, both this page and the media endpoint could eventually be replaced by Fichier for a more unified file access experience.

In a future V2, we’ll introduce automatic expiration of recordings after 7 days — stay tuned!

