### PR TITLE
(helm) fix issue with affinity : remove affinity for jobs

### DIFF
--- a/src/helm/meet/templates/backend_job_createsuperuser.yaml
+++ b/src/helm/meet/templates/backend_job_createsuperuser.yaml
@@ -75,10 +75,6 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.backend.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.backend.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/src/helm/meet/templates/backend_job_migrate.yaml
+++ b/src/helm/meet/templates/backend_job_migrate.yaml
@@ -75,10 +75,6 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.backend.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.backend.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Purpose

When you defined on the helm chart values `podAntiAffinity` on the backend or the frontend (see values below) then jobs inherits from this affinity and in this example if you have only 2 nodes, no node can be used to start the job => *0/2 nodes are available: 2 node(s) didn't match pod anti-affinity rules. preemption: 0/2 nodes are available: 2 No preemption victims found for incoming pod.*
```yaml
      backend:
        replicas: 2
        affinity:
          podAntiAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              - labelSelector:
                  matchLabels:
                    app.kubernetes.io/component: backend
                topologyKey: "kubernetes.io/hostname"
      frontend:
        replicas: 2
        affinity:
          podAntiAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              - labelSelector:
                  matchLabels:
                    app.kubernetes.io/component: frontend
                topologyKey: "kubernetes.io/hostname"
```

## Proposal

I removed the affinity for these two jobs