### PR TITLE
Invite people by email

### DIFF
--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -15,7 +15,7 @@ DJANGO_EMAIL_PORT=1025
 DJANGO_EMAIL_BRAND_NAME=La Suite Numérique
 DJANGO_EMAIL_SUPPORT_EMAIL=test@yopmail.com
 DJANGO_EMAIL_LOGO_IMG=http://localhost:3000/assets/logo-suite-numerique.png
-DJANGO_EMAIL_DOMAIN=http://localhost:3000/
+DJANGO_EMAIL_DOMAIN=localhost:3000
 
 # Backend url
 MEET_BASE_URL="http://localhost:8072"

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -16,6 +16,7 @@ DJANGO_EMAIL_BRAND_NAME=La Suite Numérique
 DJANGO_EMAIL_SUPPORT_EMAIL=test@yopmail.com
 DJANGO_EMAIL_LOGO_IMG=http://localhost:3000/assets/logo-suite-numerique.png
 DJANGO_EMAIL_DOMAIN=localhost:3000
+DJANGO_EMAIL_APP_BASE_URL=http://localhost:3000
 
 # Backend url
 MEET_BASE_URL="http://localhost:8072"

--- a/src/backend/core/api/permissions.py
+++ b/src/backend/core/api/permissions.py
@@ -94,7 +94,7 @@ class HasAbilityPermission(IsAuthenticated):
 class HasPrivilegesOnRoom(IsAuthenticated):
     """Check if user has privileges on a given room."""
 
-    message = "You must have privileges to start a recording."
+    message = "You must have privileges on room to perform this action."
 
     def has_object_permission(self, request, view, obj):
         """Determine if user has privileges on room."""

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -189,11 +189,11 @@ class RequestEntrySerializer(serializers.Serializer):
 
     def create(self, validated_data):
         """Not implemented as this is a validation-only serializer."""
-        raise NotImplementedError("StartRecordingSerializer is validation-only")
+        raise NotImplementedError("RequestEntrySerializer is validation-only")
 
     def update(self, instance, validated_data):
         """Not implemented as this is a validation-only serializer."""
-        raise NotImplementedError("StartRecordingSerializer is validation-only")
+        raise NotImplementedError("RequestEntrySerializer is validation-only")
 
 
 class ParticipantEntrySerializer(serializers.Serializer):
@@ -204,11 +204,11 @@ class ParticipantEntrySerializer(serializers.Serializer):
 
     def create(self, validated_data):
         """Not implemented as this is a validation-only serializer."""
-        raise NotImplementedError("StartRecordingSerializer is validation-only")
+        raise NotImplementedError("ParticipantEntrySerializer is validation-only")
 
     def update(self, instance, validated_data):
         """Not implemented as this is a validation-only serializer."""
-        raise NotImplementedError("StartRecordingSerializer is validation-only")
+        raise NotImplementedError("ParticipantEntrySerializer is validation-only")
 
 
 class CreationCallbackSerializer(serializers.Serializer):
@@ -218,8 +218,8 @@ class CreationCallbackSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         """Not implemented as this is a validation-only serializer."""
-        raise NotImplementedError("StartRecordingSerializer is validation-only")
+        raise NotImplementedError("CreationCallbackSerializer is validation-only")
 
     def update(self, instance, validated_data):
         """Not implemented as this is a validation-only serializer."""
-        raise NotImplementedError("StartRecordingSerializer is validation-only")
+        raise NotImplementedError("CreationCallbackSerializer is validation-only")

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -223,3 +223,17 @@ class CreationCallbackSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         """Not implemented as this is a validation-only serializer."""
         raise NotImplementedError("CreationCallbackSerializer is validation-only")
