### PR TITLE
🚸(frontend) prevent authentication screen flashing during user data fetch

### DIFF
--- a/src/frontend/src/features/auth/api/useUser.tsx
+++ b/src/frontend/src/features/auth/api/useUser.tsx
@@ -65,6 +65,7 @@ export const useUser = (
     refetch: query.refetch,
     user: isLoggedOut ? undefined : (query.data as ApiUser | undefined),
     isLoggedIn,
+    isLoading: query.isLoading,
     logout,
   }
 }

--- a/src/frontend/src/features/recording/routes/RecordingDownload.tsx
+++ b/src/frontend/src/features/recording/routes/RecordingDownload.tsx
@@ -17,7 +17,7 @@ import { RecordingStatus } from '@/features/recording'
 export const RecordingDownload = () => {
   const { t } = useTranslation('recording')
   const { recordingId } = useParams()
-  const { isLoggedIn } = useUser()
+  const { isLoggedIn, isLoading: isAuthLoading } = useUser()
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['recording', recordingId],
@@ -26,7 +26,7 @@ export const RecordingDownload = () => {
     enabled: !!recordingId,
   })
 
-  if (isLoading || !data) {
+  if (isLoading || !data || isAuthLoading) {
     return <LoadingScreen />
   }
 


### PR DESCRIPTION
Fix UI flickering where authentication screen briefly appeared for logged-in users during initial data loading. Address issue caused by increased request delay from waterfall cascade introduced by configurable silent auth setting.
