### PR TITLE
♻️(frontend) use LiveKit default mobile detection in noise reduction hook

### DIFF
--- a/src/frontend/src/features/rooms/livekit/hooks/useNoiseReductionAvailable.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useNoiseReductionAvailable.ts
@@ -1,13 +1,12 @@
-import { useIsMobile } from '@/utils/useIsMobile'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { FeatureFlags } from '@/features/analytics/enums'
 import { useIsAnalyticsEnabled } from '@/features/analytics/hooks/useIsAnalyticsEnabled'
+import { isMobileBrowser } from '@livekit/components-core'
 
 export const useNoiseReductionAvailable = () => {
   const featureEnabled = useFeatureFlagEnabled(FeatureFlags.faceLandmarks)
   const isAnalyticsEnabled = useIsAnalyticsEnabled()
 
-  const isMobile = useIsMobile()
-
+  const isMobile = isMobileBrowser()
   return !isMobile && (!isAnalyticsEnabled || featureEnabled)
 }


### PR DESCRIPTION
Replace custom mobile browser detection with livekit-client's built-in isMobile() function for consistency and better reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved mobile device detection for noise reduction availability, resulting in more reliable feature behavior across devices. No visible changes to functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->