### PR TITLE
🐛(frontend) restore user language synchronization between frontend and backend

### DIFF
--- a/src/frontend/src/components/AppInitialization.tsx
+++ b/src/frontend/src/components/AppInitialization.tsx
@@ -2,9 +2,11 @@ import { silenceLiveKitLogs } from '@/utils/livekit'
 import { useConfig } from '@/api/useConfig'
 import { useAnalytics } from '@/features/analytics/hooks/useAnalytics'
 import { useSupport } from '@/features/support/hooks/useSupport'
+import { useSyncUserPreferencesWithBackend } from '@/features/auth'
 
 export const AppInitialization = () => {
   const { data } = useConfig()
+  useSyncUserPreferencesWithBackend()
 
   const {
     analytics = {},


### PR DESCRIPTION
Fix issue where user language preferences stopped properly syncing between frontend and backend, causing inconsistent language experience. Issue was reported by user and affected localization settings persistence.