### PR TITLE
:construction_worker:(ci) use variables in pipelines for easy fork an…

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,19 +1,21 @@
 name: Docker Hub Workflow
 run-name: Docker Hub Workflow
 
+env:
+  DOCKER_USER: 1001:127
+  DOCKER_CONTAINER_REGISTRY: lasuite
+  MAIN_BRANCH: main
+
 on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - '${{ MAIN_BRANCH }}'
     tags:
       - 'v*'
   pull_request:
     branches:
-      - 'main'
-
-env:
-  DOCKER_USER: 1001:127
+      - '${{ MAIN_BRANCH }}'
 
 jobs:
   build-and-push-backend:
@@ -27,7 +29,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: lasuite/meet-backend
+          images: '${{ env.DOCKER_CONTAINER_REGISTRY }}/meet-backend'
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
@@ -37,7 +39,7 @@ jobs:
         uses: numerique-gouv/action-trivy-cache@main
         with:
           docker-build-args: '--target backend-production -f Dockerfile'
-          docker-image-name: 'docker.io/lasuite/meet-backend:${{ github.sha }}'
+          docker-image-name: 'docker.io/${{ env.DOCKER_CONTAINER_REGISTRY }}/meet-backend:${{ github.sha }}'
       -
         name: Build and push
         uses: docker/build-push-action@v6
@@ -60,7 +62,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: lasuite/meet-frontend
+          images: '${{ env.DOCKER_CONTAINER_REGISTRY }}/meet-frontend'
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
@@ -70,7 +72,7 @@ jobs:
         uses: numerique-gouv/action-trivy-cache@main
         with:
           docker-build-args: '-f src/frontend/Dockerfile --target frontend-production'
-          docker-image-name: 'docker.io/lasuite/meet-frontend:${{ github.sha }}'
+          docker-image-name: 'docker.io/${{ env.DOCKER_CONTAINER_REGISTRY }}/meet-frontend:${{ github.sha }}'
       -
         name: Build and push
         uses: docker/build-push-action@v6
@@ -94,7 +96,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: lasuite/meet-frontend-dinum
+          images: '${{ env.DOCKER_CONTAINER_REGISTRY }}/meet-frontend-dinum'
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
@@ -104,7 +106,7 @@ jobs:
         uses: numerique-gouv/action-trivy-cache@main
         with:
           docker-build-args: '-f docker/dinum-frontend/Dockerfile --target frontend-production'
-          docker-image-name: 'docker.io/lasuite/meet-frontend-dinum:${{ github.sha }}'
+          docker-image-name: 'docker.io/${{ env.DOCKER_CONTAINER_REGISTRY }}/meet-frontend-dinum:${{ github.sha }}'
       -
         name: Build and push
         uses: docker/build-push-action@v6
@@ -128,7 +130,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: lasuite/meet-summary
+          images: '${{ env.DOCKER_CONTAINER_REGISTRY }}/meet-summary'
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Purpose

Introduce some variables in pipelines to make easier customisation of forks for testing

## Proposal

It is common to fork a project and test it locally. But for whoever who wants to test it at scale, it could be interesting to use environment variables and change only what is required to get started.

Two variables are introduced:

- one for the docker registry (and not try to push docker images to `lasuite/...`)
- one for the main branch from which pipelines should be executed (and keep `main` clean of changes for easy sync from upstream while keeping some changes local).
