### PR TITLE
Remove useless translation in the backend

### DIFF
--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -93,6 +93,6 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
                     pass
                 except User.MultipleObjectsReturned as e:
                     raise SuspiciousOperation(
-                        _("Multiple user accounts share a common email.")
+                        "Multiple user accounts share a common email."
                     ) from e
         return None

--- a/src/backend/core/recording/event/authentication.py
+++ b/src/backend/core/recording/event/authentication.py
@@ -55,7 +55,7 @@ class StorageEventAuthentication(BaseAuthentication):
         if not required_token:
             if settings.RECORDING_ENABLE_STORAGE_EVENT_AUTH:
                 raise AuthenticationFailed(
-                    _("Authentication is enabled but token is not configured.")
+                    "Authentication is enabled but token is not configured."
                 )
 
             return MachineUser(), None
@@ -67,7 +67,7 @@ class StorageEventAuthentication(BaseAuthentication):
                 "Authentication failed: Missing Authorization header (ip: %s)",
                 request.META.get("REMOTE_ADDR"),
             )
-            raise AuthenticationFailed(_("Authorization header is required"))
+            raise AuthenticationFailed("Authorization header is required")
 
         auth_parts = auth_header.split(" ")
         if len(auth_parts) != 2 or auth_parts[0] != self.TOKEN_TYPE:
@@ -75,7 +75,7 @@ class StorageEventAuthentication(BaseAuthentication):
                 "Authentication failed: Invalid authorization header (ip: %s)",
                 request.META.get("REMOTE_ADDR"),
             )
-            raise AuthenticationFailed(_("Invalid authorization header."))
+            raise AuthenticationFailed("Invalid authorization header.")
 
         token = auth_parts[1]
 
@@ -85,7 +85,7 @@ class StorageEventAuthentication(BaseAuthentication):
                 "Authentication failed: Invalid token (ip: %s)",
                 request.META.get("REMOTE_ADDR"),
             )
-            raise AuthenticationFailed(_("Invalid token"))
+            raise AuthenticationFailed("Invalid token")
 
         return MachineUser(), token
 

--- a/src/backend/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/backend/locale/de_DE/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-13 13:50+0000\n"
+"POT-Creation-Date: 2025-05-13 13:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,10 +34,6 @@ msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Sie müssen Administrator oder Eigentümer eines Raums sein, um Zugriffe "
 "hinzuzufügen."
-
-#: core/authentication/backends.py:96
-msgid "Multiple user accounts share a common email."
-msgstr "Mehrere Benutzerkonten verwenden dieselbe E-Mail-Adresse."
 
 #: core/models.py:31
 msgid "Member"
@@ -297,22 +293,6 @@ msgstr "Dieses Team ist bereits Teil dieser Aufzeichnung."
 #: core/models.py:666
 msgid "Either user or team must be set, not both."
 msgstr "Entweder Benutzer oder Team muss festgelegt werden, nicht beides."
-
-#: core/recording/event/authentication.py:58
-msgid "Authentication is enabled but token is not configured."
-msgstr "Authentifizierung ist aktiviert, aber Token ist nicht konfiguriert."
-
-#: core/recording/event/authentication.py:70
-msgid "Authorization header is required"
-msgstr "Autorisierungs-Header ist erforderlich"
-
-#: core/recording/event/authentication.py:78
-msgid "Invalid authorization header."
-msgstr "Ungültiger Autorisierungs-Header."
-
-#: core/recording/event/authentication.py:88
-msgid "Invalid token"
-msgstr "Ungültiges Token"
 
 #: core/recording/event/notification.py:94
 msgid "Your recording is ready"

--- a/src/backend/locale/en_US/LC_MESSAGES/django.po
+++ b/src/backend/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-13 10:15+0000\n"
+"POT-Creation-Date: 2025-05-13 13:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,10 +32,6 @@ msgstr "Important dates"
 #: core/api/serializers.py:63
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr "You must be administrator or owner of a room to add accesses to it."
-
-#: core/authentication/backends.py:96
-msgid "Multiple user accounts share a common email."
-msgstr "Multiple user accounts share a common email."
 
 #: core/models.py:31
 msgid "Member"