+
+
+class RoomInviteSerializer(serializers.Serializer):
+    """Validate room invite creation data."""
+
+    emails = serializers.ListField(child=serializers.EmailField(), allow_empty=False)
+
+    def create(self, validated_data):
+        """Not implemented as this is a validation-only serializer."""
+        raise NotImplementedError("RoomInviteSerializer is validation-only")
+
+    def update(self, instance, validated_data):
+        """Not implemented as this is a validation-only serializer."""
+        raise NotImplementedError("RoomInviteSerializer is validation-only")

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -39,6 +39,7 @@ from core.recording.worker.factories import (
 from core.recording.worker.mediator import (
     WorkerServiceMediator,
 )
+from core.services.invitation import InvitationService
 from core.services.livekit_events import (
     LiveKitEventsService,
     LiveKitWebhookError,
@@ -493,6 +494,38 @@ class RoomViewSet(
 
         return drf_response.Response(
             {"status": "success", "room": room}, status=drf_status.HTTP_200_OK
+        )
+
+    @decorators.action(
+        detail=True,
+        methods=["post"],
+        url_path="invite",
+        permission_classes=[
+            permissions.HasPrivilegesOnRoom,
+        ],
+    )
+    def invite(self, request, pk=None):  # pylint: disable=unused-argument
+        """Send email invitations to join a room.
+
+        This API endpoint allows a user with appropriate privileges to send email invitations
+        to one or more recipients, inviting them to join the specified room.
+        """
+
+        room = self.get_object()
+
+        serializer = serializers.RoomInviteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        emails = serializer.validated_data.get("emails")
+        emails = list(set(emails))
+
+        InvitationService().invite_to_room(
+            room=room, sender=request.user, emails=emails
+        )
+
+        return drf_response.Response(
+            {"status": "success", "message": "invitations sent"},
+            status=drf_status.HTTP_200_OK,
         )
 
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -364,7 +364,7 @@ class RoomViewSet(
 
     @decorators.action(
         detail=True,
-        methods=["POST"],
+        methods=["post"],
         url_path="request-entry",
         permission_classes=[],
         throttle_classes=[RequestEntryAnonRateThrottle],
@@ -447,7 +447,7 @@ class RoomViewSet(
 
     @decorators.action(
         detail=False,
-        methods=["POST"],
+        methods=["post"],
         url_path="webhooks-livekit",
         permission_classes=[],
     )
@@ -473,7 +473,7 @@ class RoomViewSet(
 
     @decorators.action(
         detail=False,
-        methods=["POST"],
+        methods=["post"],
         url_path="creation-callback",
         permission_classes=[],
         throttle_classes=[CreationCallbackAnonRateThrottle],

--- a/src/backend/core/services/invitation.py
+++ b/src/backend/core/services/invitation.py
@@ -1,0 +1,59 @@
+"""Invitation Service."""
+
+import smtplib
+from logging import getLogger
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from django.utils.translation import get_language, override
+from django.utils.translation import gettext_lazy as _
+
+logger = getLogger(__name__)
+
+
+class InvitationError(Exception):
+    """Exception raised when invitation emails cannot be sent."""
+
+    status_code = 500
+
+
+class InvitationService:
+    """Service for invitations to users."""
+
+    @staticmethod
+    def invite_to_room(room, sender, emails):
+        """Send invitation emails to join a room."""
+
+        language = get_language()
+
+        context = {
+            "brandname": settings.EMAIL_BRAND_NAME,
+            "logo_img": settings.EMAIL_LOGO_IMG,
+            "domain": settings.EMAIL_DOMAIN,
+            "room_url": f"{settings.EMAIL_APP_BASE_URL}/{room.slug}",
+            "room_link": f"{settings.EMAIL_DOMAIN}/{room.slug}",
+            "sender_email": sender.email,
+        }
+
+        with override(language):
+            msg_html = render_to_string("mail/html/invitation.html", context)
+            msg_plain = render_to_string("mail/text/invitation.txt", context)
+            subject = str(
+                _(
+                    f"Video call in progress: {sender.email} is waiting for you to connect"
+                )
+            )  # Force translation
+
+            try:
+                send_mail(
+                    subject,
+                    msg_plain,
+                    settings.EMAIL_FROM,
+                    emails,
+                    html_message=msg_html,
+                    fail_silently=False,
+                )
+            except smtplib.SMTPException as e:
+                logger.error("invitation to %s was not sent: %s", emails, e)
+                raise InvitationError("Could not send invitation") from e

--- a/src/backend/core/tests/rooms/test_api_rooms_invite.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_invite.py
@@ -1,0 +1,295 @@
+"""
+Test rooms API endpoints in the Meet core app: invite.
+"""
+
+# pylint: disable=W0621,W0613
+
+import json
+import random
+from unittest import mock
+
+import pytest
+from rest_framework.test import APIClient
+
+from ...factories import RoomFactory, UserFactory
+from ...services.invitation import InvitationError, InvitationService
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_rooms_invite_anonymous():
+    """Test anonymous users should not be allowed to invite people to rooms."""
+
+    client = APIClient()
+    room = RoomFactory()
+
+    data = {"emails": ["toto@yopmail.com"]}
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 401
+
+
+def test_api_rooms_invite_no_access():
+    """Test non-privileged users should not be allowed to invite people to rooms."""
+
+    client = APIClient()
+    room = RoomFactory()
+
+    user = UserFactory()
+    client.force_login(user)
+
+    data = {"emails": ["toto@yopmail.com"]}
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "You must have privileges on room to perform this action.",
+    }
+
+
+def test_api_rooms_invite_member():
+    """Test member users should not be allowed to invite people to rooms."""
+
+    client = APIClient()
+    room = RoomFactory()
+
+    user = UserFactory()
+    client.force_login(user)
+
+    room.accesses.create(user=user, role="member")
+
+    data = {"emails": ["toto@yopmail.com"]}
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "You must have privileges on room to perform this action.",
+    }
+
+
+def test_api_rooms_invite_missing_emails():
+    """Test missing email list should return validation error."""
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+
+    client.force_login(user)
+
+    data = {"foo": []}
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "emails": [
+            "This field is required.",
+        ]
+    }
+
+
+def test_api_rooms_invite_empty_emails():
+    """Test empty email list should return validation error."""
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+
+    client.force_login(user)
+
+    data = {"emails": []}
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "emails": [
+            "This list may not be empty.",
+        ]
+    }
+
+
+def test_api_rooms_invite_invalid_emails():
+    """Test invalid email addresses should return validation errors."""
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+
+    client.force_login(user)
+
+    data = {"emails": ["abdc", "efg"]}
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "emails": {
+            "0": ["Enter a valid email address."],
+            "1": ["Enter a valid email address."],
+        }
+    }
+
+
+def test_api_rooms_invite_partially_invalid_emails():
+    """Test partially invalid email addresses should return validation errors."""
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+
+    client.force_login(user)
+
+    data = {"emails": ["fabrice@yopmail.com", "efg"]}
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "emails": {
+            "1": ["Enter a valid email address."],
+        }
+    }
+
+
+@mock.patch.object(InvitationService, "invite_to_room")
+def test_api_rooms_invite_duplicates(mock_invite_to_room):
+    """Test duplicate emails should be deduplicated before processing."""
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+
+    client.force_login(user)
+
+    data = {"emails": ["toto@yopmail.com", "toto@yopmail.com", "Toto@yopmail.com"]}
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    mock_invite_to_room.assert_called_once()
+
+    _, kwargs = mock_invite_to_room.call_args
+
+    assert kwargs["room"] == room
+    assert kwargs["sender"] == user
+    assert sorted(kwargs["emails"]) == sorted(["Toto@yopmail.com", "toto@yopmail.com"])
+
+
+@mock.patch.object(InvitationService, "invite_to_room", side_effect=InvitationError())
+def test_api_rooms_invite_error(mock_invite_to_room):
+    """Test invitation service error should return appropriate error response."""
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+
+    client.force_login(user)
+
+    data = {"emails": ["toto@yopmail.com", "toto@yopmail.com"]}
+
+    with pytest.raises(InvitationError) as excinfo:
+        client.post(
+            f"/api/v1.0/rooms/{room.id}/invite/",
+            json.dumps(data),
+            content_type="application/json",
+        )
+
+        mock_invite_to_room.assert_called_once()
+        assert "Could not send invitation" in str(excinfo.value)
+
+
+@mock.patch("core.services.invitation.send_mail")
+def test_api_rooms_invite_success(mock_send_mail, settings):
+    """Test privileged users should successfully send invitation emails."""
+
+    settings.EMAIL_BRAND_NAME = "ACME"
+    settings.EMAIL_LOGO_IMG = "https://acme.com/logo"
+    settings.EMAIL_APP_BASE_URL = "https://acme.com"
+    settings.EMAIL_FROM = "notifications@acme.com"
+    settings.EMAIL_DOMAIN = "acme.com"
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+
+    client.force_login(user)
+
+    data = {"emails": ["fabien@yopmail.com", "gerald@yopmail.com"]}
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps(data),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "success", "message": "invitations sent"}
+
+    mock_send_mail.assert_called_once()
+
+    subject, body, sender, recipients = mock_send_mail.call_args[0]
+
+    assert (
+        subject == f"Video call in progress: {user.email} is waiting for you to connect"
+    )
+
+    # Verify email contains expected content
+    required_content = [
+        "ACME",  # Brand name
+        "https://acme.com/logo",  # Logo URL
+        f"https://acme.com/{room.slug}",  # Room url
+        f"acme.com/{room.slug}",  # Room link
+    ]
+
+    for content in required_content:
+        assert content in body
+
+    assert sender == "notifications@acme.com"
+
+    # Verify all owners received the email (order-independent comparison)
+    assert sorted(recipients) == sorted(["fabien@yopmail.com", "gerald@yopmail.com"])

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -322,6 +322,7 @@ class Base(Configuration):
     EMAIL_SUPPORT_EMAIL = values.Value(None)
     EMAIL_LOGO_IMG = values.Value(None)
     EMAIL_DOMAIN = values.Value(None)
+    EMAIL_APP_BASE_URL = values.Value(None)
 
     AUTH_USER_MODEL = "core.User"
 

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -486,7 +486,7 @@ class Base(Configuration):
         None, environ_name="SUMMARY_SERVICE_API_TOKEN", environ_prefix=None
     )
     SCREEN_RECORDING_BASE_URL = values.Value(
-        None, environ_name="SUMMARY_SERVICE_API_TOKEN", environ_prefix=None
+        None, environ_name="SCREEN_RECORDING_BASE_URL", environ_prefix=None
     )
 
     # Marketing and communication settings

