### PR TITLE
🥅(backend) add broad exception handling for non-twirp errors in recording

### DIFF
--- a/src/backend/core/recording/worker/services.py
+++ b/src/backend/core/recording/worker/services.py
@@ -41,6 +41,10 @@ class BaseEgressService:
             raise WorkerConnectionError(
                 f"LiveKit client connection error, {e.message}."
             ) from e
+        except Exception as e:
+            raise WorkerConnectionError(
+                f"Unexpected error during LiveKit client connection: {str(e)}"
+            ) from e
 
         finally:
             await lkapi.aclose()

--- a/src/frontend/src/features/recording/api/startRecording.ts
+++ b/src/frontend/src/features/recording/api/startRecording.ts
@@ -27,5 +27,6 @@ export function useStartRecording(
   return useMutation<ApiRoom, ApiError, StartRecordingParams>({
     mutationFn: startRecording,
     onSuccess: options?.onSuccess,
+    onError: options?.onError,
   })
 }

--- a/src/frontend/src/features/recording/api/stopRecording.ts
+++ b/src/frontend/src/features/recording/api/stopRecording.ts
@@ -19,5 +19,6 @@ export function useStopRecording(
   return useMutation<ApiRoom, ApiError, StopRecordingParams>({
     mutationFn: stopRecording,
     onSuccess: options?.onSuccess,
+    onError: options?.onError,
   })
 }

--- a/src/frontend/src/features/recording/components/ScreenRecordingSidePanel.tsx
+++ b/src/frontend/src/features/recording/components/ScreenRecordingSidePanel.tsx
@@ -1,4 +1,4 @@
-import { A, Button, Div, H, Text } from '@/primitives'
+import { A, Button, Dialog, Div, H, P, Text } from '@/primitives'
 
 import fourthSlide from '@/assets/intro-slider/4_record.png'
 import { css } from '@/styled-system/css'
@@ -29,14 +29,20 @@ export const ScreenRecordingSidePanel = () => {
   const recordingSnap = useSnapshot(recordingStore)
   const { t } = useTranslation('rooms', { keyPrefix: 'screenRecording' })
 
+  const [isErrorDialogOpen, setIsErrorDialogOpen] = useState('')
+
   const { notifyParticipants } = useNotifyParticipants()
 
   const roomId = useRoomId()
 
   const { mutateAsync: startRecordingRoom, isPending: isPendingToStart } =
-    useStartRecording()
+    useStartRecording({
+      onError: () => setIsErrorDialogOpen('start'),
+    })
   const { mutateAsync: stopRecordingRoom, isPending: isPendingToStop } =
-    useStopRecording()
+    useStopRecording({
+      onError: () => setIsErrorDialogOpen('stop'),
+    })
 
   const statuses = useMemo(() => {
     return {
@@ -208,6 +214,20 @@ export const ScreenRecordingSidePanel = () => {
           )}
         </>
       )}
+      <Dialog
+        isOpen={!!isErrorDialogOpen}
+        role="alertdialog"
+        aria-label={t('alert.title')}
+      >
+        <P>{t(`alert.body.${isErrorDialogOpen}`)}</P>
+        <Button
+          variant="text"
+          size="sm"
+          onPress={() => setIsErrorDialogOpen('')}
+        >
+          {t('alert.button')}
+        </Button>
+      </Dialog>
     </Div>
   )
 }

