### PR TITLE
✨ Restrict settable room access levels

### DIFF
--- a/src/backend/core/api/__init__.py
+++ b/src/backend/core/api/__init__.py
@@ -62,6 +62,9 @@ def get_frontend_configuration(request):
         },
         "telephony": build_telephony_config(),
         "subtitle": {"enabled": settings.ROOM_SUBTITLE_ENABLED},
+        "room": {
+            "allowed_access_levels": settings.RESOURCE_ALLOWED_ACCESS_LEVELS,
+        },
         "livekit": {
             "url": settings.LIVEKIT_CONFIGURATION["url"],
             "force_wss_protocol": settings.LIVEKIT_FORCE_WSS_PROTOCOL,

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -142,6 +142,14 @@ class RoomSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(e.errors()) from e
         return value
 
+    def validate_access_level(self, access_level):
+        """Validate the access level against the instance allow-list."""
+        if access_level not in settings.RESOURCE_ALLOWED_ACCESS_LEVELS:
+            raise serializers.ValidationError(
+                "This access level is not allowed on this instance."
+            )
+        return access_level
+
     def to_representation(self, instance):
         """
         Add users only for administrator users.

--- a/src/backend/core/tests/rooms/test_api_rooms_create.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_create.py
@@ -9,7 +9,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from ...factories import RoomFactory, UserFactory
-from ...models import Room
+from ...models import Room, RoomAccessLevel
 
 pytestmark = pytest.mark.django_db
 
@@ -63,6 +63,30 @@ def test_api_rooms_create_authenticated(reset_cache):
 
     rooms_data = cache.keys("room-creation-callback_*")
     assert not rooms_data
+
+
+def test_api_rooms_create_access_level_not_allowed(reset_cache, settings):
+    """Creating a room with a disallowed access level should be rejected."""
+    settings.RESOURCE_ALLOWED_ACCESS_LEVELS = [
+        RoomAccessLevel.TRUSTED,
+        RoomAccessLevel.RESTRICTED,
+    ]
+    user = UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        "/api/v1.0/rooms/",
+        {
+            "name": "my room",
+            "access_level": RoomAccessLevel.PUBLIC,
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert not Room.objects.exists()
 
 
 def test_api_rooms_create_generation_cache(reset_cache):

--- a/src/backend/core/tests/rooms/test_api_rooms_update.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_update.py
@@ -437,3 +437,63 @@ def test_api_rooms_update_livekit_sync_failure(mock_update_metadata):
             "configuration": {"can_publish_sources": ["camera"]},
         },
     )
+
+
+@patch.object(RoomManagement, "update_metadata")
+def test_api_rooms_update_access_level_not_allowed(mock_update_metadata, settings):
+    """An access level outside RESOURCE_ALLOWED_ACCESS_LEVELS should be rejected."""
+    settings.RESOURCE_ALLOWED_ACCESS_LEVELS = [
+        RoomAccessLevel.TRUSTED,
+        RoomAccessLevel.RESTRICTED,
+    ]
+    user = UserFactory()
+    room = RoomFactory(
+        access_level=RoomAccessLevel.RESTRICTED,
+        users=[(user, random.choice(["administrator", "owner"]))],
+    )
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.patch(
+        f"/api/v1.0/rooms/{room.id!s}/",
+        {"access_level": RoomAccessLevel.PUBLIC},
+        format="json",
+    )
+    assert response.status_code == 400
+    room.refresh_from_db()
+    assert room.access_level == RoomAccessLevel.RESTRICTED
+    mock_update_metadata.assert_not_called()
+
+
+@patch.object(RoomManagement, "update_metadata")
+def test_api_rooms_update_access_level_allowed(mock_update_metadata, settings):
+    """An access level within RESOURCE_ALLOWED_ACCESS_LEVELS should be accepted."""
+    settings.RESOURCE_ALLOWED_ACCESS_LEVELS = [
+        RoomAccessLevel.TRUSTED,
+        RoomAccessLevel.RESTRICTED,
+    ]
+    user = UserFactory()
+    room = RoomFactory(
+        access_level=RoomAccessLevel.TRUSTED,
+        users=[(user, random.choice(["administrator", "owner"]))],
+        configuration={},
+    )
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.patch(
+        f"/api/v1.0/rooms/{room.id!s}/",
+        {"access_level": RoomAccessLevel.RESTRICTED},
+        format="json",
+    )
+    assert response.status_code == 200
+    room.refresh_from_db()
+    assert room.access_level == RoomAccessLevel.RESTRICTED
+
+    mock_update_metadata.assert_called_once_with(
+        room_name=str(room.id),
+        metadata={
+            "access_level": "restricted",
+            "configuration": {},
+        },
+    )

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -662,6 +662,11 @@ class Base(Configuration):
     RESOURCE_DEFAULT_ACCESS_LEVEL = values.Value(
         "public", environ_name="RESOURCE_DEFAULT_ACCESS_LEVEL", environ_prefix=None
     )
+    RESOURCE_ALLOWED_ACCESS_LEVELS = values.ListValue(
+        ["public", "trusted", "restricted"],
+        environ_name="RESOURCE_ALLOWED_ACCESS_LEVELS",
+        environ_prefix=None,
+    )
     ALLOW_UNREGISTERED_ROOMS = values.BooleanValue(
         True, environ_name="ALLOW_UNREGISTERED_ROOMS", environ_prefix=None
     )
@@ -1101,6 +1106,11 @@ class Base(Configuration):
         if cls.FILE_UPLOAD_TMP_PATH == cls.FILE_UPLOAD_PATH:
             raise ValueError(
                 "FILE_UPLOAD_TMP_PATH cannot be the same as FILE_UPLOAD_PATH"
+            )
+
+        if cls.RESOURCE_DEFAULT_ACCESS_LEVEL not in cls.RESOURCE_ALLOWED_ACCESS_LEVELS:
+            raise ValueError(
+                "RESOURCE_DEFAULT_ACCESS_LEVEL must be one of RESOURCE_ALLOWED_ACCESS_LEVELS"
             )
 
         # The SENTRY_DSN setting should be available to activate sentry for an environment

--- a/src/frontend/src/api/useConfig.ts
+++ b/src/frontend/src/api/useConfig.ts
@@ -2,6 +2,7 @@ import { fetchApi } from './fetchApi'
 import { keys } from './queryKeys'
 import { useQuery } from '@tanstack/react-query'
 import { RecordingMode } from '@/features/recording'
+import { ApiAccessLevel } from '@/features/rooms/api/ApiRoom'
 import type { Track } from 'livekit-client'
 type Source = Track.Source
 
@@ -41,6 +42,9 @@ export interface ApiConfig {
   }
   subtitle: {
     enabled: boolean
+  }
+  room?: {
+    allowed_access_levels: ApiAccessLevel[]
   }
   telephony: {
     enabled: boolean

--- a/src/frontend/src/features/rooms/livekit/components/Admin.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/Admin.tsx
@@ -7,6 +7,7 @@ import { fetchRoom } from '@/features/rooms/api/fetchRoom'
 import { ApiAccessLevel } from '@/features/rooms/api/ApiRoom'
 import { queryClient } from '@/api/queryClient'
 import { keys } from '@/api/queryKeys'
+import { useConfig } from '@/api/useConfig'
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'wouter'
 import { usePublishSourcesManager } from '../hooks/usePublishSourcesManager'
@@ -40,6 +41,35 @@ export const Admin = () => {
   } = usePublishSourcesManager()
 
   const { toggleMuting, isMutingEnabled } = usePermissionsManager()
+
+  const { data: config } = useConfig()
+
+  const accessLevelItems = [
+    {
+      value: ApiAccessLevel.PUBLIC,
+      label: t('access.levels.public.label'),
+      description: t('access.levels.public.description'),
+    },
+    {
+      value: ApiAccessLevel.TRUSTED,
+      label: t('access.levels.trusted.label'),
+      description: t('access.levels.trusted.description'),
+    },
+    {
+      value: ApiAccessLevel.RESTRICTED,
+      label: t('access.levels.restricted.label'),
+      description: t('access.levels.restricted.description'),
+    },
+  ]
+
+  const allowedAccessLevels = config?.room?.allowed_access_levels
+  const visibleAccessLevelItems = allowedAccessLevels
+    ? accessLevelItems.filter(
+        (item) =>
+          allowedAccessLevels.includes(item.value) ||
+          item.value === readOnlyData?.access_level
+      )
+    : accessLevelItems
 
   return (
     <Div
@@ -201,23 +231,7 @@ export const Admin = () => {
               })
               .catch((e) => console.error(e))
           }
-          items={[
-            {
-              value: ApiAccessLevel.PUBLIC,
-              label: t('access.levels.public.label'),
-              description: t('access.levels.public.description'),
-            },
-            {
-              value: ApiAccessLevel.TRUSTED,
-              label: t('access.levels.trusted.label'),
-              description: t('access.levels.trusted.description'),
-            },
-            {
-              value: ApiAccessLevel.RESTRICTED,
-              label: t('access.levels.restricted.label'),
-              description: t('access.levels.restricted.description'),
-            },
-          ]}
+          items={visibleAccessLevelItems}
         />
       </div>
     </Div>


### PR DESCRIPTION
## Purpose

Instance operators can set the default room access level, but room owners and admins can still create or update a room with any access level, including `public`, so operators can't enforce an instance-wide policy such as forbidding fully public rooms.

## Proposal

Add a `RESOURCE_ALLOWED_ACCESS_LEVELS` allow-list, defaulting to all current levels, enforced through the room API on create and update. The allow-list is exposed via the config endpoint, and the room access settings hide the options that aren't allowed.

Closes #1076