### PR TITLE
🩹(frontend) add participant audio leveling

### DIFF
--- a/src/frontend/src/features/rooms/livekit/hooks/useParticipantAudioLeveling.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useParticipantAudioLeveling.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react'
+import { RemoteAudioTrack, Track } from 'livekit-client'
+import { useRoomContext } from '@livekit/components-react'
+import { useSnapshot } from 'valtio'
+import { userPreferencesStore } from '@/stores/userPreferences'
+
+const TARGET_AUDIO_LEVEL = 0.35
+const MIN_GAIN = 0.6
+const MAX_GAIN = 1
+const SMOOTHING_FACTOR = 0.08
+const UPDATE_INTERVAL_MS = 500
+const MIN_AUDIO_LEVEL = 0.02
+
+export const useParticipantAudioLeveling = () => {
+  const room = useRoomContext()
+  const { is_participant_audio_leveling_enabled: enabled } =
+    useSnapshot(userPreferencesStore)
+
+  // track sid → current smoothed gain
+  const gainMapRef = useRef<Map<string, number>>(new Map())
+  // direct track object refs so reset works even if tracks are unpublished/muted
+  const touchedTracksRef = useRef<Set<RemoteAudioTrack>>(new Set())
+
+  useEffect(() => {
+    const resetTouchedTracks = () => {
+      for (const track of touchedTracksRef.current) {
+        track.setVolume(1)
+      }
+      gainMapRef.current.clear()
+      touchedTracksRef.current.clear()
+    }
+
+    if (!enabled) {
+      resetTouchedTracks()
+      return
+    }
+
+    const interval = setInterval(() => {
+      for (const participant of room.remoteParticipants.values()) {
+        const pub = participant.getTrackPublication(Track.Source.Microphone)
+        const audioTrack = pub?.audioTrack
+        if (!audioTrack || !pub.trackSid) continue
+        if (!(audioTrack instanceof RemoteAudioTrack)) continue
+
+        const sid = pub.trackSid
+        const audioLevel = participant.audioLevel
+
+        if (audioLevel < MIN_AUDIO_LEVEL) continue
+
+        const prevGain = gainMapRef.current.get(sid) ?? 1
+        const desiredGain = TARGET_AUDIO_LEVEL / audioLevel
+        const clampedGain = Math.min(MAX_GAIN, Math.max(MIN_GAIN, desiredGain))
+        const smoothedGain =
+          prevGain + SMOOTHING_FACTOR * (clampedGain - prevGain)
+
+        gainMapRef.current.set(sid, smoothedGain)
+        touchedTracksRef.current.add(audioTrack)
+        audioTrack.setVolume(smoothedGain)
+      }
+    }, UPDATE_INTERVAL_MS)
+
+    return () => {
+      clearInterval(interval)
+      resetTouchedTracks()
+    }
+  }, [enabled, room])
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useParticipantAudioLeveling.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useParticipantAudioLeveling.ts
@@ -7,7 +7,8 @@ import { userPreferencesStore } from '@/stores/userPreferences'
 const TARGET_AUDIO_LEVEL = 0.35
 const MIN_GAIN = 0.6
 const MAX_GAIN = 1
-const SMOOTHING_FACTOR = 0.08
+const ATTENUATION_SMOOTHING_FACTOR = 0.25
+const RECOVERY_SMOOTHING_FACTOR = 0.08
 const UPDATE_INTERVAL_MS = 500
 const MIN_AUDIO_LEVEL = 0.02
 
@@ -50,8 +51,12 @@ export const useParticipantAudioLeveling = () => {
         const prevGain = gainMapRef.current.get(sid) ?? 1
         const desiredGain = TARGET_AUDIO_LEVEL / audioLevel
         const clampedGain = Math.min(MAX_GAIN, Math.max(MIN_GAIN, desiredGain))
+        const smoothingFactor =
+          clampedGain < prevGain
+            ? ATTENUATION_SMOOTHING_FACTOR
+            : RECOVERY_SMOOTHING_FACTOR
         const smoothedGain =
-          prevGain + SMOOTHING_FACTOR * (clampedGain - prevGain)
+          prevGain + smoothingFactor * (clampedGain - prevGain)
 
         gainMapRef.current.set(sid, smoothedGain)
         touchedTracksRef.current.add(audioTrack)

--- a/src/frontend/src/features/rooms/livekit/hooks/useParticipantAudioLeveling.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useParticipantAudioLeveling.ts
@@ -1,5 +1,11 @@
 import { useEffect, useRef } from 'react'
-import { RemoteAudioTrack, Track } from 'livekit-client'
+import {
+  RemoteAudioTrack,
+  RemoteTrack,
+  RemoteTrackPublication,
+  RoomEvent,
+  Track,
+} from 'livekit-client'
 import { useRoomContext } from '@livekit/components-react'
 import { useSnapshot } from 'valtio'
 import { userPreferencesStore } from '@/stores/userPreferences'
@@ -11,6 +17,8 @@ const ATTENUATION_SMOOTHING_FACTOR = 0.25
 const RECOVERY_SMOOTHING_FACTOR = 0.08
 const UPDATE_INTERVAL_MS = 500
 const MIN_AUDIO_LEVEL = 0.02
+// gap to MAX_GAIN below which a recovering track is snapped to exactly 1
+const RECOVERY_EPSILON = 0.01
 
 export const useParticipantAudioLeveling = () => {
   const room = useRoomContext()
@@ -31,10 +39,24 @@ export const useParticipantAudioLeveling = () => {
       touchedTracksRef.current.clear()
     }
 
+    const handleTrackUnsubscribed = (
+      track: RemoteTrack,
+      publication: RemoteTrackPublication
+    ) => {
+      if (!(track instanceof RemoteAudioTrack)) return
+      if (!touchedTracksRef.current.has(track)) return
+
+      track.setVolume(1)
+      touchedTracksRef.current.delete(track)
+      gainMapRef.current.delete(publication.trackSid)
+    }
+
     if (!enabled) {
       resetTouchedTracks()
       return
     }
+
+    room.on(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed)
 
     const interval = setInterval(() => {
       for (const participant of room.remoteParticipants.values()) {
@@ -46,7 +68,24 @@ export const useParticipantAudioLeveling = () => {
         const sid = pub.trackSid
         const audioLevel = participant.audioLevel
 
-        if (audioLevel < MIN_AUDIO_LEVEL) continue
+        if (audioLevel < MIN_AUDIO_LEVEL) {
+          const prevGain = gainMapRef.current.get(sid)
+          if (prevGain === undefined || prevGain >= MAX_GAIN) continue
+
+          const recoveredGain =
+            prevGain + RECOVERY_SMOOTHING_FACTOR * (MAX_GAIN - prevGain)
+
+          if (MAX_GAIN - recoveredGain < RECOVERY_EPSILON) {
+            audioTrack.setVolume(MAX_GAIN)
+            gainMapRef.current.delete(sid)
+            touchedTracksRef.current.delete(audioTrack)
+          } else {
+            gainMapRef.current.set(sid, recoveredGain)
+            touchedTracksRef.current.add(audioTrack)
+            audioTrack.setVolume(recoveredGain)
+          }
+          continue
+        }
 
         const prevGain = gainMapRef.current.get(sid) ?? 1
         const desiredGain = TARGET_AUDIO_LEVEL / audioLevel
@@ -66,6 +105,7 @@ export const useParticipantAudioLeveling = () => {
 
     return () => {
       clearInterval(interval)
+      room.off(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed)
       resetTouchedTracks()
     }
   }, [enabled, room])

--- a/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
+++ b/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
@@ -32,6 +32,7 @@ import { useRegisterKeyboardShortcut } from '@/features/shortcuts/useRegisterKey
 import { useSettingsDialog } from '@/features/settings'
 import { SettingsDialogExtendedKey } from '@/features/settings/type'
 import { useVideoResolutionSubscription } from '../hooks/useVideoResolutionSubscription'
+import { useParticipantAudioLeveling } from '../hooks/useParticipantAudioLeveling'
 import { SettingsDialogProvider } from '@/features/settings/components/SettingsDialogProvider'
 import { IsIdleDisconnectModal } from '../components/IsIdleDisconnectModal'
 import { getParticipantName } from '@/features/rooms/utils/getParticipantName'
@@ -90,6 +91,7 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
   useConnectionObserver()
   useRoomPageTitle()
   useVideoResolutionSubscription()
+  useParticipantAudioLeveling()
 
   useRegisterKeyboardShortcut({
     id: 'open-shortcuts',

--- a/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
+++ b/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
@@ -18,6 +18,7 @@ import { MediaStateObserver } from '../components/MediaStateObserver'
 import { RoomMetadataSynchronizer } from '../components/RoomMetadataSynchronizer'
 import { useNoiseReduction } from '../hooks/useNoiseReduction'
 import { VideoResolutionSubscription } from '../components/VideoResolutionSubscription'
+import { useParticipantAudioLeveling } from '../hooks/useParticipantAudioLeveling'
 import { SettingsDialogProvider } from '@/features/settings/components/SettingsDialogProvider'
 import { IsIdleDisconnectModal } from '../components/IsIdleDisconnectModal'
 import { ReactionPortals } from '@/features/reactions/components/ReactionPortals'
@@ -71,6 +72,7 @@ const getScreenSharePermissionDeniedScope = (
  * @public
  */
 export function VideoConference({ ...props }: VideoConferenceProps) {
+  useParticipantAudioLeveling()
   useNoiseReduction()
 
   const { isOpen: isPictureInPictureOpen } = usePictureInPicture()

--- a/src/frontend/src/features/settings/components/tabs/AudioTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/AudioTab.tsx
@@ -14,6 +14,8 @@ import { usePersistentUserChoices } from '@/features/rooms/livekit/hooks/usePers
 import { useNoiseReductionAvailable } from '@/features/rooms/livekit/hooks/useNoiseReductionAvailable'
 import posthog from 'posthog-js'
 import { RowWrapper } from './layout/RowWrapper'
+import { useSnapshot } from 'valtio'
+import { userPreferencesStore } from '@/stores/userPreferences'
 
 export type AudioTabProps = Pick<DialogProps, 'onOpenChange'> &
   Pick<TabPanelProps, 'id'>
@@ -63,6 +65,8 @@ export const AudioTab = ({ id }: AudioTabProps) => {
       }
 
   const noiseReductionAvailable = useNoiseReductionAvailable()
+
+  const userPreferencesSnap = useSnapshot(userPreferencesStore)
 
   return (
     <TabPanel padding={'md'} flex id={id}>
@@ -117,6 +121,19 @@ export const AudioTab = ({ id }: AudioTabProps) => {
           <div />
         </RowWrapper>
       )}
+      <RowWrapper heading={t('audio.participantAudioLeveling.heading')}>
+        <Switch
+          isSelected={
+            userPreferencesSnap.is_participant_audio_leveling_enabled
+          }
+          onChange={(value) =>
+            (userPreferencesStore.is_participant_audio_leveling_enabled = value)
+          }
+        >
+          {t('audio.participantAudioLeveling.label')}
+        </Switch>
+        <Text>{t('audio.participantAudioLeveling.description')}</Text>
+      </RowWrapper>
       {noiseReductionAvailable && (
         <RowWrapper heading={t('audio.noiseReduction.heading')} beta>
           <Switch

--- a/src/frontend/src/features/settings/components/tabs/AudioTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/AudioTab.tsx
@@ -20,6 +20,7 @@ import {
   userChoicesStore,
 } from '@/stores/userChoices'
 import { captureEvent } from '@/features/analytics/telemetry'
+import { userPreferencesStore } from '@/stores/userPreferences'
 
 export type AudioTabProps = Pick<DialogProps, 'onOpenChange'> &
   Pick<TabPanelProps, 'id'>
@@ -65,6 +66,8 @@ export const AudioTab = ({ id }: AudioTabProps) => {
       }
 
   const noiseReductionAvailable = useNoiseReductionAvailable()
+
+  const userPreferencesSnap = useSnapshot(userPreferencesStore)
 
   return (
     <TabPanel padding={'md'} flex id={id}>
@@ -119,6 +122,17 @@ export const AudioTab = ({ id }: AudioTabProps) => {
           <div />
         </RowWrapper>
       )}
+      <RowWrapper heading={t('audio.participantAudioLeveling.heading')}>
+        <Switch
+          isSelected={userPreferencesSnap.is_participant_audio_leveling_enabled}
+          onChange={(value) =>
+            (userPreferencesStore.is_participant_audio_leveling_enabled = value)
+          }
+        >
+          {t('audio.participantAudioLeveling.label')}
+        </Switch>
+        <Text>{t('audio.participantAudioLeveling.description')}</Text>
+      </RowWrapper>
       {noiseReductionAvailable && (
         <RowWrapper heading={t('audio.noiseReduction.heading')} beta>
           <Switch

--- a/src/frontend/src/locales/de/settings.json
+++ b/src/frontend/src/locales/de/settings.json
@@ -35,6 +35,11 @@
       "ongoingTest": "Soundtest läuft…",
       "safariWarning": "Die Audioausgabeauswahl ist auf Safari aufgrund von Browser-Einschränkungen noch nicht verfügbar."
     },
+    "participantAudioLeveling": {
+      "heading": "Audio-Anpassung der Teilnehmer",
+      "label": "Audiopegel der Teilnehmer automatisch angleichen",
+      "description": "Passt die Lautstärke der entfernten Teilnehmer während des Anrufs schrittweise an, damit die Stimmen gleichmäßiger klingen."
+    },
     "permissionsRequired": "Berechtigungen erforderlich"
   },
   "video": {

--- a/src/frontend/src/locales/de/settings.json
+++ b/src/frontend/src/locales/de/settings.json
@@ -39,6 +39,11 @@
       "ongoingTest": "Soundtest läuft…",
       "safariWarning": "Die Audioausgabeauswahl ist auf Safari aufgrund von Browser-Einschränkungen noch nicht verfügbar."
     },
+    "participantAudioLeveling": {
+      "heading": "Audio-Anpassung der Teilnehmer",
+      "label": "Audiopegel der Teilnehmer automatisch angleichen",
+      "description": "Passt die Lautstärke der entfernten Teilnehmer während des Anrufs schrittweise an, damit die Stimmen gleichmäßiger klingen."
+    },
     "permissionsRequired": "Berechtigungen erforderlich"
   },
   "video": {

--- a/src/frontend/src/locales/en/settings.json
+++ b/src/frontend/src/locales/en/settings.json
@@ -35,6 +35,11 @@
       "ongoingTest": "Testing sound…",
       "safariWarning": "Speaker selection is not available yet on Safari due to browser limitations."
     },
+    "participantAudioLeveling": {
+      "heading": "Participant audio leveling",
+      "label": "Automatically balance participant audio levels",
+      "description": "Adjusts remote participant volume gradually during the call so voices sound more consistent."
+    },
     "permissionsRequired": "Permissions required"
   },
   "video": {

--- a/src/frontend/src/locales/en/settings.json
+++ b/src/frontend/src/locales/en/settings.json
@@ -39,6 +39,11 @@
       "ongoingTest": "Testing sound…",
       "safariWarning": "Speaker selection is not available yet on Safari due to browser limitations."
     },
+    "participantAudioLeveling": {
+      "heading": "Participant audio leveling",
+      "label": "Automatically balance participant audio levels",
+      "description": "Adjusts remote participant volume gradually during the call so voices sound more consistent."
+    },
     "permissionsRequired": "Permissions required"
   },
   "video": {

--- a/src/frontend/src/locales/en/settings.json
+++ b/src/frontend/src/locales/en/settings.json
@@ -41,8 +41,8 @@
     },
     "participantAudioLeveling": {
       "heading": "Participant audio leveling",
-      "label": "Automatically balance participant audio levels",
-      "description": "Adjusts remote participant volume gradually during the call so voices sound more consistent."
+      "label": "Automatically reduce loud participant audio",
+      "description": "Gradually lowers loud participants during the call for a more consistent listening level."
     },
     "permissionsRequired": "Permissions required"
   },

--- a/src/frontend/src/locales/fr/settings.json
+++ b/src/frontend/src/locales/fr/settings.json
@@ -35,6 +35,11 @@
       "ongoingTest": "Test du son…",
       "safariWarning": "La sélection du haut-parleur n'est pas encore disponible sur Safari en raison de limitations du navigateur."
     },
+    "participantAudioLeveling": {
+      "heading": "Égalisation audio des participants",
+      "label": "Équilibrer automatiquement les niveaux audio des participants",
+      "description": "Ajuste progressivement le volume des participants distants pendant l'appel pour que les voix soient plus homogènes."
+    },
     "permissionsRequired": "Autorisations nécessaires"
   },
   "video": {

--- a/src/frontend/src/locales/fr/settings.json
+++ b/src/frontend/src/locales/fr/settings.json
@@ -39,6 +39,11 @@
       "ongoingTest": "Test du son…",
       "safariWarning": "La sélection du haut-parleur n'est pas encore disponible sur Safari en raison de limitations du navigateur."
     },
+    "participantAudioLeveling": {
+      "heading": "Égalisation audio des participants",
+      "label": "Équilibrer automatiquement les niveaux audio des participants",
+      "description": "Ajuste progressivement le volume des participants distants pendant l'appel pour que les voix soient plus homogènes."
+    },
     "permissionsRequired": "Autorisations nécessaires"
   },
   "video": {

--- a/src/frontend/src/locales/nl/settings.json
+++ b/src/frontend/src/locales/nl/settings.json
@@ -35,6 +35,11 @@
       "ongoingTest": "Testgeluid ...",
       "safariWarning": "Luidsprekerselectie is nog niet beschikbaar op Safari vanwege browserbeperkingen."
     },
+    "participantAudioLeveling": {
+      "heading": "Audionivellering deelnemers",
+      "label": "Audioniveaus van deelnemers automatisch balanceren",
+      "description": "Past het volume van externe deelnemers geleidelijk aan tijdens het gesprek zodat stemmen consistenter klinken."
+    },
     "permissionsRequired": "Machtigingen vereist"
   },
   "video": {

--- a/src/frontend/src/locales/nl/settings.json
+++ b/src/frontend/src/locales/nl/settings.json
@@ -39,6 +39,11 @@
       "ongoingTest": "Testgeluid ...",
       "safariWarning": "Luidsprekerselectie is nog niet beschikbaar op Safari vanwege browserbeperkingen."
     },
+    "participantAudioLeveling": {
+      "heading": "Audionivellering deelnemers",
+      "label": "Audioniveaus van deelnemers automatisch balanceren",
+      "description": "Past het volume van externe deelnemers geleidelijk aan tijdens het gesprek zodat stemmen consistenter klinken."
+    },
     "permissionsRequired": "Machtigingen vereist"
   },
   "video": {

--- a/src/frontend/src/stores/userPreferences.ts
+++ b/src/frontend/src/stores/userPreferences.ts
@@ -4,10 +4,12 @@ import { STORAGE_KEYS } from '@/utils/storageKeys'
 
 type State = {
   is_idle_disconnect_modal_enabled: boolean
+  is_participant_audio_leveling_enabled: boolean
 }
 
 const DEFAULT_STATE = {
   is_idle_disconnect_modal_enabled: true,
+  is_participant_audio_leveling_enabled: false,
 }
 
 function getUserPreferencesState(): State {

--- a/src/frontend/src/stores/userPreferences.ts
+++ b/src/frontend/src/stores/userPreferences.ts
@@ -5,11 +5,13 @@ import { reportError } from '@/features/analytics/telemetry'
 type State = {
   is_idle_disconnect_modal_enabled: boolean
   is_auto_mute_large_room_enabled: boolean
+  is_participant_audio_leveling_enabled: boolean
 }
 
 const DEFAULT_STATE = {
   is_idle_disconnect_modal_enabled: true,
   is_auto_mute_large_room_enabled: true,
+  is_participant_audio_leveling_enabled: false,
 }
 
 function getUserPreferencesState(): State {


### PR DESCRIPTION
## Purpose

Adds an optional participant audio leveling setting for calls, addressing #1345.

## Proposal

Automatically equalize participant audio levels

## Changes

- Add a persisted audio setting for participant audio leveling.
- Add an Audio settings switch with localized label and description.
- Add a LiveKit hook that gradually attenuates loud remote microphone tracks.
- Reset touched remote audio tracks to volume 1 when disabled or unmounted.

## Safety

This MVP is attenuation-only. `MAX_GAIN` is capped at `1`, so the hook never sets `HTMLMediaElement.volume` above the safe browser limit.