--- a/src/frontend/src/features/recording/components/ScreenRecordingSidePanel.tsx
+++ b/src/frontend/src/features/recording/components/ScreenRecordingSidePanel.tsx
@@ -33,8 +33,10 @@ export const ScreenRecordingSidePanel = () => {
 
   const roomId = useRoomId()
 
-  const { mutateAsync: startRecordingRoom } = useStartRecording()
-  const { mutateAsync: stopRecordingRoom } = useStopRecording()
+  const { mutateAsync: startRecordingRoom, isPending: isPendingToStart } =
+    useStartRecording()
+  const { mutateAsync: stopRecordingRoom, isPending: isPendingToStop } =
+    useStopRecording()
 
   const statuses = useMemo(() => {
     return {
@@ -145,7 +147,7 @@ export const ScreenRecordingSidePanel = () => {
         </>
       ) : (
         <>
-          {statuses.isStopping ? (
+          {statuses.isStopping || isPendingToStop ? (
             <>
               <H lvl={3} margin={false}>
                 {t('stopping.heading')}
@@ -193,7 +195,7 @@ export const ScreenRecordingSidePanel = () => {
                 size="sm"
                 variant="tertiary"
               >
-                {statuses.isStarting ? (
+                {statuses.isStarting || isPendingToStart ? (
                   <>
                     <Spinner size={20} />
                     {t('start.loading')}

--- a/src/frontend/src/features/recording/components/TranscriptSidePanel.tsx
+++ b/src/frontend/src/features/recording/components/TranscriptSidePanel.tsx
@@ -1,4 +1,4 @@
-import { A, Button, Div, H, LinkButton, Text } from '@/primitives'
+import { A, Button, Dialog, Div, H, LinkButton, P, Text } from '@/primitives'
 
 import thirdSlide from '@/assets/intro-slider/3_resume.png'
 import { css } from '@/styled-system/css'
@@ -32,6 +32,8 @@ export const TranscriptSidePanel = () => {
   const [isLoading, setIsLoading] = useState(false)
   const { t } = useTranslation('rooms', { keyPrefix: 'transcript' })
 
+  const [isErrorDialogOpen, setIsErrorDialogOpen] = useState('')
+
   const recordingSnap = useSnapshot(recordingStore)
 
   const { notifyParticipants } = useNotifyParticipants()
@@ -43,10 +45,14 @@ export const TranscriptSidePanel = () => {
   const roomId = useRoomId()
 
   const { mutateAsync: startRecordingRoom, isPending: isPendingToStart } =
-    useStartRecording()
+    useStartRecording({
+      onError: () => setIsErrorDialogOpen('start'),
+    })
 
   const { mutateAsync: stopRecordingRoom, isPending: isPendingToStop } =
-    useStopRecording()
+    useStopRecording({
+      onError: () => setIsErrorDialogOpen('stop'),
+    })
 
   const statuses = useMemo(() => {
     return {
@@ -243,6 +249,20 @@ export const TranscriptSidePanel = () => {
           )}
         </>
       )}
+      <Dialog
+        isOpen={!!isErrorDialogOpen}
+        role="alertdialog"
+        aria-label={t('alert.title')}
+      >
+        <P>{t(`alert.body.${isErrorDialogOpen}`)}</P>
+        <Button
+          variant="text"
+          size="sm"
+          onPress={() => setIsErrorDialogOpen('')}
+        >
+          {t('alert.button')}
+        </Button>
+      </Dialog>
     </Div>
   )
 }

--- a/src/frontend/src/features/recording/components/TranscriptSidePanel.tsx
+++ b/src/frontend/src/features/recording/components/TranscriptSidePanel.tsx
@@ -42,8 +42,11 @@ export const TranscriptSidePanel = () => {
   )
   const roomId = useRoomId()
 
-  const { mutateAsync: startRecordingRoom } = useStartRecording()
-  const { mutateAsync: stopRecordingRoom } = useStopRecording()
+  const { mutateAsync: startRecordingRoom, isPending: isPendingToStart } =
+    useStartRecording()
+
+  const { mutateAsync: stopRecordingRoom, isPending: isPendingToStop } =
+    useStopRecording()
 
   const statuses = useMemo(() => {
     return {
@@ -177,7 +180,7 @@ export const TranscriptSidePanel = () => {
             </>
           ) : (
             <>
-              {statuses.isStopping ? (
+              {statuses.isStopping || isPendingToStop ? (
                 <>
                   <H lvl={3} margin={false}>
                     {t('stopping.heading')}
@@ -225,7 +228,7 @@ export const TranscriptSidePanel = () => {
                     size="sm"
                     variant="tertiary"
                   >
-                    {statuses.isStarting ? (
+                    {statuses.isStarting || isPendingToStart ? (
                       <>
                         <Spinner size={20} />
                         {t('start.loading')}

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -237,6 +237,14 @@
       "heading": "",
       "body": "",
       "button": ""
+    },
+    "alert": {
+      "title": "",
+      "body": {
+        "stop": "",
+        "start": ""
+      },
+      "button": ""
     }
   },
   "screenRecording": {
@@ -253,6 +261,14 @@
     "stop": {
       "heading": "",
       "body": "",
+      "button": ""
+    },
+    "alert": {
+      "title": "",
+      "body": {
+        "stop": "",
+        "start": ""
+      },
       "button": ""
     }
   },

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -237,6 +237,14 @@
       "heading": "Become a beta tester",
       "body": "Record your meeting for later. You will receive a summary by email once the meeting is finished.",
       "button": "Sign up"
+    },
+    "alert": {
+      "title": "Transcription Failed",
+      "body": {
+        "stop": "We were unable to stop the transcription. Please try again in a moment.",
+        "start": "We were unable to start the transcription. Please try again in a moment."
+      },
+      "button": "OK"
     }
   },
   "screenRecording": {
@@ -255,6 +263,14 @@
       "heading": "Recording in progress…",
       "body": "You will receive the result by email once the recording is complete.",
       "button": "Stop recording"
+    },
+    "alert": {
+      "title": "Recording Failed",
+      "body": {
+        "stop": "We were unable to stop the recording. Please try again in a moment.",
+        "start": "We were unable to start the recording. Please try again in a moment."
+      },
+      "button": "OK"
     }
   },
   "admin": {

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -237,6 +237,14 @@
       "heading": "Devenez beta testeur",
       "body": "Enregistrer votre réunion pour plus tard. Vous recevrez un compte-rendu par email une fois la réunion terminée.",
       "button": "Inscrivez-vous"
+    },
+    "alert": {
+      "title": "Échec de transcription",
+      "body": {
+        "stop": "Nous n'avons pas pu stopper la transcription. Veuillez réessayer dans quelques instants.",
+        "start": "Nous n'avons pas pu démarrer la transcription. Veuillez réessayer dans quelques instants."
+      },
+      "button": "OK"
     }
   },
   "screenRecording": {
@@ -255,6 +263,14 @@
       "heading": "Enregistrement en cours …",
       "body": "Vous recevrez le resultat par email une fois l'enregistrement terminé.",
       "button": "Arrêter l'enregistrement"
+    },
+    "alert": {
+      "title": "Échec de l'enregistrement",
+      "body": {
+        "stop": "Nous n'avons pas pu stopper l'enregistrement. Veuillez réessayer dans quelques instants.",
+        "start": "Nous n'avons pas pu démarrer l'enregistrement. Veuillez réessayer dans quelques instants."
+      },
+      "button": "OK"
     }
   },
   "admin": {

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -237,6 +237,14 @@
       "heading": "Word betatester",
       "body": "Neem uw vergadering op voor later. U ontvangt een samenvatting per e-mail zodra de vergadering is afgelopen.",
       "button": "Aanmelden"
+    },
+    "alert": {
+      "title": "Transcriptie mislukt",
+      "body": {
+        "stop": "We konden de transcriptie niet stoppen. Probeer het over enkele ogenblikken opnieuw.",
+        "start": "We konden de transcriptie niet starten. Probeer het over enkele ogenblikken opnieuw."
+      },
+      "button": "Opnieuw proberen"
     }
   },
   "screenRecording": {
@@ -255,6 +263,14 @@
       "heading": "Opname bezig …",
       "body": "Je ontvangt het resultaat per e-mail zodra de opname is voltooid.",
       "button": "Opname stoppen"
+    },
+    "alert": {
+      "title": "Opname mislukt",
+      "body": {
+        "stop": "We konden de opname niet stoppen. Probeer het over enkele ogenblikken opnieuw.",
+        "start": "We konden de opname niet starten. Probeer het over enkele ogenblikken opnieuw."
+      },
+      "button": "Opnieuw proberen"
     }
   },
   "admin": {


### PR DESCRIPTION
Implement broad exception handling to catch any non-twirp errors
during recording operations. Ensures recording status is properly reset to
"failed to start" when errors occur, allowing users to retry the recording
while still logging errors to Sentry for investigation.

It's generally a bad practice, however in this case it's fine, I am
catching exception beforehand and it only acts as a fallback.