### PR TITLE
♻️(frontend) refactor preview track to avoid unnecessary resets

### DIFF
--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -30,7 +30,7 @@ import { useSnapshot } from 'valtio'
 import { openPermissionsDialog, permissionsStore } from '@/stores/permissions'
 import { ToggleDevice } from './join/ToggleDevice'
 import { SelectDevice } from './join/SelectDevice'
-import { useResolveDefaultDeviceId } from '../livekit/hooks/useResolveDefaultDevice'
+import { useResolveInitiallyDefaultDeviceId } from '../livekit/hooks/useResolveInitiallyDefaultDeviceId'
 import { isSafari } from '@/utils/livekit'
 import type { LocalUserChoices } from '@/stores/userChoices'
 
@@ -163,8 +163,16 @@ export const Join = ({
 
   // LiveKit by default populates device choices with "default" value.
   // Instead, use the current device id used by the preview track as a default
-  useResolveDefaultDeviceId(audioDeviceId, audioTrack, saveAudioInputDeviceId)
-  useResolveDefaultDeviceId(videoDeviceId, videoTrack, saveVideoInputDeviceId)
+  useResolveInitiallyDefaultDeviceId(
+    audioDeviceId,
+    audioTrack,
+    saveAudioInputDeviceId
+  )
+  useResolveInitiallyDefaultDeviceId(
+    videoDeviceId,
+    videoTrack,
+    saveVideoInputDeviceId
+  )
 
   const videoEl = useRef(null)
   const isVideoInitiated = useRef(false)

--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -3,7 +3,7 @@ import { usePreviewTracks } from '@livekit/components-react'
 import { css } from '@/styled-system/css'
 import { Screen } from '@/layout/Screen'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { LocalVideoTrack, Track } from 'livekit-client'
+import { LocalAudioTrack, LocalVideoTrack, Track } from 'livekit-client'
 import { H } from '@/primitives/H'
 import { Field } from '@/primitives/Field'
 import { Button, Dialog, Text, Form } from '@/primitives'
@@ -157,7 +157,7 @@ export const Join = ({
     () =>
       tracks?.filter(
         (track) => track.kind === Track.Kind.Audio
-      )[0] as LocalVideoTrack,
+      )[0] as LocalAudioTrack,
     [tracks]
   )
 

--- a/src/frontend/src/features/rooms/livekit/hooks/useResolveInitiallyDefaultDeviceId.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useResolveInitiallyDefaultDeviceId.ts
@@ -1,17 +1,21 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
-export const useResolveDefaultDeviceId = <
+export const useResolveInitiallyDefaultDeviceId = <
   T extends { getDeviceId(): Promise<string | undefined> },
 >(
   currentId: string,
   track: T | undefined,
   save: (id: string) => void
 ) => {
+  const isInitiated = useRef(false)
   useEffect(() => {
-    if (currentId !== 'default' || !track) return
+    if (currentId !== 'default' || !track || isInitiated.current) return
     const resolveDefaultDeviceId = async () => {
       const actualDeviceId = await track.getDeviceId()
-      if (actualDeviceId && actualDeviceId !== 'default') save(actualDeviceId)
+      if (actualDeviceId && actualDeviceId !== 'default') {
+        isInitiated.current = true
+        save(actualDeviceId)
+      }
     }
     resolveDefaultDeviceId()
   }, [currentId, track, save])


### PR DESCRIPTION
Replace usePreviewTrack approach with manual track management inspired by deprecated LiveKit implementation that only toggles what's needed instead of resetting entire preview track on config changes.

Previous approach created new videoTrack when updating audio track, causing video preview to blink black during audio configuration changes.

It was also acquiring video streams even when disabled.

New implementation:
* Initializes tracks once with user permissions for both devices
* Manually handles muting/unmuting and device updates
* Preserves muted state when changing device IDs
* Uses exact device constraints on Chrome for proper device selection

Prevents unnecessary track recreation and eliminates preview blinking.
