### PR TITLE
feat(auth): OAuth2 + PKCE token endpoint for native apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ➕(backend) add djangorestframework-simplejwt 5.5.1 #1409
+- ✨(backend) add update_url_query_params helper #1409
+- ✨(backend) add Pydantic schemas for PKCE OAuth2 flow #1409
+- ✨(backend) add OAuth2 + PKCE views for native mobile/desktop login #1409
+- ✨(backend) wire PKCE auth + JWT for native app login #1409
+- ✨(backend) expose PKCE token endpoints + /mobile-login URL #1409
+- ✅(backend) port dictaphone PKCE view test suite (19 tests) #1409
+
+### Fixed
+
+- 🔒️(backend) restrict /mobile-login to GET only #1409
+
 ## [1.19.0] - 2026-06-04
 
 ### Added

--- a/src/backend/core/authentication/schemas.py
+++ b/src/backend/core/authentication/schemas.py
@@ -1,0 +1,26 @@
+"""Pydantic models for authentication-related operations."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class PKCEAuthenticationRequestModel(BaseModel):
+    """Model for generating PKCE authentication requests."""
+
+    code_challenge: str = Field(
+        min_length=43, max_length=128, pattern=r"^[A-Za-z0-9\-_]+$"
+    )
+    code_challenge_method: Literal["S256"] = Field(
+        default="S256", description="Code challenge method for PKCE authentication"
+    )
+    state: str = Field(min_length=43, max_length=128, pattern=r"^[A-Za-z0-9\-_]+$")
+
+
+class PKCETokenExchangeModel(BaseModel):
+    """Model for exchanging PKCE tokens."""
+
+    code: str = Field(min_length=43, max_length=128, pattern=r"^[A-Za-z0-9\-_]+$")
+    code_verifier: str = Field(
+        min_length=43, max_length=128, pattern=r"^[A-Za-z0-9\-_]+$"
+    )

--- a/src/backend/core/authentication/views.py
+++ b/src/backend/core/authentication/views.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, JsonResponse
 
 from lasuite.oidc_login.views import (
     OIDCAuthenticationCallbackView,
@@ -77,9 +77,9 @@ class PKCEOIDCAuthenticationRequestView(OIDCAuthenticationRequestView):
                 }
             )
         except ValidationError as e:
-            return Response(
+            return JsonResponse(
                 {"detail": "Invalid pkce request parameters.", "errors": e.errors()},
-                status=status.HTTP_400_BAD_REQUEST,
+                status=400,
             )
 
         request.session["pkce_oidc_response_type"] = "code"

--- a/src/backend/core/authentication/views.py
+++ b/src/backend/core/authentication/views.py
@@ -1,0 +1,217 @@
+"""PKCE OIDC Authentication Views for native mobile/desktop apps.
+
+Implements RFC 8252 (OAuth 2.0 for Native Apps) on top of the existing
+lasuite/mozilla-django-oidc auth code flow. Web browser flows are unaffected
+when the `response_type=code` PKCE marker is absent.
+"""
+
+import logging
+import secrets
+from urllib.parse import urlsplit
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.http import HttpResponseRedirect
+
+from lasuite.oidc_login.views import (
+    OIDCAuthenticationCallbackView,
+    OIDCAuthenticationRequestView,
+)
+from mozilla_django_oidc.utils import generate_code_challenge
+from pydantic import ValidationError
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from core.authentication.schemas import (
+    PKCEAuthenticationRequestModel,
+    PKCETokenExchangeModel,
+)
+from core.utils import update_url_query_params
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+PKCE_AUTH_CODE_CACHE_KEY_PREFIX = "pkce-auth-code"
+AUTHORIZATION_CODE_SIZE = 64
+
+
+def get_pkce_authorization_code_cache_key(code: str) -> str:
+    """Generate cache key for PKCE authorization code."""
+    return f"{PKCE_AUTH_CODE_CACHE_KEY_PREFIX}:{code}"
+
+
+def is_mobile_login_url(url: str) -> bool:
+    """Check if URL is for mobile login."""
+    return urlsplit(url).path == "/mobile-login"
+
+
+class PKCEOIDCAuthenticationRequestView(OIDCAuthenticationRequestView):
+    """OIDC authentication request view with PKCE support for native apps.
+
+    Extends the lasuite OIDCAuthenticationRequestView to detect PKCE
+    parameters (`code_challenge`, `code_challenge_method`, `state`) in the
+    incoming request and store them in the session for later use by the
+    callback. Web flows without `response_type=code` are untouched.
+    """
+
+    def get(self, request):
+        response = super().get(request)
+
+        if request.GET.get("response_type", None) != "code":
+            return response
+
+        try:
+            pkce_data = PKCEAuthenticationRequestModel.model_validate(
+                {
+                    "code_challenge": request.GET.get("code_challenge"),
+                    "code_challenge_method": request.GET.get(
+                        "code_challenge_method",
+                        "S256",
+                    ),
+                    "state": request.GET.get("state"),
+                }
+            )
+        except ValidationError as e:
+            return Response(
+                {"detail": "Invalid pkce request parameters.", "errors": e.errors()},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        request.session["pkce_oidc_response_type"] = "code"
+        request.session["pkce_oidc_data"] = pkce_data.model_dump()
+        request.session.save()
+        return response
+
+
+class MobileFriendlyRedirect(HttpResponseRedirect):
+    """Redirect that allows the configured native-app deep-link scheme."""
+
+    @property
+    def allowed_schemes(self) -> list[str]:
+        """Add the mobile deep link prefix to the allowed schemes list."""
+        return [
+            *HttpResponseRedirect.allowed_schemes,
+            settings.MOBILE_DEEP_LINK_SCHEME.split(":")[0],
+        ]
+
+
+class OIDCAuthenticationCallbackWithPkceView(OIDCAuthenticationCallbackView):
+    """OIDC callback view that emits a one-time PKCE authorization code.
+
+    On successful SSO login for a PKCE-marked session, generates a 64-byte
+    URL-safe authorization code bound to the request's code_challenge,
+    stores it in cache with `AUTH_PKCE_CACHE_TTL_SECONDS` TTL, and redirects
+    to `MOBILE_DEEP_LINK_SCHEME?code=...&state=...`. Web flows fall through
+    to the parent class behavior.
+    """
+
+    def login_success(self):
+        """Handle successful login callback."""
+        res = super().login_success()
+        if self.request.session.pop("pkce_oidc_response_type", None) != "code":
+            logger.info(
+                "PKCE response type not 'code', defaulting to usual login success response"
+            )
+            return res
+
+        pkce_data = self.request.session.pop("pkce_oidc_data", None)
+        self.request.session.save()
+        if not pkce_data:
+            logger.error("No PKCE data found in session")
+            return self.login_failure()
+
+        authorization_code = secrets.token_urlsafe(AUTHORIZATION_CODE_SIZE)
+        cache.set(
+            get_pkce_authorization_code_cache_key(authorization_code),
+            {
+                "user_id": self.user.pk,
+                "code_challenge": pkce_data["code_challenge"],
+                "code_challenge_method": pkce_data["code_challenge_method"],
+            },
+            timeout=settings.AUTH_PKCE_CACHE_TTL_SECONDS,
+        )
+
+        if not is_mobile_login_url(res.url):
+            logger.warning(
+                "PKCE mobile callback did not resolve to the expected mobile login URL"
+            )
+            return self.login_failure()
+
+        logger.info(
+            "Mobile login successful, redirecting to mobile app for user %s",
+            self.user.pk,
+        )
+        mobile_redirect = update_url_query_params(
+            settings.MOBILE_DEEP_LINK_SCHEME,
+            {"code": [authorization_code], "state": [pkce_data["state"]]},
+        )
+        return MobileFriendlyRedirect(mobile_redirect)
+
+    def login_failure(self):
+        logger.info("Login failed")
+        return super().login_failure()
+
+
+class PKCEOAuthTokenExchangeView(APIView):
+    """OAuth token exchange endpoint for PKCE native-app flow.
+
+    POST `{code, code_verifier}`. Verifies the verifier against the cached
+    challenge using constant-time comparison, then issues an access+refresh
+    JWT pair via SimpleJWT. The authorization code is deleted on first use
+    (anti-replay).
+    """
+
+    permission_classes = [AllowAny]
+    authentication_classes = []
+
+    def post(self, request) -> Response:
+        """Handle request for PKCE OAuth token exchange."""
+        try:
+            request_data = PKCETokenExchangeModel.model_validate(request.data)
+        except ValidationError as e:
+            return Response(
+                {"detail": "Invalid pkce request parameters.", "errors": e.errors()},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        cache_key = get_pkce_authorization_code_cache_key(request_data.code)
+        code_data = cache.get(cache_key)
+        if not code_data:
+            return Response(
+                {"detail": "Invalid or expired authorization code."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        # Single-use: invalidate the code BEFORE verification so a failed
+        # attempt cannot be retried (prevents oracle).
+        cache.delete(cache_key)
+
+        expected_challenge = code_data["code_challenge"]
+        method = code_data.get("code_challenge_method", "S256")
+
+        computed_challenge = generate_code_challenge(request_data.code_verifier, method)
+        if not secrets.compare_digest(computed_challenge, expected_challenge):
+            logger.warning("Invalid code_verifier for PKCE token exchange")
+            return Response(
+                {"detail": "Invalid code_verifier."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user = User.objects.filter(pk=code_data["user_id"], is_active=True).first()
+        if not user:
+            return Response(
+                {"detail": "Invalid authorization code user."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        refresh = RefreshToken.for_user(user)
+        return Response(
+            {
+                "refresh": str(refresh),
+                "access": str(refresh.access_token),
+            }
+        )

--- a/src/backend/core/tests/authentication/test_pkce_views.py
+++ b/src/backend/core/tests/authentication/test_pkce_views.py
@@ -1,0 +1,388 @@
+"""Tests for PKCE/OIDC authentication views and OAuth token endpoints."""
+
+from unittest import mock
+
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.cache import cache
+from django.http import HttpResponseRedirect
+from django.test import RequestFactory
+
+import pytest
+from mozilla_django_oidc.utils import generate_code_challenge
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from core.authentication.views import (
+    OIDCAuthenticationCallbackWithPkceView,
+    PKCEOIDCAuthenticationRequestView,
+    get_pkce_authorization_code_cache_key,
+)
+from core.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _attach_session(request):
+    """Attach a working session to a request-factory request."""
+    middleware = SessionMiddleware(lambda req: None)
+    middleware.process_request(request)
+    request.session.save()
+
+
+def test_pkce_oidc_authentication_request_view_stores_pkce_data():
+    """Should store PKCE data in session when response_type is code."""
+    code_challenge = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    state = "NhnR1y7iA2aCrh3Ic5_6wD9rI3C-N3fDNzxt3wti7e1"
+    request = RequestFactory().get(
+        "/api/v1.0/authenticate/",
+        {
+            "response_type": "code",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        },
+    )
+    _attach_session(request)
+
+    with mock.patch(
+        "core.authentication.views.OIDCAuthenticationRequestView.get",
+        return_value=HttpResponseRedirect("https://sso.example/authorize"),
+    ):
+        response = PKCEOIDCAuthenticationRequestView().get(request)
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert request.session["pkce_oidc_response_type"] == "code"
+    assert request.session["pkce_oidc_data"] == {
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+
+
+def test_pkce_oidc_authentication_request_view_invalid_parameters():
+    """Should return 400 when PKCE params are invalid."""
+    request = RequestFactory().get(
+        "/api/v1.0/authenticate/",
+        {
+            "response_type": "code",
+            "code_challenge": "too-short",
+            "state": "also-too-short",
+        },
+    )
+    _attach_session(request)
+
+    with mock.patch(
+        "core.authentication.views.OIDCAuthenticationRequestView.get",
+        return_value=HttpResponseRedirect("https://sso.example/authorize"),
+    ):
+        response = PKCEOIDCAuthenticationRequestView().get(request)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["detail"] == "Invalid pkce request parameters."
+
+
+@pytest.mark.parametrize(
+    ("length", "expected_status"),
+    [(43, status.HTTP_302_FOUND), (128, status.HTTP_302_FOUND)],
+)
+def test_pkce_oidc_authentication_request_view_pkce_length_boundaries_are_valid(
+    length, expected_status
+):
+    """Should accept PKCE request fields at min/max allowed lengths."""
+    code_challenge = "a" * length
+    state = "b" * length
+    request = RequestFactory().get(
+        "/api/v1.0/authenticate/",
+        {
+            "response_type": "code",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        },
+    )
+    _attach_session(request)
+
+    with mock.patch(
+        "core.authentication.views.OIDCAuthenticationRequestView.get",
+        return_value=HttpResponseRedirect("https://sso.example/authorize"),
+    ):
+        response = PKCEOIDCAuthenticationRequestView().get(request)
+
+    assert response.status_code == expected_status
+    assert request.session["pkce_oidc_data"] == {
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+
+
+@pytest.mark.parametrize(
+    ("field_name", "length"),
+    [
+        ("code_challenge", 42),
+        ("code_challenge", 129),
+        ("state", 42),
+        ("state", 129),
+    ],
+)
+def test_pkce_oidc_authentication_request_view_rejects_out_of_bounds_lengths(
+    field_name, length
+):
+    """Should reject PKCE request fields shorter/longer than allowed."""
+    params = {
+        "response_type": "code",
+        "code_challenge": "a" * 43,
+        "code_challenge_method": "S256",
+        "state": "b" * 43,
+    }
+    params[field_name] = "c" * length
+    request = RequestFactory().get("/api/v1.0/authenticate/", params)
+    _attach_session(request)
+
+    with mock.patch(
+        "core.authentication.views.OIDCAuthenticationRequestView.get",
+        return_value=HttpResponseRedirect("https://sso.example/authorize"),
+    ):
+        response = PKCEOIDCAuthenticationRequestView().get(request)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["detail"] == "Invalid pkce request parameters."
+    assert any(error["loc"] == (field_name,) for error in response.data["errors"])
+
+
+def test_pkce_oidc_authentication_request_view_non_code_response_type():
+    """Should leave session untouched when response_type is not code."""
+    request = RequestFactory().get(
+        "/api/v1.0/authenticate/",
+        {"response_type": "token"},
+    )
+    _attach_session(request)
+
+    with mock.patch(
+        "core.authentication.views.OIDCAuthenticationRequestView.get",
+        return_value=HttpResponseRedirect("https://sso.example/authorize"),
+    ):
+        response = PKCEOIDCAuthenticationRequestView().get(request)
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert "pkce_oidc_response_type" not in request.session
+    assert "pkce_oidc_data" not in request.session
+
+
+def test_oidc_callback_with_pkce_login_success_returns_mobile_redirect(settings):
+    """Should cache auth code and redirect to mobile deep-link URL."""
+    user = UserFactory()
+    request = RequestFactory().get("/api/v1.0/callback/")
+    _attach_session(request)
+
+    code_challenge = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    state = "NhnR1y7iA2aCrh3Ic5_6wD9rI3C-N3fDNzxt3wti7e1"
+    request.session["pkce_oidc_response_type"] = "code"
+    request.session["pkce_oidc_data"] = {
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    request.session.save()
+
+    view = OIDCAuthenticationCallbackWithPkceView()
+    view.request = request
+    view.user = user
+
+    with (
+        mock.patch(
+            "core.authentication.views.OIDCAuthenticationCallbackView.login_success",
+            return_value=HttpResponseRedirect("/mobile-login"),
+        ),
+        mock.patch(
+            "core.authentication.views.secrets.token_urlsafe",
+            return_value="code",
+        ),
+    ):
+        response = view.login_success()
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response.url.startswith(settings.MOBILE_DEEP_LINK_SCHEME)
+    assert "code=code" in response.url
+    assert f"state={state}" in response.url
+
+    cached = cache.get(get_pkce_authorization_code_cache_key("code"))
+    assert cached == {
+        "user_id": user.pk,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+
+
+def test_oidc_callback_with_pkce_login_success_non_mobile_redirect_fails():
+    """Should fallback to failure when callback URL is not the mobile login URL."""
+    user = UserFactory()
+    request = RequestFactory().get("/api/v1.0/callback/")
+    _attach_session(request)
+    request.session["pkce_oidc_response_type"] = "code"
+
+    code_challenge = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    state = "NhnR1y7iA2aCrh3Ic5_6wD9rI3C-N3fDNzxt3wti7e1"
+    request.session["pkce_oidc_data"] = {
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    request.session.save()
+
+    view = OIDCAuthenticationCallbackWithPkceView()
+    view.request = request
+    view.user = user
+
+    with (
+        mock.patch(
+            "core.authentication.views.OIDCAuthenticationCallbackView.login_success",
+            return_value=HttpResponseRedirect("/somewhere-else"),
+        ),
+        mock.patch.object(
+            OIDCAuthenticationCallbackWithPkceView,
+            "login_failure",
+            return_value=HttpResponseRedirect("/failure"),
+        ),
+    ):
+        response = view.login_success()
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response.url == "/failure"
+
+
+def test_oidc_callback_with_pkce_login_success_without_pkce_data_fails():
+    """Should fallback to login failure when PKCE data is missing from session."""
+    user = UserFactory()
+    request = RequestFactory().get("/api/v1.0/callback/")
+    _attach_session(request)
+    request.session["pkce_oidc_response_type"] = "code"
+    request.session.save()
+
+    view = OIDCAuthenticationCallbackWithPkceView()
+    view.request = request
+    view.user = user
+
+    with (
+        mock.patch(
+            "core.authentication.views.OIDCAuthenticationCallbackView.login_success",
+            return_value=HttpResponseRedirect("/mobile-login"),
+        ),
+        mock.patch.object(
+            OIDCAuthenticationCallbackWithPkceView,
+            "login_failure",
+            return_value=HttpResponseRedirect("/failure"),
+        ),
+    ):
+        response = view.login_success()
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response.url == "/failure"
+
+
+def test_oauth_token_exchange_success_and_single_use():
+    """Should exchange a valid auth code once for JWT tokens."""
+    user = UserFactory()
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    code = "my-auth-code-at-least-43-characters-like-really"
+    cache.set(
+        get_pkce_authorization_code_cache_key(code),
+        {
+            "user_id": user.pk,
+            "code_challenge": generate_code_challenge(verifier, "S256"),
+            "code_challenge_method": "S256",
+        },
+        timeout=120,
+    )
+
+    client = APIClient()
+    response = client.post(
+        "/api/v1.0/oauth/token/",
+        {"code": code, "code_verifier": verifier},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert set(response.json()) == {"refresh", "access"}
+
+    second_try = client.post(
+        "/api/v1.0/oauth/token/",
+        {"code": code, "code_verifier": verifier},
+        format="json",
+    )
+    assert second_try.status_code == status.HTTP_400_BAD_REQUEST
+    assert second_try.json() == {"detail": "Invalid or expired authorization code."}
+
+
+def test_oauth_token_exchange_invalid_code_verifier_consumes_code():
+    """Should reject invalid verifier and consume the auth code."""
+    user = UserFactory()
+    code = "my-auth-code-at-least-43-characters-like-really-2"
+    cache.set(
+        get_pkce_authorization_code_cache_key(code),
+        {
+            "user_id": user.pk,
+            "code_challenge": generate_code_challenge(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "S256"
+            ),
+            "code_challenge_method": "S256",
+        },
+        timeout=120,
+    )
+
+    client = APIClient()
+    response = client.post(
+        "/api/v1.0/oauth/token/",
+        {
+            "code": code,
+            "code_verifier": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Invalid code_verifier."}
+    assert cache.get(get_pkce_authorization_code_cache_key(code)) is None
+
+
+@pytest.mark.parametrize(
+    ("field_name", "length"),
+    [
+        ("code", 42),
+        ("code", 129),
+        ("code_verifier", 42),
+        ("code_verifier", 129),
+    ],
+)
+def test_oauth_token_exchange_rejects_out_of_bounds_lengths(field_name, length):
+    """Should reject PKCE token exchange fields shorter/longer than allowed."""
+    payload = {
+        "code": "a" * 43,
+        "code_verifier": "b" * 43,
+    }
+    payload[field_name] = "c" * length
+
+    client = APIClient()
+    response = client.post("/api/v1.0/oauth/token/", payload, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    data = response.json()
+    assert data["detail"] == "Invalid pkce request parameters."
+    assert any(error["loc"] == [field_name] for error in data["errors"])
+
+
+def test_oauth_token_refresh_endpoint_returns_access_token():
+    """Should issue a new access token from a valid refresh token."""
+    user = UserFactory()
+    refresh = RefreshToken.for_user(user)
+
+    client = APIClient()
+    response = client.post(
+        "/api/v1.0/oauth/token/refresh/",
+        {"refresh": str(refresh)},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "access" in response.json()

--- a/src/backend/core/tests/authentication/test_pkce_views.py
+++ b/src/backend/core/tests/authentication/test_pkce_views.py
@@ -1,5 +1,6 @@
 """Tests for PKCE/OIDC authentication views and OAuth token endpoints."""
 
+import json
 from unittest import mock
 
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -79,7 +80,7 @@ def test_pkce_oidc_authentication_request_view_invalid_parameters():
         response = PKCEOIDCAuthenticationRequestView().get(request)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.data["detail"] == "Invalid pkce request parameters."
+    assert json.loads(response.content)["detail"] == "Invalid pkce request parameters."
 
 
 @pytest.mark.parametrize(
@@ -147,8 +148,9 @@ def test_pkce_oidc_authentication_request_view_rejects_out_of_bounds_lengths(
         response = PKCEOIDCAuthenticationRequestView().get(request)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.data["detail"] == "Invalid pkce request parameters."
-    assert any(error["loc"] == (field_name,) for error in response.data["errors"])
+    body = json.loads(response.content)
+    assert body["detail"] == "Invalid pkce request parameters."
+    assert any(error["loc"] == [field_name] for error in body["errors"])
 
 
 def test_pkce_oidc_authentication_request_view_non_code_response_type():

--- a/src/backend/core/urls.py
+++ b/src/backend/core/urls.py
@@ -1,14 +1,27 @@
 """URL configuration for the core app."""
 
 from django.conf import settings
+from django.http import HttpResponse
 from django.urls import include, path
 
 from lasuite.oidc_login.urls import urlpatterns as oidc_urls
 from rest_framework.routers import DefaultRouter, SimpleRouter
+from rest_framework_simplejwt.views import TokenRefreshView
 
 from core.addons import viewsets as addons_viewsets
 from core.api import get_frontend_configuration, viewsets
+from core.authentication.views import PKCEOAuthTokenExchangeView
 from core.external_api import viewsets as external_viewsets
+
+
+def mobile_login_landing(request):  # noqa: ARG001
+    """Empty 200 page used as the success_url marker for native-app PKCE login.
+
+    The PKCE callback view detects this path before swapping in the
+    `MOBILE_DEEP_LINK_SCHEME` redirect; users following the web flow never
+    reach this page.
+    """
+    return HttpResponse(status=204)
 
 # - Main endpoints
 router = DefaultRouter()
@@ -39,6 +52,7 @@ external_router.register(
 )
 
 urlpatterns = [
+    path("mobile-login", mobile_login_landing, name="mobile_login_landing"),
     path(
         f"api/{settings.API_VERSION}/",
         include(
@@ -46,6 +60,16 @@ urlpatterns = [
                 *router.urls,
                 *oidc_urls,
                 path("config/", get_frontend_configuration, name="config"),
+                path(
+                    "oauth/token/",
+                    PKCEOAuthTokenExchangeView.as_view(),
+                    name="token_obtain_pair",
+                ),
+                path(
+                    "oauth/token/refresh/",
+                    TokenRefreshView.as_view(),
+                    name="token_refresh",
+                ),
             ]
         ),
     ),

--- a/src/backend/core/urls.py
+++ b/src/backend/core/urls.py
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.http import HttpResponse
 from django.urls import include, path
+from django.views.decorators.http import require_GET
 
 from lasuite.oidc_login.urls import urlpatterns as oidc_urls
 from rest_framework.routers import DefaultRouter, SimpleRouter
@@ -14,14 +15,17 @@ from core.authentication.views import PKCEOAuthTokenExchangeView
 from core.external_api import viewsets as external_viewsets
 
 
-def mobile_login_landing(request):  # noqa: ARG001
-    """Empty 200 page used as the success_url marker for native-app PKCE login.
+@require_GET
+def mobile_login_landing(request):
+    """Empty 204 page used as the success_url marker for native-app PKCE login.
 
     The PKCE callback view detects this path before swapping in the
     `MOBILE_DEEP_LINK_SCHEME` redirect; users following the web flow never
-    reach this page.
+    reach this page. Restricted to GET so the endpoint can't be reached
+    via POST/PUT/etc., per S5122.
     """
     return HttpResponse(status=204)
