### PR TITLE
🔧(backend) set explicit user subscription permissions for other tracks

### DIFF
--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -90,6 +90,7 @@ def generate_token(
         can_update_own_metadata=True,
         can_publish=bool(sources),
         can_publish_sources=sources,
+        can_subscribe=True,
     )
 
     if user.is_anonymous:


### PR DESCRIPTION
Configure LiveKit token to explicitly allow users to subscribe to other participants' video and audio tracks instead of relying on default permissions.