### PR TITLE
⬆️(backend) upgrade django to 5.2.7

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "django-redis==6.0.0",
     "django-storages[s3]==1.14.6",
     "django-timezone-field>=5.1",
-    "django==5.2.6",
+    "django==5.2.7",
     "djangorestframework==3.16.0",
     "drf_spectacular==0.28.0",
     "dockerflow==2024.4.2",


### PR DESCRIPTION
Resolve vulnerability CVE-2025-59681, that triggers Trivy scan and block PR's merging.

More information there https://avd.aquasec.com/nvd/cve-2025-59681