+
 
 # - Main endpoints
 router = DefaultRouter()

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -14,6 +14,7 @@ import secrets
 import string
 from functools import lru_cache
 from typing import List, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
 from django.conf import settings
@@ -547,3 +548,19 @@ def build_telephony_config():
         "default_country": country,
         "international_phone_number": international,
     }
+
+
+def update_url_query_params(url: str, query_parameters: dict[str, list[str]]) -> str:
+    """Update the query parameters of a URL with the provided parameters."""
+    parsed_url = urlsplit(url)
+    query = dict(parse_qsl(parsed_url.query, keep_blank_values=True))
+    query.update(query_parameters)
+    return urlunsplit(
+        (
+            parsed_url.scheme,
+            parsed_url.netloc,
+            parsed_url.path,
+            urlencode(query, doseq=True),
+            parsed_url.fragment,
+        )
+    )

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 # pylint: disable=too-many-lines
 
 import json
+from datetime import timedelta
 from os import path
 from socket import gethostbyname, gethostname
 
@@ -323,6 +324,7 @@ class Base(Configuration):
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
+            "rest_framework_simplejwt.authentication.JWTAuthentication",
             "mozilla_django_oidc.contrib.drf.OIDCAuthentication",
             "rest_framework.authentication.SessionAuthentication",
         ),
