### PR TITLE
🐛(summary) fix featureflag

### DIFF
--- a/src/backend/core/recording/event/notification.py
+++ b/src/backend/core/recording/event/notification.py
@@ -131,8 +131,8 @@ class NotificationService:
         if not owner_access:
             logger.error("No owner found for recording %s", recording.id)
             return False
-
         payload = {
+            "owner_id": str(owner_access.user.id),
             "filename": recording.key,
             "email": owner_access.user.email,
             "sub": owner_access.user.sub,

--- a/src/summary/summary/api/route/tasks.py
+++ b/src/summary/summary/api/route/tasks.py
@@ -18,6 +18,7 @@ settings = get_settings()
 class TaskCreation(BaseModel):
     """Task data."""
 
+    owner_id: str
     filename: str
     email: str
     sub: str
@@ -35,6 +36,7 @@ async def create_task(request: TaskCreation):
     """Create a task."""
     task = process_audio_transcribe_summarize_v2.apply_async(
         args=[
+            request.owner_id,
             request.filename,
             request.email,
             request.sub,

--- a/src/summary/summary/core/celery_worker.py
+++ b/src/summary/summary/core/celery_worker.py
@@ -204,6 +204,7 @@ def task_failure_handler(task_id, exception=None, **kwargs):
 )
 def process_audio_transcribe_summarize_v2(
     self,
+    owner_id: str,
     filename: str,
     email: str,
     sub: str,
@@ -320,7 +321,7 @@ def process_audio_transcribe_summarize_v2(
     metadata_manager.capture(task_id, settings.posthog_event_success)
 
     if (
-        analytics.is_feature_enabled("summary-enabled", distinct_id=sub)
+        analytics.is_feature_enabled("summary-enabled", distinct_id=owner_id)
         and settings.is_summary_enabled
     ):
         logger.info("Queuing summary generation task.")


### PR DESCRIPTION
fix the featureflag to allow chosen users to use
the summary feature by using the owner_id instead of sub because 
users are identified with owner_id as distinct_id in posthog. It's necessary
to use the distinct_id to check the feature flag.