--- a/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
@@ -20,6 +20,7 @@ backend:
     DJANGO_EMAIL_SUPPORT_EMAIL: "test@yopmail.com"
     DJANGO_EMAIL_LOGO_IMG: https://meet.127.0.0.1.nip.io/assets/logo-suite-numerique.png
     DJANGO_EMAIL_DOMAIN: meet.127.0.0.1.nip.io
+    DJANGO_EMAIL_APP_BASE_URL: https://meet.127.0.0.1.nip.io
     OIDC_OP_JWKS_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/meet/protocol/openid-connect/certs
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/meet/protocol/openid-connect/auth
     OIDC_OP_TOKEN_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/meet/protocol/openid-connect/token

--- a/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
@@ -19,7 +19,7 @@ backend:
     DJANGO_EMAIL_BRAND_NAME: "La Suite Numérique"
     DJANGO_EMAIL_SUPPORT_EMAIL: "test@yopmail.com"
     DJANGO_EMAIL_LOGO_IMG: https://meet.127.0.0.1.nip.io/assets/logo-suite-numerique.png
-    DJANGO_EMAIL_DOMAIN: https://meet.127.0.0.1.nip.io
+    DJANGO_EMAIL_DOMAIN: meet.127.0.0.1.nip.io
     OIDC_OP_JWKS_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/meet/protocol/openid-connect/certs
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/meet/protocol/openid-connect/auth
     OIDC_OP_TOKEN_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/meet/protocol/openid-connect/token

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -35,7 +35,7 @@ backend:
     DJANGO_EMAIL_BRAND_NAME: "La Suite Numérique"
     DJANGO_EMAIL_SUPPORT_EMAIL: "test@yopmail.com"
     DJANGO_EMAIL_LOGO_IMG: https://meet.127.0.0.1.nip.io/assets/logo-suite-numerique.png