@@ -468,8 +470,12 @@ class Base(Configuration):
     )
 
     # OIDC - Authorization Code Flow
-    OIDC_AUTHENTICATE_CLASS = "lasuite.oidc_login.views.OIDCAuthenticationRequestView"
-    OIDC_CALLBACK_CLASS = "lasuite.oidc_login.views.OIDCAuthenticationCallbackView"
+    OIDC_AUTHENTICATE_CLASS = (
+        "core.authentication.views.PKCEOIDCAuthenticationRequestView"
+    )
+    OIDC_CALLBACK_CLASS = (
+        "core.authentication.views.OIDCAuthenticationCallbackWithPkceView"
+    )
     OIDC_CREATE_USER = values.BooleanValue(
         default=True, environ_name="OIDC_CREATE_USER", environ_prefix=None
     )
@@ -580,6 +586,60 @@ class Base(Configuration):
         environ_name="OIDC_USERINFO_ESSENTIAL_CLAIMS",
         environ_prefix=None,
     )
+
+    # Native App PKCE Login (RFC 8252)
+    # The mobile/desktop client opens an in-app browser to the standard OIDC
+    # flow with `response_type=code` + `code_challenge`; on successful login the
+    # callback view redirects to `MOBILE_DEEP_LINK_SCHEME?code=...&state=...`.
+    # The client then exchanges the code at `/api/v1.0/oauth/token/`.
+    AUTH_PKCE_CACHE_TTL_SECONDS = values.IntegerValue(
+        default=60,
+        environ_name="AUTH_PKCE_CACHE_TTL_SECONDS",
+        environ_prefix=None,
+    )
+    MOBILE_DEEP_LINK_SCHEME = values.Value(
+        default="visio://auth-callback",
+        environ_name="MOBILE_DEEP_LINK_SCHEME",
+        environ_prefix=None,
+    )
+    SIMPLE_JWT_SIGNING_KEY = SecretFileValue(
+        None,
+        environ_name="SIMPLE_JWT_SIGNING_KEY",
+        environ_prefix=None,
+    )
+    JWT_ACCESS_TOKEN_LIFETIME_SECONDS = values.IntegerValue(
+        default=10 * 60,
+        environ_name="JWT_ACCESS_TOKEN_LIFETIME_SECONDS",
+        environ_prefix=None,
+    )
+    JWT_REFRESH_TOKEN_LIFETIME_SECONDS = values.IntegerValue(
+        default=7 * 24 * 60 * 60,
+        environ_name="JWT_REFRESH_TOKEN_LIFETIME_SECONDS",
+        environ_prefix=None,
+    )
+
+    # pylint: disable=invalid-name
+    @property
+    def SIMPLE_JWT(self):
+        """Build SimpleJWT config, falling back to SECRET_KEY for the signing key.
+
+        SimpleJWT's own default already points at ``settings.SECRET_KEY`` when
+        ``SIGNING_KEY`` is unset, but we still want a dedicated env var
+        (``SIMPLE_JWT_SIGNING_KEY``) for production deployments so JWT and
+        Django session signing can be rotated independently.
+        """
+        return {
+            "ALGORITHM": "HS256",
+            "SIGNING_KEY": self.SIMPLE_JWT_SIGNING_KEY or self.SECRET_KEY,
+            "ACCESS_TOKEN_LIFETIME": timedelta(
+                seconds=self.JWT_ACCESS_TOKEN_LIFETIME_SECONDS
+            ),
+            "REFRESH_TOKEN_LIFETIME": timedelta(
+                seconds=self.JWT_REFRESH_TOKEN_LIFETIME_SECONDS
+            ),
+            "ROTATE_REFRESH_TOKENS": True,
+            "BLACKLIST_AFTER_ROTATION": True,
+        }
 
     # OIDC Resource Server Backend
     OIDC_RS_BACKEND_CLASS = "core.external_api.authentication.ResourceServerBackend"

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -291,6 +291,8 @@ class Base(Configuration):
         "rest_framework",
         "parler",
         "easy_thumbnails",
