### PR TITLE
🔒️(oidc) disable OIDC authentication on API

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -257,7 +257,6 @@ class Base(Configuration):
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
-            "mozilla_django_oidc.contrib.drf.OIDCAuthentication",
             "rest_framework.authentication.SessionAuthentication",
         ),
         "DEFAULT_PARSER_CLASSES": [


### PR DESCRIPTION
## Purpose

Our authentication flow uses the Django authentication which creates a session for the User. Then the session is used to make API calls, therefore we don't need to accept OIDC tokens directly on the API.

Accepting the OIDC token on the API can allow to bypass the "resource server mode" which allows to restrict provided information according to the Service Provider which makes the request.


## Proposal

- [x] remove OIDC backend authentication on API
