### PR TITLE
🐛(summary) fix Celery task execution by number of required args

### DIFF
--- a/src/summary/summary/core/analytics.py
+++ b/src/summary/summary/core/analytics.py
@@ -107,12 +107,13 @@ class MetadataManager:
             "retries": 0,
         }
 
-        _required_args_count = 4
+        _required_args_count = 7
         if len(task_args) != _required_args_count:
             logger.error("Invalid number of arguments.")
             return
 
-        filename, email, _, received_at = task_args
+        filename, email, _, received_at, *_ = task_args
+
         initial_metadata = {
             **initial_metadata,
             "filename": filename,

--- a/src/summary/summary/core/celery_config.py
+++ b/src/summary/summary/core/celery_config.py
@@ -1,8 +1,9 @@
+"""Celery Config."""
 
 # https://github.com/danihodovic/celery-exporter
 # Enable task events for Prometheus monitoring via celery-exporter.
 
-# worker_send_task_events: Sends task lifecycle events (e.g., started, succeeded, failed),
+# worker_send_task_events: Sends task lifecycle events (e.g., started, succeeded),
 # allowing the exporter to track task execution metrics and durations.
 worker_send_task_events = True
 

--- a/src/summary/summary/core/celery_worker.py
+++ b/src/summary/summary/core/celery_worker.py
@@ -37,7 +37,7 @@ celery = Celery(
     broker_connection_retry_on_startup=True,
 )
 
-celery.config_from_object('summary.core.celery_config')
+celery.config_from_object("summary.core.celery_config")
 
 if settings.sentry_dsn and settings.sentry_is_enabled:
 


### PR DESCRIPTION
Forgot to update the args verification while enriching the task with more recording metadata