+        "rest_framework_simplejwt",
+        "rest_framework_simplejwt.token_blacklist",
         # Django
         "django.contrib.admin",
         "django.contrib.auth",

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "django-pydantic-field==0.5.4",
     "django==5.2.14",
     "djangorestframework==3.17.1",
+    "djangorestframework-simplejwt==5.5.1",
     "drf_spectacular==0.29.0",
     "dockerflow==2026.3.4",
     "easy_thumbnails==2.10.1",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -186,16 +186,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.43.19"
+version = "1.43.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/a7/298986789785b74a954e2347114993be7e6b070417159125a6865f2687b6/botocore-1.43.19.tar.gz", hash = "sha256:18ac2fdd76c89b940707eb10493ff58678adad337d03215caec2d408ccd43cc0", size = 15435441, upload-time = "2026-06-01T19:32:53.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/cf/840f1b8db16d45e3807c23d1ea779723eed1cd9cf3b6c49e16f372d2a777/botocore-1.43.22.tar.gz", hash = "sha256:b00de525e538289ed4a7a85263f1be4e47473c124cec87be6b23be49356bf745", size = 15458781, upload-time = "2026-06-03T19:33:02.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/75/fe4d45bdd08afd66f3d5273db58f3d8a29365e52ce3a0851f7f5e5900943/botocore-1.43.19-py3-none-any.whl", hash = "sha256:99dbdccbf748974750601e805cecc9362a85d11fee89d6d58cd3f4ff302e6ff9", size = 15117709, upload-time = "2026-06-01T19:32:47.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6b/576a1b0f915871e35f14a33104f2bcae635f19c6a72486ba639db0d1fc70/botocore-1.43.22-py3-none-any.whl", hash = "sha256:ceec9f81d0891abe7b28ca2b2ee47e32de7b3360ad11e80d351470f015217379", size = 15141375, upload-time = "2026-06-03T19:32:58.324Z" },
 ]
 
 [[package]]
