### PR TITLE
YWH reports 

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -120,7 +120,7 @@ class RoomSerializer(serializers.ModelSerializer):
         role = instance.get_role(request.user)
         is_admin = models.RoleChoices.check_administrator_role(role)
 
-        if role is not None:
+        if is_admin:
             access_serializer = NestedResourceAccessSerializer(
                 instance.accesses.select_related("resource", "user").all(),
                 context=self.context,

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -263,6 +263,9 @@ class Base(Configuration):
             "rest_framework.parsers.JSONParser",
             "nested_multipart_parser.drf.DrfNestedParser",
         ],
+        "DEFAULT_RENDERER_CLASSES": [
+            "rest_framework.renderers.JSONRenderer",
+        ],
         "EXCEPTION_HANDLER": "core.api.exception_handler",
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
         "PAGE_SIZE": 20,


### PR DESCRIPTION
Respond to YesWeHack reports:
- Report #YWH-PGM14336-4
- Report #YWH-PGM14336-5

Goal:
- Ensure members are not trusted by default; do not expose the list of accessible resources to room members.
- Disable the browsable API to prevent leakage of sensitive information.