### PR TITLE
👷(ci) add pip caching and upgrade setup-python action to v5

### DIFF
--- a/.github/workflows/meet.yml
+++ b/.github/workflows/meet.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: "pip"
       - name: Install development dependencies
         run: pip install --user .[dev]
       - name: Check code formatting with ruff
@@ -186,6 +187,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: "pip"
 
       - name: Install development dependencies
         run: pip install --user .[dev]


### PR DESCRIPTION
Implement pip dependency caching across all CI jobs requiring package installation and upgrade actions/setup-python from v4 to v5.

The setup-python action is able to cache the dependencies and reuse this cache while the pyproject file has not changed. It is easy to setup, just the package manager used has to be declared in the cache settings

