### PR TITLE
🐛(frontend) stop overwriting saved language on page load

### DIFF
--- a/src/frontend/src/features/auth/api/useSyncUserPreferencesWithBackend.tsx
+++ b/src/frontend/src/features/auth/api/useSyncUserPreferencesWithBackend.tsx
@@ -1,47 +1,66 @@
 import { useMutation } from '@tanstack/react-query'
 import { keys } from '@/api/queryKeys'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { queryClient } from '@/api/queryClient'
 import { updateUserPreferences } from './updateUserPreferences'
-import { convertToBackendLanguage } from '@/utils/languages'
+import {
+  convertToBackendLanguage,
+  convertToFrontendLanguage,
+  type BackendLanguage,
+} from '@/utils/languages'
 import { useUser } from './useUser'
 
 /**
- * Hook that synchronizes user browser preferences (language, timezone) with backend user settings.
- * Automatically updates backend when browser settings change for logged-in users.
+ * Synchronizes user preferences with the backend. The saved language is the
+ * source of truth: it is adopted into the UI on load and only pushed back when
+ * the user changes it in the settings panel. Timezone follows the browser.
  */
 export const useSyncUserPreferencesWithBackend = () => {
   const { i18n } = useTranslation()
   const { user, isLoggedIn } = useUser()
 
-  const { mutateAsync } = useMutation({
+  const lastServerLanguage = useRef<BackendLanguage | null>(null)
+
+  const { mutate } = useMutation({
     mutationFn: updateUserPreferences,
     onSuccess: (updatedUser) => {
       queryClient.setQueryData([keys.user], updatedUser)
+      lastServerLanguage.current = updatedUser.language
+    },
+    onError: (error) => {
+      console.error(error)
     },
   })
 
   useEffect(() => {
-    if (!user || !isLoggedIn) return
+    if (!user || !isLoggedIn || !user.language) return
 
-    const syncBrowserPreferencesToBackend = async () => {
-      const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-      const currentLanguage = convertToBackendLanguage(i18n.language)
-      if (
-        currentLanguage !== user.language ||
-        currentTimezone !== user.timezone
-      ) {
-        await mutateAsync({
-          user: {
-            id: user.id,
-            timezone: currentTimezone,
-            language: currentLanguage,
-          },
-        })
+    const serverLang = user.language
+    const frontendServerLang = convertToFrontendLanguage(serverLang)
+
+    if (lastServerLanguage.current !== serverLang) {
+      lastServerLanguage.current = serverLang
+      if (frontendServerLang && frontendServerLang !== i18n.language) {
+        i18n.changeLanguage(frontendServerLang)
+        return
       }
     }
 
-    syncBrowserPreferencesToBackend()
-  }, [i18n.language, isLoggedIn, user, mutateAsync])
+    const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const uiLang = convertToBackendLanguage(i18n.language)
+    const languageChanged =
+      !!frontendServerLang && !!uiLang && uiLang !== serverLang
+    const timezoneChanged = currentTimezone !== user.timezone
+
+    if (!languageChanged && !timezoneChanged) return
+
+    mutate({
+      user: {
+        id: user.id,
+        timezone: currentTimezone,
+        language: languageChanged ? uiLang : serverLang,
+      },
+    })
+  }, [i18n, i18n.language, isLoggedIn, user, mutate])
 }

--- a/src/frontend/src/features/auth/api/useSyncUserPreferencesWithBackend.tsx
+++ b/src/frontend/src/features/auth/api/useSyncUserPreferencesWithBackend.tsx
@@ -1,54 +1,78 @@
 import { useMutation } from '@tanstack/react-query'
 import { keys } from '@/api/queryKeys'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { queryClient } from '@/api/queryClient'
 import { updateUserPreferences } from './updateUserPreferences'
-import { convertToBackendLanguage } from '@/utils/languages'
+import {
+  convertToBackendLanguage,
+  convertToFrontendLanguage,
+  type BackendLanguage,
+} from '@/utils/languages'
 import { useUser } from './useUser'
 import { ApiError } from '@/api/ApiError.ts'
 import { reportError } from '@/features/analytics/telemetry'
 
 /**
- * Hook that synchronizes user browser preferences (language, timezone) with backend user settings.
- * Automatically updates backend when browser settings change for logged-in users.
+ * The saved language is the source of truth: adopted into the UI on load, and
+ * pushed back only once the user changes it. Timezone follows the browser.
  */
 export const useSyncUserPreferencesWithBackend = () => {
   const { i18n } = useTranslation()
   const { user, isLoggedIn } = useUser()
 
-  const { mutateAsync } = useMutation({
+  const lastServerLanguage = useRef<BackendLanguage | null>(null)
+
+  const { mutate } = useMutation({
     mutationFn: updateUserPreferences,
+    retry: (failureCount, error) =>
+      failureCount < 3 &&
+      !(error instanceof ApiError && error.statusCode < 500),
     onSuccess: (updatedUser) => {
       queryClient.setQueryData([keys.user], updatedUser)
+      lastServerLanguage.current = updatedUser.language
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.statusCode === 401) return
+      reportError('generic_failure', error, {
+        context: '[useSyncUserPreferencesWithBackend] Failed to sync:',
+      })
     },
   })
 
   useEffect(() => {
     if (!user || !isLoggedIn) return
 
-    const syncBrowserPreferencesToBackend = async () => {
-      const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-      const currentLanguage = convertToBackendLanguage(i18n.language)
-      if (
-        currentLanguage !== user.language ||
-        currentTimezone !== user.timezone
-      ) {
-        await mutateAsync({
-          user: {
-            id: user.id,
-            timezone: currentTimezone,
-            language: currentLanguage,
-          },
+    const serverLang = user.language
+    const frontendServerLang = convertToFrontendLanguage(serverLang)
+
+    if (lastServerLanguage.current !== serverLang) {
+      lastServerLanguage.current = serverLang
+      if (frontendServerLang && frontendServerLang !== i18n.language) {
+        i18n.changeLanguage(frontendServerLang).catch((error) => {
+          reportError('generic_failure', error, {
+            context:
+              '[useSyncUserPreferencesWithBackend] Failed to apply saved language:',
+          })
         })
+        return
       }
     }
 
-    syncBrowserPreferencesToBackend().catch((error) => {
-      if (error instanceof ApiError && error.statusCode === 401) return
-      reportError('generic_failure', error, {
-        context: '[useSyncUserPreferencesWithBackend] Failed to sync:',
-      })
+    const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const uiLang = convertToBackendLanguage(i18n.language)
+    const languageChanged =
+      !!frontendServerLang && !!uiLang && uiLang !== serverLang
+    const timezoneChanged = currentTimezone !== user.timezone
+
+    if (!languageChanged && !timezoneChanged) return
+
+    mutate({
+      user: {
+        id: user.id,
+        timezone: currentTimezone,
+        language: languageChanged ? uiLang : serverLang,
+      },
     })
-  }, [i18n.language, isLoggedIn, user, mutateAsync])
+  }, [i18n, i18n.language, isLoggedIn, user, mutate])
 }

--- a/src/frontend/src/i18n/init.ts
+++ b/src/frontend/src/i18n/init.ts
@@ -2,8 +2,8 @@ import i18n from 'i18next'
 import resourcesToBackend from 'i18next-resources-to-backend'
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
+import { fallbackLng } from '@/utils/languages'
 const i18nDefaultNamespace = 'global'
-const fallbackLng = 'fr'
 
 i18n.setDefaultNamespace(i18nDefaultNamespace)
 i18n

--- a/src/frontend/src/utils/languages.ts
+++ b/src/frontend/src/utils/languages.ts
@@ -12,6 +12,14 @@ const frontendToBackendMap: Record<FrontendLanguage, BackendLanguage> = {
 
 export const convertToBackendLanguage = (
   frontendLang: string = 'fr'
-): BackendLanguage => {
+): BackendLanguage | undefined => {
   return frontendToBackendMap[frontendLang as FrontendLanguage]
+}
+
+export const convertToFrontendLanguage = (
+  backendLang: string
+): FrontendLanguage | undefined => {
+  return (Object.keys(frontendToBackendMap) as FrontendLanguage[]).find(
+    (key) => frontendToBackendMap[key] === backendLang
+  )
 }

--- a/src/frontend/src/utils/languages.ts
+++ b/src/frontend/src/utils/languages.ts
@@ -11,8 +11,18 @@ const frontendToBackendMap: Record<FrontendLanguage, BackendLanguage> = {
   es: 'es-es',
 }
 
+export const fallbackLng: FrontendLanguage = 'fr'
+
 export const convertToBackendLanguage = (
-  frontendLang: string = 'fr'
-): BackendLanguage => {
+  frontendLang: string = fallbackLng
+): BackendLanguage | undefined => {
   return frontendToBackendMap[frontendLang as FrontendLanguage]
+}
+
+export const convertToFrontendLanguage = (
+  backendLang: string
+): FrontendLanguage | undefined => {
+  return (Object.keys(frontendToBackendMap) as FrontendLanguage[]).find(
+    (key) => frontendToBackendMap[key] === backendLang
+  )
 }


### PR DESCRIPTION
## Problem

Every page load pushes the browser's detected language back to the user endpoint, overwriting whatever the server had. A language saved in settings gets reverted whenever it disagrees with the browser locale, so signing in from a different browser locale silently changes the saved preference.

https://github.com/suitenumerique/meet/issues/1363

## Solution

Treat the saved language as the source of truth: adopt it into the UI on load, and PUT only when the user picks a language in the settings panel. Timezone keeps following the browser as before.