### PR TITLE
Add email to userDisplay

### DIFF
--- a/src/frontend/src/features/settings/components/SettingsDialog.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialog.tsx
@@ -10,6 +10,7 @@ export const SettingsDialog = (props: SettingsDialogProps) => {
   const { t, i18n } = useTranslation('settings')
   const { user, isLoggedIn, logout } = useUser()
   const { languagesList, currentLanguage } = useLanguageLabels()
+  const userDisplay = (user?.full_name && user?.email) ? `${user.full_name} (${user.email})` : user?.email
   return (
     <Dialog title={t('dialog.heading')} {...props}>
       <H lvl={2}>{t('account.heading')}</H>
@@ -18,7 +19,7 @@ export const SettingsDialog = (props: SettingsDialogProps) => {
           <P>
             <Trans
               i18nKey="settings:account.currentlyLoggedAs"
-              values={{ user: user?.full_name ?? user?.email }}
+              values={{ user: userDisplay }}
               components={[<Badge />]}
             />
           </P>

--- a/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
@@ -18,6 +18,7 @@ export const AccountTab = ({ id, onOpenChange }: AccountTabProps) => {
   const room = useRoomContext()
   const { user, isLoggedIn, logout } = useUser()
   const [name, setName] = useState(room?.localParticipant.name ?? '')
+  const userDisplay = (user?.full_name && user?.email) ? `${user.full_name} (${user.email})` : user?.email
 
   const handleOnSubmit = () => {
     if (room) room.localParticipant.setName(name)
@@ -46,7 +47,7 @@ export const AccountTab = ({ id, onOpenChange }: AccountTabProps) => {
           <P>
             <Trans
               i18nKey="settings:account.currentlyLoggedAs"
-              values={{ user: user?.full_name || user?.email }}
+              values={{ user: userDisplay }}
               components={[<Badge />]}
             />
           </P>


### PR DESCRIPTION
## Purpose

Add email to `currentlyLoggedAs` to avoid confusion. Useful for users with mutliple emails, eg. beta+other

## Proposal

Simply create a userDisplay variable that concatenates full name and email when available.