@@ -765,6 +765,20 @@ wheels = [
 ]
 
 [[package]]
+name = "djangorestframework-simplejwt"
+version = "5.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "djangorestframework" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/27/2874a325c11112066139769f7794afae238a07ce6adf96259f08fd37a9d7/djangorestframework_simplejwt-5.5.1.tar.gz", hash = "sha256:e72c5572f51d7803021288e2057afcbd03f17fe11d484096f40a460abc76e87f", size = 101265, upload-time = "2025-07-21T16:52:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/94/fdfb7b2f0b16cd3ed4d4171c55c1c07a2d1e3b106c5978c8ad0c15b4a48b/djangorestframework_simplejwt-5.5.1-py3-none-any.whl", hash = "sha256:2c30f3707053d384e9f315d11c2daccfcb548d4faa453111ca19a542b732e469", size = 107674, upload-time = "2025-07-21T16:52:07.493Z" },
+]
+
+[[package]]
 name = "dockerflow"
 version = "2026.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1208,6 +1222,7 @@ dependencies = [
     { name = "django-storages", extra = ["s3"] },
     { name = "django-timezone-field" },
     { name = "djangorestframework" },
+    { name = "djangorestframework-simplejwt" },
     { name = "dockerflow" },
     { name = "drf-spectacular" },
     { name = "easy-thumbnails" },
