### PR TITLE
Fix the path of the backend ingress.

### DIFF
--- a/src/helm/meet/templates/ingress.yaml
+++ b/src/helm/meet/templates/ingress.yaml
@@ -60,7 +60,7 @@ spec:
               serviceName: {{ include "meet.frontend.fullname" . }}
               servicePort: {{ .Values.frontend.service.port }}
             {{- end }}
-          - path: /api/v
+          - path: /api/
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}
@@ -96,7 +96,7 @@ spec:
               serviceName: {{ include "meet.frontend.fullname" $ }}
               servicePort: {{ $.Values.frontend.service.port }}
             {{- end }}
-          - path: /api/v
+          - path: /api/
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}


### PR DESCRIPTION
## Purpose
The current path is `/api/v`, and it doesn't work with `ingress-nginx`. 

## Proposal
I'm not sure if other ingress controllers work with this prefix, but changing it to `/api/` will work for `ingress-nginx` and likely for others as well.