### PR TITLE
🐛(backend) update media auth endpoint to check correct recording status

### DIFF
--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -581,7 +581,10 @@ class Recording(BaseModel):
     @property
     def is_saved(self) -> bool:
         """Check if the recording is in a saved state."""
-        return self.status == RecordingStatusChoices.SAVED
+        return self.status in {
+            RecordingStatusChoices.NOTIFICATION_SUCCEEDED,
+            RecordingStatusChoices.SAVED,
+        }
 
     @property
     def extension(self):

--- a/src/backend/core/tests/test_models_recording.py
+++ b/src/backend/core/tests/test_models_recording.py
@@ -256,8 +256,11 @@ def test_models_recording_key_for_unknown_mode(settings):
 
 
 def test_models_recording_is_saved_true():
-    """Test is_saved property returns True for SAVED status."""
+    """Test is_saved property returns True for SAVED and NOTIFICATION_SUCCEEDED status."""
     recording = RecordingFactory(status=RecordingStatusChoices.SAVED)
+    assert recording.is_saved is True
+
+    recording = RecordingFactory(status=RecordingStatusChoices.NOTIFICATION_SUCCEEDED)
     assert recording.is_saved is True
 
 


### PR DESCRIPTION
Modify media auth endpoint to properly handle recordings with "Notification succeeded" status alongside "Saved" status. Previous code incorrectly expected only "Saved" status, causing access issues after email notifications were sent and status was updated.