### PR TITLE
✨(frontend) add emoji reactions to chat messages

### DIFF
--- a/src/frontend/src/features/notifications/NotificationPayload.ts
+++ b/src/frontend/src/features/notifications/NotificationPayload.ts
@@ -5,5 +5,8 @@ export interface NotificationPayload {
   data?: {
     emoji?: string
     removedSources?: string[]
+    messageId?: string
+    action?: 'add' | 'remove'
+    participantName?: string
   }
 }

--- a/src/frontend/src/features/notifications/NotificationType.ts
+++ b/src/frontend/src/features/notifications/NotificationType.ts
@@ -5,6 +5,7 @@ export enum NotificationType {
   MessageReceived = 'messageReceived',
   LowerHand = 'lowerHand',
   ReactionReceived = 'reactionReceived',
+  ChatReactionReceived = 'chatReactionReceived',
   ParticipantWaiting = 'participantWaiting',
   TranscriptionStarted = 'transcriptionStarted',
   TranscriptionStopped = 'transcriptionStopped',

--- a/src/frontend/src/features/rooms/livekit/components/chat/ReactionPicker.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/chat/ReactionPicker.tsx
@@ -1,0 +1,119 @@
+import { useTranslation } from 'react-i18next'
+import { RiEmotionLine } from '@remixicon/react'
+import { useState, useEffect } from 'react'
+import { css } from '@/styled-system/css'
+import { Button } from '@/primitives'
+import { Emoji } from '@/features/rooms/livekit/components/controls/ReactionsToggle'
+import { getEmojiLabel } from '@/features/rooms/livekit/utils/reactionUtils'
+import { Toolbar as RACToolbar } from 'react-aria-components'
+
+interface ReactionPickerProps {
+  onReactionSelect: (emoji: string) => void
+}
+
+export const ReactionPicker = ({ onReactionSelect }: ReactionPickerProps) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'chat.reactions' })
+  const [isVisible, setIsVisible] = useState(false)
+
+  // Animation state management
+  const [isRendered, setIsRendered] = useState(isVisible)
+  const [opacity, setOpacity] = useState(isVisible ? 1 : 0)
+
+  useEffect(() => {
+    if (isVisible) {
+      setIsRendered(true)
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setOpacity(1)
+        })
+      })
+    } else if (isRendered) {
+      setOpacity(0)
+      const timer = setTimeout(() => {
+        setIsRendered(false)
+      }, 200)
+      return () => clearTimeout(timer)
+    }
+  }, [isVisible, isRendered])
+
+  const handleReactionSelect = (emoji: string) => {
+    onReactionSelect(emoji)
+    setIsVisible(false)
+  }
+
+  return (
+    <div
+      className={css({
+        position: 'relative',
+      })}
+    >
+      <Button
+        size="xs"
+        variant="quaternaryText"
+        square
+        aria-label={t('add')}
+        tooltip={t('add')}
+        onPress={() => setIsVisible(!isVisible)}
+        data-attr="chat-reaction-picker-trigger"
+      >
+        <RiEmotionLine size={18} />
+      </Button>
+      {isRendered && (
+        <div
+          className={css({
+            position: 'absolute',
+            bottom: '100%',
+            right: 0,
+            marginBottom: '0.25rem',
+            borderRadius: '8px',
+            padding: '0.35rem',
+            backgroundColor: 'white',
+            boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+            border: '1px solid',
+            borderColor: 'greyscale.200',
+            opacity: opacity,
+            transition: 'opacity 0.2s ease',
+            zIndex: 10,
+          })}
+          onTransitionEnd={() => {
+            if (!isVisible) {
+              setIsRendered(false)
+            }
+          }}
+        >
+          <RACToolbar
+            className={css({
+              display: 'flex',
+              gap: '0.25rem',
+            })}
+          >
+            {Object.values(Emoji).map((emoji, index) => (
+              <Button
+                key={index}
+                onPress={() => handleReactionSelect(emoji)}
+                aria-label={t('sendReaction', {
+                  emoji: getEmojiLabel(emoji, t),
+                })}
+                variant="secondaryText"
+                size="xs"
+                square
+                data-attr={`chat-reaction-${emoji}`}
+              >
+                <img
+                  src={`/assets/reactions/${emoji}.png`}
+                  alt=""
+                  className={css({
+                    minHeight: '24px',
+                    minWidth: '24px',
+                    pointerEvents: 'none',
+                    userSelect: 'none',
+                  })}
+                />
+              </Button>
+            ))}
+          </RACToolbar>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/frontend/src/features/rooms/livekit/components/chat/ReactionsDisplay.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/chat/ReactionsDisplay.tsx
@@ -1,0 +1,128 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { css } from '@/styled-system/css'
+import { Button } from '@/primitives'
+import { ChatReaction } from '@/stores/chatReactions'
+import { getEmojiLabel } from '@/features/rooms/livekit/utils/reactionUtils'
+
+interface GroupedReaction {
+  emoji: string
+  count: number
+  participants: { identity: string; name?: string }[]
+  hasCurrentUser: boolean
+}
+
+interface ReactionsDisplayProps {
+  reactions: ChatReaction[]
+  currentUserIdentity: string
+  onReactionToggle: (emoji: string) => void
+}
+
+export const ReactionsDisplay = ({
+  reactions,
+  currentUserIdentity,
+  onReactionToggle,
+}: ReactionsDisplayProps) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'chat.reactions' })
+
+  const groupedReactions = useMemo((): GroupedReaction[] => {
+    const groups: Record<string, GroupedReaction> = {}
+
+    for (const reaction of reactions) {
+      if (!groups[reaction.emoji]) {
+        groups[reaction.emoji] = {
+          emoji: reaction.emoji,
+          count: 0,
+          participants: [],
+          hasCurrentUser: false,
+        }
+      }
+      groups[reaction.emoji].count++
+      groups[reaction.emoji].participants.push({
+        identity: reaction.participantIdentity,
+        name: reaction.participantName,
+      })
+      if (reaction.participantIdentity === currentUserIdentity) {
+        groups[reaction.emoji].hasCurrentUser = true
+      }
+    }
+
+    return Object.values(groups)
+  }, [reactions, currentUserIdentity])
+
+  if (groupedReactions.length === 0) {
+    return null
+  }
+
+  const getTooltipText = (group: GroupedReaction): string => {
+    const names = group.participants
+      .slice(0, 3)
+      .map((p) => {
+        if (p.identity === currentUserIdentity) {
+          return t('you')
+        }
+        return p.name || p.identity
+      })
+      .join(', ')
+
+    if (group.participants.length > 3) {
+      return t('reactedByWithOthers', {
+        names,
+        count: group.participants.length - 3,
+      })
+    }
+    return t('reactedBy', { names })
+  }
+
+  return (
+    <div
+      className={css({
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '0.25rem',
+        marginTop: '0.25rem',
+      })}
+    >
+      {groupedReactions.map((group) => (
+        <Button
+          key={group.emoji}
+          size="xs"
+          variant={group.hasCurrentUser ? 'tertiary' : 'secondaryText'}
+          onPress={() => onReactionToggle(group.emoji)}
+          aria-label={
+            group.hasCurrentUser
+              ? t('removeReaction', { emoji: getEmojiLabel(group.emoji, t) })
+              : t('addReaction', { emoji: getEmojiLabel(group.emoji, t) })
+          }
+          tooltip={getTooltipText(group)}
+          data-attr={`chat-reaction-badge-${group.emoji}`}
+          className={css({
+            gap: '0.125rem !important',
+            paddingX: '0.25rem !important',
+            paddingY: '0.125rem !important',
+            minHeight: 'auto',
+          })}
+        >
+          <img
+            src={`/assets/reactions/${group.emoji}.png`}
+            alt=""
+            className={css({
+              height: '16px',
+              width: '16px',
+              pointerEvents: 'none',
+              userSelect: 'none',
+            })}
+          />
+          <span
+            className={css({
+              fontSize: '12px',
+              fontWeight: 'medium',
+            })}
+          >
+            {group.count}
+          </span>
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useChatReactions.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useChatReactions.ts
@@ -1,0 +1,73 @@
+import { useCallback } from 'react'
+import { useRoomContext } from '@livekit/components-react'
+import { useSnapshot } from 'valtio'
+import { NotificationType } from '@/features/notifications/NotificationType'
+import { NotificationPayload } from '@/features/notifications/NotificationPayload'
+import {
+  chatReactionsStore,
+  addReaction,
+  removeReaction,
+} from '@/stores/chatReactions'
+import useRateLimiter from '@/hooks/useRateLimiter'
+
+// Note: Receiving reactions from other participants is handled in MainNotificationToast.tsx
+// This hook handles sending reactions and exposes the store state
+
+export const useChatReactions = () => {
+  const room = useRoomContext()
+  const { reactions } = useSnapshot(chatReactionsStore)
+
+  const sendReaction = useCallback(
+    async (messageId: string, emoji: string, action: 'add' | 'remove') => {
+      const encoder = new TextEncoder()
+      const payload: NotificationPayload = {
+        type: NotificationType.ChatReactionReceived,
+        data: {
+          messageId,
+          emoji,
+          action,
+          participantName: room.localParticipant.name,
+        },
+      }
+      const data = encoder.encode(JSON.stringify(payload))
+      await room.localParticipant.publishData(data, { reliable: true })
+
+      // Update local state immediately
+      if (action === 'add') {
+        addReaction(messageId, {
+          emoji,
+          participantIdentity: room.localParticipant.identity,
+          participantName: room.localParticipant.name,
+        })
+      } else {
+        removeReaction(messageId, room.localParticipant.identity, emoji)
+      }
+    },
+    [room]
+  )
+
+  const rateLimitedSendReaction = useRateLimiter({
+    callback: sendReaction,
+    maxCalls: 10,
+    windowMs: 1000,
+  })
+
+  const toggleReaction = useCallback(
+    (messageId: string, emoji: string) => {
+      const messageReactions = reactions[messageId] || []
+      const hasReacted = messageReactions.some(
+        (r) =>
+          r.participantIdentity === room.localParticipant.identity &&
+          r.emoji === emoji
+      )
+      rateLimitedSendReaction(messageId, emoji, hasReacted ? 'remove' : 'add')
+    },
+    [reactions, room.localParticipant.identity, rateLimitedSendReaction]
+  )
+
+  return {
+    reactions,
+    toggleReaction,
+    getReactionsForMessage: (messageId: string) => reactions[messageId] || [],
+  }
+}

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -315,7 +315,16 @@
     "closeButton": "Hide {{content}}"
   },
   "chat": {
-    "disclaimer": "The messages are visible to participants only at the time they are sent. All messages are deleted at the end of the call."
+    "disclaimer": "The messages are visible to participants only at the time they are sent. All messages are deleted at the end of the call.",
+    "reactions": {
+      "add": "Add reaction",
+      "sendReaction": "React with {{emoji}}",
+      "addReaction": "Add {{emoji}} reaction",
+      "removeReaction": "Remove {{emoji}} reaction",
+      "you": "You",
+      "reactedBy": "Reacted by {{names}}",
+      "reactedByWithOthers": "Reacted by {{names}} and {{count}} others"
+    }
   },
   "moreTools": {
     "body": "Access more tools to enhance your meetings.",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -315,7 +315,16 @@
     "closeButton": "Masquer {{content}}"
   },
   "chat": {
-    "disclaimer": "Les messages sont visibles par les participants uniquement au moment de\nleur envoi. Tous les messages sont supprimés à la fin de l'appel."
+    "disclaimer": "Les messages sont visibles par les participants uniquement au moment de\nleur envoi. Tous les messages sont supprimés à la fin de l'appel.",
+    "reactions": {
+      "add": "Ajouter une réaction",
+      "sendReaction": "Réagir avec {{emoji}}",
+      "addReaction": "Ajouter la réaction {{emoji}}",
+      "removeReaction": "Retirer la réaction {{emoji}}",
+      "you": "Vous",
+      "reactedBy": "Réaction de {{names}}",
+      "reactedByWithOthers": "Réaction de {{names}} et {{count}} autres"
+    }
   },
   "moreTools": {
     "body": "Accèder à d'avantage d'outils pour améliorer vos réunions.",

--- a/src/frontend/src/stores/chatReactions.ts
+++ b/src/frontend/src/stores/chatReactions.ts
@@ -1,0 +1,64 @@
+import { proxy } from 'valtio'
+
+export interface ChatReaction {
+  emoji: string
+  participantIdentity: string
+  participantName?: string
+}
+
+type State = {
+  // Map of messageId -> array of reactions
+  reactions: Record<string, ChatReaction[]>
+}
+
+export const chatReactionsStore = proxy<State>({
+  reactions: {},
+})
+
+export const addReaction = (
+  messageId: string,
+  reaction: ChatReaction
+): void => {
+  const currentReactions = chatReactionsStore.reactions[messageId] || []
+
+  // Check if this participant already reacted with this emoji
+  const alreadyExists = currentReactions.some(
+    (r) =>
+      r.participantIdentity === reaction.participantIdentity &&
+      r.emoji === reaction.emoji
+  )
+
+  // Only add if not already present - create new array for reactivity
+  if (!alreadyExists) {
+    chatReactionsStore.reactions[messageId] = [...currentReactions, reaction]
+  }
+}
+
+export const removeReaction = (
+  messageId: string,
+  participantIdentity: string,
+  emoji: string
+): void => {
+  if (!chatReactionsStore.reactions[messageId]) {
+    return
+  }
+
+  chatReactionsStore.reactions[messageId] = chatReactionsStore.reactions[
+    messageId
+  ].filter(
+    (r) => !(r.participantIdentity === participantIdentity && r.emoji === emoji)
+  )
+
+  // Clean up empty arrays
+  if (chatReactionsStore.reactions[messageId].length === 0) {
+    delete chatReactionsStore.reactions[messageId]
+  }
+}
+
+export const getReactions = (messageId: string): ChatReaction[] => {
+  return chatReactionsStore.reactions[messageId] || []
+}
+
+export const clearAllReactions = (): void => {
+  chatReactionsStore.reactions = {}
+}


### PR DESCRIPTION
## Purpose

Allow participants to react to chat messages with emojis, similar to reactions in messaging apps like Slack or Teams. This enhances communication by providing a lightweight way to acknowledge or respond to messages without typing a reply.

https://github.com/orgs/suitenumerique/projects/11?pane=issue&itemId=131558444

## Proposal

  Add emoji reactions to chat messages, synchronized in real-time across all participants via LiveKit data channels.

  - [x] Add reaction picker (8 emojis) that appears on message hover
  - [x] Display aggregated reactions below messages with participant count
  - [x] Sync reactions between participants in real-time
  - [x] Toggle reactions by clicking existing reaction badges
  - [x] Add i18n translations (English, French)