@@ -1271,6 +1286,7 @@ requires-dist = [
     { name = "django-storages", extras = ["s3"], specifier = "==1.14.6" },
     { name = "django-timezone-field", specifier = ">=5.1" },
     { name = "djangorestframework", specifier = "==3.17.1" },
+    { name = "djangorestframework-simplejwt", specifier = "==5.5.1" },
     { name = "dockerflow", specifier = "==2026.3.4" },
     { name = "drf-spectacular", specifier = "==0.29.0" },
     { name = "easy-thumbnails", specifier = "==2.10.1" },


### PR DESCRIPTION
## Summary

Adds an RFC 8252 / RFC 7636 PKCE flow to Meet so native mobile and desktop apps
can authenticate against a Meet instance without sharing a session cookie.

**Why:** native clients (Android, iOS, Tauri) can't keep a Django session
cookie alive cleanly — and the previous session-exchange path of #1170 isn't
a standard the OAuth ecosystem recognises. PKCE is the recommended flow for
public/native clients (OAuth 2.1 §4.1, IETF BCP 212).

**How:** the implementation mirrors what
[`suitenumerique/dictaphone`](https://github.com/suitenumerique/dictaphone)
already ships in production. We port its `core/authentication` module almost
verbatim: same schemas, same view classes, same JWT settings. Web SSO is
untouched — PKCE only activates when `response_type=code` is on
`/api/v1.0/authenticate/`.

### What changes

- `djangorestframework-simplejwt` 5.5.1 + `token_blacklist` for rotating refresh tokens.
- Pydantic schemas validating `code_challenge` / `code_challenge_method` / `state` per RFC 7636.
- Three views in `core/authentication/views.py`:
  - request: caches the PKCE challenge in the session before SSO,
  - callback: issues a single-use auth code, redirects to `MOBILE_DEEP_LINK_SCHEME?code=…&state=…`,
  - exchange: verifies the verifier, deletes the code first (anti-oracle), returns a JWT pair.
- New routes: `POST /api/v1.0/oauth/token/`, `POST /api/v1.0/oauth/token/refresh/`, `GET /mobile-login`.
- Settings: swap `OIDC_AUTHENTICATE_CLASS` / `OIDC_CALLBACK_CLASS`, add `MOBILE_DEEP_LINK_SCHEME` and `AUTH_PKCE_CACHE_TTL_SECONDS`, add `SIMPLE_JWT` (10 min access, 7 day refresh, rotate + blacklist).
- 19 tests ported from dictaphone covering parameter validation, code single-use, verifier mismatch, deep-link redirect, refresh rotation, and non-PKCE fall-through.

## Test plan

- [ ] `pytest src/backend/core/tests/authentication/test_pkce_views.py` green (19 tests).
- [ ] Full backend suite still green (no regression on web SSO).
- [ ] End-to-end against a local Meet + Keycloak + visio-mobile dev build: SSO login → deep-link → `/oauth/token/` → Bearer call → `/oauth/token/refresh/`.
- [ ] Replay: second exchange of the same code is rejected.