### PR TITLE
🐛(backend) fix OIDC returnTo parameter validation in Docker compose

### DIFF
--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -42,7 +42,7 @@ LOGIN_REDIRECT_URL=http://localhost:3000
 LOGIN_REDIRECT_URL_FAILURE=http://localhost:3000
 LOGOUT_REDIRECT_URL=http://localhost:3000
 
-OIDC_REDIRECT_ALLOWED_HOSTS=["http://localhost:8083", "http://localhost:3000"]
+OIDC_REDIRECT_ALLOWED_HOSTS=localhost:8083,localhost:3000
 OIDC_AUTH_REQUEST_EXTRA_PARAMS={"acr_values": "eidas1"}
 
 # Livekit Token settings


### PR DESCRIPTION
Correct OIDC_REDIRECT_ALLOWED_HOSTS configuration that was preventing proper URL validation. Thanks to @nvasse for identifying and fixing the issue.

Note: Update your common env file with corrected values.
