### PR TITLE
✨(backend) force ProConnect official name in trusted rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(backend) force official name in trusted rooms #1155
+
 ### Changed
 
 - ♿️(frontend) fix sidepanel accessibility aria-label #1182

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -172,6 +172,14 @@ class RoomSerializer(serializers.ModelSerializer):
         if should_access_room:
             room_id = f"{instance.id!s}"
             username = request.query_params.get("username", None)
+
+            # Force official identity for authenticated users in trusted rooms
+            if (
+                instance.access_level == models.RoomAccessLevel.TRUSTED
+                and request.user.is_authenticated
+            ):
+                username = request.user.full_name or str(request.user)
+
             output["livekit"] = utils.generate_livekit_config(
                 room_id=room_id,
                 user=request.user,

--- a/src/backend/core/services/lobby.py
+++ b/src/backend/core/services/lobby.py
@@ -146,6 +146,13 @@ class LobbyService:
         room_id = str(room.id)
 
         if self.can_bypass_lobby(room=room, user=request.user):
+            # Force official identity for authenticated users in trusted rooms
+            if (
+                room.access_level == models.RoomAccessLevel.TRUSTED
+                and request.user.is_authenticated
+            ):
+                username = request.user.full_name or str(request.user)
+
             if participant is None:
                 participant = LobbyParticipant(
                     status=LobbyParticipantStatus.ACCEPTED,
@@ -176,6 +183,13 @@ class LobbyService:
             self.refresh_waiting_status(room.id, participant_id)
 
         elif participant.status == LobbyParticipantStatus.ACCEPTED:
+            # Force official identity for authenticated users in trusted rooms
+            if (
+                room.access_level == models.RoomAccessLevel.TRUSTED
+                and request.user.is_authenticated
+            ):
+                username = request.user.full_name or str(request.user)
+
             # wrongly named, contains access token to join a room
             livekit_config = utils.generate_livekit_config(
                 room_id=room_id,

--- a/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
@@ -283,6 +283,7 @@ def test_api_rooms_retrieve_authenticated_trusted(mock_token):
     Authenticated users should be allowed to retrieve a room and get a token for a room to
     which they are not related, provided the room has a trusted access_level.
     They should not see related users.
+    The username should be forced to the user's official name.
     """
     room = RoomFactory(access_level=RoomAccessLevel.TRUSTED)
 
@@ -310,10 +311,84 @@ def test_api_rooms_retrieve_authenticated_trusted(mock_token):
         "slug": room.slug,
     }
 
+    # Username is forced to user's full_name in trusted rooms
     mock_token.assert_called_once_with(
         room=expected_name,
         user=user,
-        username=None,
+        username=user.full_name,
+        color=None,
+        sources=None,
+        is_admin_or_owner=False,
+        participant_id=None,
+    )
+
+
+@mock.patch("core.utils.generate_token", return_value="foo")
+@override_settings(
+    LIVEKIT_CONFIGURATION={
+        "api_key": "key",
+        "api_secret": "secret",
+        "url": "test_url_value",
+    }
+)
+def test_api_rooms_retrieve_authenticated_trusted_forces_official_name(mock_token):
+    """
+    When a room has trusted access level and the user is authenticated,
+    the username should be forced to the user's official ProConnect name
+    (full_name), ignoring any custom username passed as query parameter.
+    """
+    room = RoomFactory(access_level=RoomAccessLevel.TRUSTED)
+
+    user = UserFactory(full_name="Jean Dupont")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get(
+        f"/api/v1.0/rooms/{room.id!s}/?username=FakeIdentity",
+    )
+    assert response.status_code == 200
+
+    expected_name = f"{room.id!s}"
+    mock_token.assert_called_once_with(
+        room=expected_name,
+        user=user,
+        username="Jean Dupont",
+        color=None,
+        sources=None,
+        is_admin_or_owner=False,
+        participant_id=None,
+    )
+
+
+@mock.patch("core.utils.generate_token", return_value="foo")
+@override_settings(
+    LIVEKIT_CONFIGURATION={
+        "api_key": "key",
+        "api_secret": "secret",
+        "url": "test_url_value",
+    }
+)
+def test_api_rooms_retrieve_authenticated_trusted_fallback_to_email(mock_token):
+    """
+    When a room has trusted access level and the user is authenticated but has no
+    full_name, the username should fall back to str(user) (email).
+    """
+    room = RoomFactory(access_level=RoomAccessLevel.TRUSTED)
+
+    user = UserFactory(full_name="")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get(
+        f"/api/v1.0/rooms/{room.id!s}/?username=FakeIdentity",
+    )
+    assert response.status_code == 200
+
+    expected_name = f"{room.id!s}"
+    mock_token.assert_called_once_with(
+        room=expected_name,
+        user=user,
+        username=str(user),
         color=None,
         sources=None,
         is_admin_or_owner=False,

--- a/src/backend/core/tests/services/test_lobby.py
+++ b/src/backend/core/tests/services/test_lobby.py
@@ -277,10 +277,12 @@ def test_request_entry_public_room(
 def test_request_entry_trusted_room(
     mock_generate_config, lobby_service, participant_id, username
 ):
-    """Test requesting entry to a trusted room when the user is authenticated."""
+    """Test requesting entry to a trusted room when the user is authenticated.
+    The username should be forced to the user's official name."""
     request = mock.Mock()
     request.user = mock.Mock()
     request.user.is_authenticated = True
+    request.user.full_name = "Official Name"
 
     room = RoomFactory(access_level=RoomAccessLevel.TRUSTED)
 
@@ -299,10 +301,11 @@ def test_request_entry_trusted_room(
 
     assert participant.status == LobbyParticipantStatus.ACCEPTED
     assert livekit_config == {"token": "test-token"}
+    # Username is forced to the official name in trusted rooms
     mock_generate_config.assert_called_once_with(
         room_id=str(room.id),
         user=request.user,
-        username=username,
+        username="Official Name",
         color=participant.color,
         configuration=room.configuration,
         is_admin_or_owner=False,


### PR DESCRIPTION
## Summary

- When a room has **trusted** access level and the user is authenticated via ProConnect/OIDC, the display name is now forced to the user's official `full_name` from the OIDC claims
- Custom usernames passed as query parameters are ignored for authenticated users in trusted rooms, preventing identity fraud
- Falls back to `str(user)` (email) if `full_name` is not available
- Applied consistently in both the room serializer (direct room access) and the lobby service (entry request flow)

Closes #784

## Test plan

- [ ] Create a room with **trusted** access level
- [ ] Join as an authenticated ProConnect user with a custom username → verify the display name shows the official ProConnect name, not the custom one
- [ ] Join as an authenticated user with no `full_name` set → verify fallback to email
- [ ] Join a **public** room as an authenticated user with a custom username → verify custom username is still used (no override)
- [ ] Run backend tests: `pytest src/backend/core/tests/rooms/test_api_rooms_retrieve.py src/backend/core/tests/services/test_lobby.py`