### PR TITLE
🐛(backend) fix ingress path to use specific API path

### DIFF
--- a/src/helm/meet/Chart.yaml
+++ b/src/helm/meet/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: meet
-version: 0.0.6
+version: 0.0.7

--- a/src/helm/meet/templates/ingress.yaml
+++ b/src/helm/meet/templates/ingress.yaml
@@ -60,7 +60,7 @@ spec:
               serviceName: {{ include "meet.frontend.fullname" . }}
               servicePort: {{ .Values.frontend.service.port }}
             {{- end }}
-          - path: /api
+          - path: /api/v
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}
@@ -96,7 +96,7 @@ spec:
               serviceName: {{ include "meet.frontend.fullname" $ }}
               servicePort: {{ $.Values.frontend.service.port }}
             {{- end }}
-          - path: /api
+          - path: /api/v
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}


### PR DESCRIPTION
Replace generic '/api' path with versioned '/api/v' pattern in Helm ingress template to ensure proper routing for backend requests.

It closes #539