### PR TITLE
✨(backend) use room_create grant for room auto creation

### DIFF
--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -96,6 +96,7 @@ def generate_token(
         room=room,
         room_join=True,
         room_admin=is_admin_or_owner,
+        room_create=is_admin_or_owner,
         can_update_own_metadata=False,
         can_publish=bool(sources),
         can_publish_sources=sources,


### PR DESCRIPTION
This pull request sets the room_create grant for room admins, allowing livekit's global room auto create option to be disabled.

Requires https://github.com/livekit/livekit/pull/4320