### PR TITLE
⬇️(frontend) rollback LiveKit component library from 2.9.0 to 2.8.1

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "meet",
       "version": "0.1.22",
       "dependencies": {
-        "@livekit/components-react": "2.9.3",
+        "@livekit/components-react": "2.8.1",
         "@livekit/components-styles": "1.1.5",
         "@livekit/track-processors": "0.5.6",
         "@pandacss/preset-panda": "0.53.6",
@@ -990,13 +990,13 @@
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
+      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/utils": {
@@ -1214,39 +1214,48 @@
       }
     },
     "node_modules/@livekit/components-core": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@livekit/components-core/-/components-core-0.12.4.tgz",
-      "integrity": "sha512-a/GkK8XFULPhXoSKxuXEU62gwTAYJ83DP5/vlRzwESEY+rsoiw2NvvPZtDCU17yyd/5QBIF9VdDjB9ZZF0dOfQ==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@livekit/components-core/-/components-core-0.12.1.tgz",
+      "integrity": "sha512-R7qWoVzPckOYxEHZgP3Kp8u+amu+isnTptgoZV7+bpmLRBHI7mWnaD+0uDWlyIMjI1pBbK3wHg0ILKa5UytI+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@floating-ui/dom": "1.6.13",
+        "@floating-ui/dom": "1.6.11",
         "loglevel": "1.9.1",
-        "rxjs": "7.8.2"
+        "rxjs": "7.8.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "livekit-client": "^2.11.1",
+        "livekit-client": "^2.8.1",
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@livekit/components-react": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@livekit/components-react/-/components-react-2.9.3.tgz",
-      "integrity": "sha512-gE1sEE57BkBz3+TQHrOXVDVwVMwV5wtIYokdrfd7vshh22/PtWWj3vON9wzYLFRKx98L6QyAzyh7W9EWu3Lj9Q==",
+    "node_modules/@livekit/components-core/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@livekit/components-core": "0.12.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@livekit/components-react": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@livekit/components-react/-/components-react-2.8.1.tgz",
+      "integrity": "sha512-XpuDu7iDMcN4pkV8CYNzHf9hLNdYOeEtbmCr7Zesy6Au3BxUl4aS1Ajmg0b75Rx7zTlkyCJt9Lm4VrEqbJCI6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/components-core": "0.12.1",
         "clsx": "2.1.1",
-        "usehooks-ts": "3.1.1"
+        "usehooks-ts": "3.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@livekit/krisp-noise-filter": "^0.2.12",
-        "livekit-client": "^2.11.1",
+        "livekit-client": "^2.8.1",
         "react": ">=18",
         "react-dom": ">=18",
         "tslib": "^2.6.2"
@@ -7385,7 +7394,8 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7418,6 +7428,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
       "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -8661,6 +8672,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9490,9 +9502,9 @@
       }
     },
     "node_modules/usehooks-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
-      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+      "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
       "license": "MIT",
       "dependencies": {
         "lodash.debounce": "^4.0.8"
@@ -9501,7 +9513,7 @@
         "node": ">=16.15.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
+        "react": "^16.8.0  || ^17 || ^18"
       }
     },
     "node_modules/util-deprecate": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -13,7 +13,7 @@
     "check": "prettier --check ./src"
   },
   "dependencies": {
-    "@livekit/components-react": "2.9.3",
+    "@livekit/components-react": "2.8.1",
     "@livekit/components-styles": "1.1.5",
     "@livekit/track-processors": "0.5.6",
     "@pandacss/preset-panda": "0.53.6",


### PR DESCRIPTION
Downgrade @livekit/components-js due to bug introduced in version 2.9.0. Issue has been reported to upstream maintainers at: https://github.com/livekit/components-js/issues/1158

Reverting to last known stable version until fix is available.

