### PR TITLE
✨(frontend) increase chat message limit to 2000 characters

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/chat/Input.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/chat/Input.tsx
@@ -101,7 +101,7 @@ export const ChatInput = ({
         }}
         placeholderStyle={'strong'}
         spellCheck={false}
-        maxLength={500}
+        maxLength={2000}
         aria-label={t('textArea.label')}
       />
       <Button


### PR DESCRIPTION
Expand text area input character limit from default to 2000 characters to allow users more space for detailed chat messages.

Provides better user experience for longer form communication within chat interface while maintaining reasonable message size constraints.