### PR TITLE
✏️(backend) fix typo in FRONTEND_IS_SILENT_LOGIN_ENABLED env var

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -314,7 +314,7 @@ class Base(Configuration):
             False, environ_name="FRONTEND_SILENCE_LIVEKIT_DEBUG", environ_prefix=None
         ),
         "is_silent_login_enabled": values.BooleanValue(
-            True, environ_name="FRONTEND_IS_SILENT_LOGING_ENABLED", environ_prefix=None
+            True, environ_name="FRONTEND_IS_SILENT_LOGIN_ENABLED", environ_prefix=None
         ),
         "feedback": values.DictValue(
             {}, environ_name="FRONTEND_FEEDBACK", environ_prefix=None


### PR DESCRIPTION
Correct spelling in environment variable name as identified by @K900. This is technically a breaking change for existing deployments using this setting, but acceptable as we haven't released an official version yet. Will personally notify known users of this setting about the change to minimize disruption.

It closes #556