### PR TITLE
🔥(frontend) remove duplicated aria-label from join screen username input

### DIFF
--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -353,7 +353,6 @@ export const Join = ({
                 type="text"
                 onChange={setUsername}
                 label={t('usernameLabel')}
-                aria-label={t('usernameLabel')}
                 defaultValue={initialUserChoices?.username}
                 validate={(value) => !value && t('errors.usernameEmpty')}
                 wrapperProps={{


### PR DESCRIPTION
Eliminate redundant accessibility attribute that wasn't providing relevant information to screen readers.

