### PR TITLE
⬆️(livekit) upgrade local LiveKit server to version 1.9.0

### DIFF
--- a/docker/livekit/Dockerfile
+++ b/docker/livekit/Dockerfile
@@ -1,4 +1,4 @@
-FROM livekit/livekit-server:v1.8.0
+FROM livekit/livekit-server:v1.9.0
 
 # We inject the nip.io certificate manually because the livekit chart doesn't support volume mounting
 COPY rootCA.pem /etc/ssl/certs/


### PR DESCRIPTION
Update development environment LiveKit server from previous version to 1.9.0 for latest features and bug fixes.

Ensures development environment stays current
with LiveKit production version.