@@ -292,22 +288,6 @@ msgstr "This team is already in this recording."
 #: core/models.py:666
 msgid "Either user or team must be set, not both."
 msgstr "Either user or team must be set, not both."
-
-#: core/recording/event/authentication.py:58
-msgid "Authentication is enabled but token is not configured."
-msgstr "Authentication is enabled but token is not configured."
-
-#: core/recording/event/authentication.py:70
-msgid "Authorization header is required"
-msgstr "Authorization header is required"
-
-#: core/recording/event/authentication.py:78
-msgid "Invalid authorization header."
-msgstr "Invalid authorization header."
-
-#: core/recording/event/authentication.py:88
-msgid "Invalid token"
-msgstr "Invalid token"
 
 #: core/recording/event/notification.py:94
 msgid "Your recording is ready"

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-13 10:15+0000\n"
+"POT-Creation-Date: 2025-05-13 13:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: antoine.lebaud@mail.numerique.gouv.fr\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,10 +34,6 @@ msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Vous devez être administrateur ou propriétaire d'une salle pour y ajouter "
 "des accès."
-
-#: core/authentication/backends.py:96
-msgid "Multiple user accounts share a common email."
-msgstr "Plusieurs comptes utilisateur partagent une adresse e-mail commune."
 
 #: core/models.py:31
 msgid "Member"
@@ -298,22 +294,6 @@ msgstr "Cette équipe est déjà dans cet enregistrement."
 #: core/models.py:666
 msgid "Either user or team must be set, not both."
 msgstr "Soit l'utilisateur, soit l'équipe doit être défini, pas les deux."
-
-#: core/recording/event/authentication.py:58
-msgid "Authentication is enabled but token is not configured."
-msgstr "L'authentification est activée mais le jeton n'est pas configuré."
-
-#: core/recording/event/authentication.py:70
-msgid "Authorization header is required"
-msgstr "L'en-tête d'autorisation est requis"
-
-#: core/recording/event/authentication.py:78
-msgid "Invalid authorization header."
-msgstr "En-tête d'autorisation invalide."
-
-#: core/recording/event/authentication.py:88
-msgid "Invalid token"
-msgstr "Jeton invalide"
 
 #: core/recording/event/notification.py:94
 msgid "Your recording is ready"

--- a/src/backend/locale/nl_NL/LC_MESSAGES/django.po
+++ b/src/backend/locale/nl_NL/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-13 10:15+0000\n"
+"POT-Creation-Date: 2025-05-13 13:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,10 +33,6 @@ msgstr "Belangrijke datums"
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Je moet beheerder of eigenaar van een ruimte zijn om toegang toe te voegen."
-
-#: core/authentication/backends.py:96
-msgid "Multiple user accounts share a common email."
-msgstr "Meerdere gebruikersaccounts delen een gemeenschappelijk e-mailadres."
 
 #: core/models.py:31
 msgid "Member"
@@ -292,22 +288,6 @@ msgstr "Dit team is al in deze opname."
 #: core/models.py:666
 msgid "Either user or team must be set, not both."
 msgstr "Ofwel gebruiker of team moet worden ingesteld, niet beide."
-
-#: core/recording/event/authentication.py:58
-msgid "Authentication is enabled but token is not configured."
-msgstr "Authenticatie is ingeschakeld maar token is niet geconfigureerd."
-
-#: core/recording/event/authentication.py:70
-msgid "Authorization header is required"
-msgstr "Autorisatie-header is vereist"
-
-#: core/recording/event/authentication.py:78
-msgid "Invalid authorization header."
-msgstr "Ongeldige autorisatie-header."
-
-#: core/recording/event/authentication.py:88
-msgid "Invalid token"
-msgstr "Ongeldig token"
 
 #: core/recording/event/notification.py:94
 msgid "Your recording is ready"


### PR DESCRIPTION
Some backend translations were wrongly internationalized, as not user facing.
Fix those issues.

