### PR TITLE
⬆️(docker) upgrade backend image to python 3.13

### DIFF
--- a/.github/workflows/meet.yml
+++ b/.github/workflows/meet.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install development dependencies
         run: pip install --user .[dev]
       - name: Check code formatting with ruff
@@ -185,7 +185,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install development dependencies
         run: pip install --user .[dev]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Django Meet
 
 # ---- base image to inherit from ----
-FROM python:3.12.6-alpine3.20 AS base
+FROM python:3.13.5-alpine3.21 AS base
 
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN python -m pip install --upgrade pip setuptools

--- a/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
@@ -68,7 +68,7 @@ backend:
     SUMMARY_SERVICE_API_TOKEN: password
     SCREEN_RECORDING_BASE_URL: https://meet.127.0.0.1.nip.io/recordings
     ROOM_TELEPHONY_ENABLED: True
-    SSL_CERT_FILE: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
+    SSL_CERT_FILE: /usr/local/lib/python3.13/site-packages/certifi/cacert.pem
 
 
   migrate:
@@ -112,7 +112,7 @@ backend:
   # Extra volume mounts to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumeMounts:
     - name: certs
-      mountPath: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
+      mountPath: /usr/local/lib/python3.13/site-packages/certifi/cacert.pem
       subPath: cacert.pem
 
   # Extra volumes to manage our local custom CA and avoid to set ssl_verify: false

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -95,7 +95,7 @@ backend:
         key: BREVO_API_KEY
     BREVO_API_CONTACT_LIST_IDS: 8
     ROOM_TELEPHONY_ENABLED: True
-    SSL_CERT_FILE: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
+    SSL_CERT_FILE: /usr/local/lib/python3.13/site-packages/certifi/cacert.pem
 
 
   migrate:
@@ -139,7 +139,7 @@ backend:
   # Extra volume mounts to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumeMounts:
     - name: certs
-      mountPath: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
+      mountPath: /usr/local/lib/python3.13/site-packages/certifi/cacert.pem
       subPath: cacert.pem
 
   # Extra volumes to manage our local custom CA and avoid to set ssl_verify: false

--- a/src/summary/Dockerfile
+++ b/src/summary/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS builder
+FROM python:3.13-slim AS builder
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY pyproject.toml .
 
 RUN pip3 install --no-cache-dir .
 
-FROM python:3.12-slim AS production
+FROM python:3.13-slim AS production
 
 WORKDIR /app
 

--- a/src/summary/Dockerfile
+++ b/src/summary/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.13-slim AS builder
+FROM python:3.13-slim AS base
+
+FROM base AS builder
 
 WORKDIR /app
 
@@ -6,7 +8,7 @@ COPY pyproject.toml .
 
 RUN pip3 install --no-cache-dir .
 
-FROM python:3.13-slim AS production
+FROM base AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
Python 3.13 is now stable, our libraries are compatible with it. We also
upgrade the alpine version and node one used in the backend.