-    DJANGO_EMAIL_DOMAIN: https://meet.127.0.0.1.nip.io
+    DJANGO_EMAIL_DOMAIN: meet.127.0.0.1.nip.io
     OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize
     OIDC_OP_TOKEN_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/token

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -36,6 +36,7 @@ backend:
     DJANGO_EMAIL_SUPPORT_EMAIL: "test@yopmail.com"
     DJANGO_EMAIL_LOGO_IMG: https://meet.127.0.0.1.nip.io/assets/logo-suite-numerique.png
     DJANGO_EMAIL_DOMAIN: meet.127.0.0.1.nip.io
+    DJANGO_EMAIL_APP_BASE_URL: https://meet.127.0.0.1.nip.io
     OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize
     OIDC_OP_TOKEN_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/token

--- a/src/mail/mjml/invitation.mjml
+++ b/src/mail/mjml/invitation.mjml
@@ -3,46 +3,58 @@
 
   <mj-body mj-class="bg--blue-100">
     <mj-wrapper css-class="wrapper" padding="0 40px 40px 40px">
-      <mj-section background-url="{% base64_static 'images/mail-header-background.png' %}" background-size="cover" background-repeat="no-repeat" background-position="0 -30px">
+      <mj-section css-class="wrapper-logo">
         <mj-column>
-            <mj-image align="center" src="{% base64_static 'images/logo-suite-numerique.png' %}" width="250px" align="left" alt="{%trans 'La Suite Numérique' %}" />
+          <mj-image
+            align="center"
+            src="{{logo_img}}"
+            width="320px"
+            alt="{%trans 'Logo email' %}"
+          />
         </mj-column>
       </mj-section>
