### PR TITLE
🔧(backend) add MEET_DATA_DIR env variable to specify the data dir

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -23,7 +23,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join("/", "data")
+DATA_DIR = os.environ.get("MEET_DATA_DIR", os.path.join("/", "data"))
 
 
 def get_release():


### PR DESCRIPTION
## Purpose

When building Visio without Docker, the data directory may not (and probably should not) be placed at the root of the filesystem. 

## Proposal

This commit offers a way to specify where the data directory is placed, and when omitted it is assumed to be at `/data`.