+
       <mj-section mj-class="bg--white-100" padding="30px 20px 60px 20px">
         <mj-column>
+          <!-- Invitation message -->
+          <mj-text font-size="18px" color="#202124">
+            <p><a href="mailto:{{ sender_email }}">{{ sender_email }}</a>  {% trans "invites you to join an ongoing video call" %}</p>
+          </mj-text>
+
+          <!-- Join button -->
+          <mj-button href="{{ room_url }}" background-color="#1A73E8" color="white" border-radius="4px" font-weight="bold" font-size="16px" padding="20px 0">
+            {% trans "JOIN THE CALL" %}
+          </mj-button>
+
+          <!-- Call URL -->
+          <mj-text align="center" color="#5F6368" font-size="14px" padding-top="15px">
+            <p>{{ room_link }}</p>
+          </mj-text>
+
+          <mj-divider border-width="1px" border-style="solid" border-color="#EEEEEE" padding="30px 0" />
+
+          <!-- Additional information -->
           <mj-text font-size="14px">
-            <p>{% trans "Invitation to join a team" %}</p>
+            <p>{% trans "If you can't click the button, copy and paste the URL into your browser to join the call." %}</p>
           </mj-text>
 
-          <!-- Welcome Message -->
-          <mj-text>
-            <h1>{% blocktrans %}Welcome to <strong>Meet</strong>{% endblocktrans %}</h1>
-          </mj-text>
-          <mj-divider border-width="1px" border-style="solid" border-color="#DDDDDD" width="30%" align="left"/>
-
-          <mj-image src="{% base64_static 'images/logo.svg' %}" width="157px" align="left" alt="{%trans 'Logo' %}" />
-
-          <!-- Main Message -->
-          <mj-text>{% trans "We are delighted to welcome you to our community on Meet, your new companion to collaborate on documents efficiently, intuitively, and securely." %}</mj-text>
-          <mj-text>{% trans "Our application is designed to help you organize, collaborate, and manage permissions." %}</mj-text>
-          <mj-text>
-            {% trans "With Meet, you will be able to:" %}
+          <!-- Quick tips -->
+          <mj-text padding-top="20px" font-size="14px">
+            <p>{% trans "Tips for a better experience:" %}</p>
             <ul>
-              <li>{% trans "Create documents."%}</li>
-              <li>{% trans "Invite members of your document or community in just a few clicks."%}</li>
+              <li>{% trans "Use Chrome or Firefox for better call quality" %}</li>
+              <li>{% trans "Test your microphone and camera before joining" %}</li>
+              <li>{% trans "Make sure you have a stable internet connection" %}</li>
             </ul>
           </mj-text>
-          <mj-button href="//{{site.domain}}" background-color="#000091" color="white" padding-bottom="30px">
-            {% trans "Visit Meet"%}
-          </mj-button>
-          <mj-text>{% trans "We are confident that Meet will help you increase efficiency and productivity while strengthening the bond among members." %}</mj-text>
-          <mj-text>{% trans "Feel free to explore all the features of the application and share your feedback and suggestions with us. Your feedback is valuable to us and will enable us to continually improve our service." %}</mj-text>
-          <mj-text>{% trans "Once again, welcome aboard! We are eager to accompany you on you collaboration adventure." %}</mj-text>
 
           <!-- Signature -->
-          <mj-text>
-            <p>{% trans "Sincerely," %}</p>
-            <p>{% trans "The La Suite Numérique Team" %}</p>
+          <mj-text font-size="14px">
+            <p>
+              {% blocktrans %}
+              Thank you for using {{brandname}}.
+              {% endblocktrans %}
+            </p>
           </mj-text>
         </mj-column>
       </mj-section>
@@ -51,4 +63,3 @@
 
   <mj-include path="./partial/footer.mjml" />
 </mjml>
-


### PR DESCRIPTION
## Purpose

Feature requested by some users. 
Being able to send email invitation from a room. (Inspired by proprietary solutions)

## Proposal

Frontend will display a pop-in with email selection / search. 
Frontend will be responsible to call the /invite endpoint to trigger the email, and add the invited people to the room as member, if they exist in our user base (we don't have pending invitation mechanism as on docs).

This frontend feature will be added in a next PR. 

This new endpoint is intentionally minimal and simply handles sending emails to all invited users. I haven’t added unit tests for the service, as I’m relying on integration tests at the viewset level instead. Feel free to challenge the implementation — I shipped it fast 
