### PR TITLE
✨(backend) Add per recording encoding config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to
 - 🩹(backend) identify externally provisioned users to PostHog
 - 🐛(backend) fix info panel crash for unregistered rooms
 - ♿️(frontend) focus side panel container on open #1452
-- ♻️(backend) change how encoding settings are defined
+- 💥(backend) replace recording encoding options with a profile/resolution model.
 
 ## [1.23.0] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - ✨(frontend) add participant color gradient when camera is off #1490
 - ✨(all) allow forcing SSO display name for authenticated users
 - ➕(frontend) install vite-plugin-static-copy for MediaPipe WASM assets
+- ✨(backend) add per-recording encoding quality presets to start-recording API
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to
 - 🩹(backend) identify externally provisioned users to PostHog
 - 🐛(backend) fix info panel crash for unregistered rooms
 - ♿️(frontend) focus side panel container on open #1452
-- 💥(backend) replace recording encoding options with a profile/resolution model.
+- 💥(backend) replace recording encoding options with a profile model
 
 ## [1.23.0] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 ### Changed
 
+- ♻️(backend) apply a default recording encoding (LiveKit preset when its defaults are unset); gate per-recording override behind RECORDING_CUSTOM_ENCODING_ENABLED
 - 🗑️(settings) deprecate SUMMARY_SERVICE_VERSION=1
 - ⬆️(mail) update mjml to v5 and @html-to/text-cli
 - 🚸(frontend) initialize the join input name with the persisted full name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to
 
 ### Changed
 
-- ♻️(backend) apply a default recording encoding (LiveKit preset when its defaults are unset); gate per-recording override behind RECORDING_CUSTOM_ENCODING_ENABLED
 - 🗑️(settings) deprecate SUMMARY_SERVICE_VERSION=1
 - ⬆️(mail) update mjml to v5 and @html-to/text-cli
 - 🚸(frontend) initialize the join input name with the persisted full name
@@ -35,6 +34,7 @@ and this project adheres to
 - 🩹(backend) identify externally provisioned users to PostHog
 - 🐛(backend) fix info panel crash for unregistered rooms
 - ♿️(frontend) focus side panel container on open #1452
+- ♻️(backend) change how encoding settings are defined
 
 ## [1.23.0] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(backend) add per-recording encoding quality presets to start-recording API
+
 ## [1.30.0] - 2026-09-01
 
 ### Changed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,92 @@ the following command inside your docker container:
 
 ## [Unreleased]
 
+### Recording encoding settings replaced by a resolution/profile model
+
+The `RECORDING_ENCODING_*` settings introduced in v1.16.0 exposed raw encoder
+values (width, height, framerate, bitrate). They are replaced by two named and configurable sets of
+dimensions, a **resolution** (default: `540p`, `720p`, `1080p`) and a **profile**
+(default: `talking_heads`, `text`, `mixed`, `full`), which are resolved to the width, height,
+fps and video bitrate.
+
+**The following environment variables are no longer read. If they are still set in
+your deployment they are silently ignored, and your recordings will be encoded with
+the new defaults instead of your tuned values.**
+
+| Removed variable                        | Replaced by                                                                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `RECORDING_ENCODING_ENABLED`            | Nothing. A default encoding is now always built (see below). **Not** `RECORDING_CUSTOM_ENCODING_ENABLED`, which gates a different feature. |
+| `RECORDING_ENCODING_WIDTH`              | The `width` of the entry selected by `RECORDING_ENCODING_DEFAULT_RESOLUTION` in `RECORDING_ENCODING_AVAILABLE_RESOLUTIONS`. |
+| `RECORDING_ENCODING_HEIGHT`             | The `height` of that same entry.                                                                              |
+| `RECORDING_ENCODING_FRAMERATE`          | The `fps` of the profile selected by `RECORDING_ENCODING_DEFAULT_PROFILE` in `RECORDING_ENCODING_AVAILABLE_PROFILES`. |
+| `RECORDING_ENCODING_VIDEO_BITRATE_KBPS` | That profile's `kbps`.                                                                  |
+
+`RECORDING_ENCODING_AUDIO_BITRATE_KBPS` and `RECORDING_ENCODING_KEY_FRAME_INTERVAL_S`
+are unchanged and keep their values.
+
+#### If you never set `RECORDING_ENCODING_ENABLED=True`
+
+No action is required. The shipped defaults (`RECORDING_ENCODING_DEFAULT_PROFILE=full`,
+`RECORDING_ENCODING_DEFAULT_RESOLUTION=720p`) match LiveKit's built-in
+`H264_720P_30` preset: 1280×720, 30 fps, 3000 kbps H.264 MAIN, 128 kbps AAC.
+
+Note that these values are now sent explicitly as advanced `EncodingOptions`
+rather than relying on LiveKit's preset, so `RECORDING_ENCODING_AUDIO_BITRATE_KBPS`
+and `RECORDING_ENCODING_KEY_FRAME_INTERVAL_S` now apply to every recording. They
+previously applied only when `RECORDING_ENCODING_ENABLED` was `True`.
+
+To keep letting LiveKit pick the encoding instead, set either default to an empty
+value:
+
+```
+RECORDING_ENCODING_DEFAULT_RESOLUTION=
+RECORDING_ENCODING_DEFAULT_PROFILE=
+```
+
+#### If you had tuned `RECORDING_ENCODING_*` values
+
+Translate your old values into a default resolution and a default profile. Declare your own resolution and/or profile. Both maps are read from the
+environment as a single-line Python/JSON dict literal (parsed with
+`ast.literal_eval`, so use double-quoted keys and no trailing commas, and do not
+add outer quotes in `.env`-style files):
+
+```bash
+RECORDING_ENCODING_AVAILABLE_RESOLUTIONS={"540p": {"width": 960, "height": 540}, "720p": {"width": 1280, "height": 720}, "1080p": {"width": 1920, "height": 1080}}
+RECORDING_ENCODING_AVAILABLE_PROFILES={"my_old_profile": {"fps": 15, "kbps": {"540p": 350, "720p": 600, "1080p": 1100}}}
+RECORDING_ENCODING_DEFAULT_RESOLUTION=720p
+RECORDING_ENCODING_DEFAULT_PROFILE=my_old_profile
+```
+
+Two constraints are validated at startup and may raise a `ValueError`:
+
+- every profile in `RECORDING_ENCODING_AVAILABLE_PROFILES` must define a `kbps`
+  entry for **exactly** the keys of `RECORDING_ENCODING_AVAILABLE_RESOLUTIONS`;
+  overriding one of the two maps usually means overriding both;
+- `RECORDING_ENCODING_DEFAULT_RESOLUTION` and `RECORDING_ENCODING_DEFAULT_PROFILE`,
+  when non-empty, must be keys of their respective map.
+
+#### Optional: per-recording encoding
+
+`RECORDING_CUSTOM_ENCODING_ENABLED` (default `False`) toggles whether the
+start-recording API accepts an `encoding` object
+(`{"resolution": "720p", "profile": "talking_heads"}`, `profile` optional) that
+overrides the default for a single recording. It does not enable or disable the
+default encoding, which is built from the two `RECORDING_ENCODING_DEFAULT_*`
+settings either way. Leaving it at `False` preserves the previous behaviour, where
+every recording uses the server-side encoding: requests carrying
+`options.encoding` are rejected with a `400` before the recording is created, so
+nothing is persisted and no egress is started.
+
+Before enabling it:
+
+- clients can only pick keys you declared; there is no way to send a raw width or bitrate
+- as of this implementation, the frontend never sends `encoding`
+- `encoding` is accepted but ignored for `transcript` recordings, whose audio-only
+  egress has no video encoding to configure.
+
+See [docs/features/recording.md](docs/features/recording.md#tuning-recording-encoding)
+for the full setting reference, the shipped profile table and the tuning caveats.
+
 ## v1.30.0
 
 ### Removing S3 storage-event webhooks for recordings

--- a/docs/features/recording.md
+++ b/docs/features/recording.md
@@ -100,13 +100,13 @@ sequenceDiagram
 | **RECORDING_STORAGE_EVENT_TOKEN**       | Secret/File | `None`                                                                                                                                                             | Token used to authenticate storage webhook requests, if `RECORDING_ENABLE_STORAGE_EVENT_AUTH` is enabled.                                                                                                                                                                                          |
 | **RECORDING_EXPIRATION_DAYS**           | Integer     | `None`                                                                                                                                                             | Number of days before recordings expire. Should match bucket lifecycle policy. Set to `None` for no expiration.                                                                                                                                                                                    |
 | **RECORDING_MAX_DURATION**              | Integer     | `None`                                                                                                                                                             | Maximum duration of a recording in milliseconds. Must be synced with the LiveKit Egress configuration. Set to None for unlimited duration. When the maximum duration is reached, the recording is automatically stopped and saved, and the user is prompted in the frontend with an alert message. |
-| **RECORDING_ENCODING_ENABLED**          | Boolean     | `False`                                                                                                                                                            | When `False`, LiveKit Egress uses its built-in `H264_720P_30` preset. When `True`, the `RECORDING_ENCODING_*` values below are sent to LiveKit as advanced `EncodingOptions`. See [Tuning recording encoding](#tuning-recording-encoding).                                                          |
-| **RECORDING_ENCODING_WIDTH**            | Integer     | `1280`                                                                                                                                                             | Recording video width in pixels. Only applied when `RECORDING_ENCODING_ENABLED` is `True`.                                                                                                                                                                                                         |
-| **RECORDING_ENCODING_HEIGHT**           | Integer     | `720`                                                                                                                                                              | Recording video height in pixels. Only applied when `RECORDING_ENCODING_ENABLED` is `True`.                                                                                                                                                                                                        |
-| **RECORDING_ENCODING_FRAMERATE**        | Integer     | `30`                                                                                                                                                               | Recording video framerate (fps). Directly impacts egress worker CPU (roughly linear). Only applied when `RECORDING_ENCODING_ENABLED` is `True`.                                                                                                                                                    |
-| **RECORDING_ENCODING_VIDEO_BITRATE_KBPS** | Integer   | `3000`                                                                                                                                                             | H.264 MAIN video bitrate in kbps. Only applied when `RECORDING_ENCODING_ENABLED` is `True`.                                                                                                                                                                                                        |
-| **RECORDING_ENCODING_AUDIO_BITRATE_KBPS** | Integer   | `128`                                                                                                                                                              | AAC audio bitrate in kbps. Only applied when `RECORDING_ENCODING_ENABLED` is `True`.                                                                                                                                                                                                               |
-| **RECORDING_ENCODING_KEY_FRAME_INTERVAL_S** | Float   | `4.0`                                                                                                                                                              | Keyframe interval in seconds. Drives seek granularity in the recorded MP4 (a player can only seek to keyframe boundaries). Larger values give the encoder slightly more bits for non-keyframe content at a fixed bitrate. `4.0` is a standard VOD value. Only applied when `RECORDING_ENCODING_ENABLED` is `True`. |
+| **RECORDING_CUSTOM_ENCODING_ENABLED**          | Boolean     | `False`                                                                                                                                                            | Whether the start-recording API accepts a per-recording `encoding` object (resolution/profile) that overrides the default. When `False`, the API rejects per-recording `encoding`; when `True`, clients may pick from the available resolutions/profiles. The default encoding below is applied regardless of this flag. See [Tuning recording encoding](#tuning-recording-encoding).                                                          |
+| **RECORDING_ENCODING_AVAILABLE_RESOLUTIONS** | Dict      | `{"540p": {"width": 960, "height": 540}, "720p": {"width": 1280, "height": 720}, "1080p": {"width": 1920, "height": 1080}}`                                        | Maps a resolution name to its `{"width", "height"}` in pixels. Both the default encoding and the per-recording start-recording API pick from these keys.                                                                                                                                          |
+| **RECORDING_ENCODING_AVAILABLE_PROFILES** | Dict      | `{"full": {"fps": 30, "kbps": {…}}, …}`               | Maps a profile name to `{"fps", "kbps": {resolution: video_bitrate_kbps}}`. Every profile must define a bitrate for each available resolution (validated at startup).                                                                                                                              |
+| **RECORDING_ENCODING_DEFAULT_RESOLUTION** | String    | `"720p"`                                                                                                                                                          | Resolution used by the default encoding. When set, must be a key of `RECORDING_ENCODING_AVAILABLE_RESOLUTIONS`. Leave unset (together with, or instead of, the default profile) to disable the custom default encoding and fall back to LiveKit's built-in preset (a startup warning is emitted).                                                                                                                                                                  |
+| **RECORDING_ENCODING_DEFAULT_PROFILE**  | String    | `"full"`                                                                                                                                                          | Profile used by the default encoding. When set, must be a key of `RECORDING_ENCODING_AVAILABLE_PROFILES`. Leave unset (together with, or instead of, the default resolution) to disable the custom default encoding and fall back to LiveKit's built-in preset (a startup warning is emitted).                                                                                                                                                                        |
+| **RECORDING_ENCODING_AUDIO_BITRATE_KBPS** | Integer   | `128`                                                                                                                                                              | AAC audio bitrate in kbps used in the default encoding.                                                                                                                                                                                                               |
+| **RECORDING_ENCODING_KEY_FRAME_INTERVAL_S** | Float   | `4.0`                                                                                                                                                              | Keyframe interval in seconds. Drives seek granularity in the recorded MP4 (a player can only seek to keyframe boundaries). Larger values give the encoder slightly more bits for non-keyframe content at a fixed bitrate. `4.0` is a standard VOD value. |
 
 
 ### Manual Storage Webhook
@@ -150,52 +150,59 @@ This allows you to verify which recordings are in progress, troubleshoot egress 
 
 ## Tuning recording encoding
 
-By default, LiveKit Egress records with the built-in `H264_720P_30` preset: 1280×720 at 30 fps, 3000 kbps H.264 MAIN video and 128 kbps AAC audio. For a one-hour meeting this produces a file of roughly **1.4 GB**, which is often heavier than necessary for talking-head content and screen sharing.
+Every video recording is encoded from a default resolved from `RECORDING_ENCODING_DEFAULT_PROFILE` + `RECORDING_ENCODING_DEFAULT_RESOLUTION` and passed to LiveKit as advanced `EncodingOptions`. The shipped defaults (`full` profile) match LiveKit's built-in `H264_720P_30` preset. For a one-hour meeting that produces a file of roughly **1.4 GB**, which is often heavier than necessary for talking-head content and screen sharing; lowering the default profile/resolution shrinks it. If either default is left unset, no custom default encoding is built: a warning is logged at startup and LiveKit's built-in preset is used instead.
 
-The `RECORDING_ENCODING_*` settings let operators override this preset without modifying the source. Values are passed straight through LiveKit's `EncodingOptions.advanced` to the GStreamer pipeline (`x264enc` for video, `faac` for audio), so there are no hidden conversions — what you set is what the encoder receives.
+Encoding is chosen from two maps: `RECORDING_ENCODING_AVAILABLE_RESOLUTIONS` (`resolution → {"width", "height"}`) and `RECORDING_ENCODING_AVAILABLE_PROFILES` (`profile → {"fps", "kbps": {resolution: video_bitrate_kbps}}`):
+
+- **Default**: `RECORDING_ENCODING_DEFAULT_PROFILE` + `RECORDING_ENCODING_DEFAULT_RESOLUTION` set the encoding used by every recording that doesn't override it. Leave either unset to fall back to LiveKit's built-in preset (a startup warning is emitted).
+- **Per recording (opt-in)**: set `RECORDING_CUSTOM_ENCODING_ENABLED=True` to let clients override the default per recording. The start-recording API then accepts an `encoding` object selecting a `resolution` (required) and `profile` (optional): a resolution-only request sets the frame size but leaves LiveKit's default framerate/bitrate; adding a profile pins fps and bitrate too. When `RECORDING_CUSTOM_ENCODING_ENABLED=False`, the API rejects any per-recording `encoding` and the default is used.
+
+The resolved values are passed straight through LiveKit's `EncodingOptions.advanced` to the GStreamer pipeline (`x264enc` for video, `faac` for audio), so there are no hidden conversions — what the profile/resolution resolve to is what the encoder receives.
 
 ### How values map to GStreamer
 
-| Setting                               | GStreamer element | Property                           |
-| ------------------------------------- | ----------------- | ---------------------------------- |
-| `RECORDING_ENCODING_WIDTH/HEIGHT`     | capsfilter        | `video/x-raw,width=W,height=H`     |
-| `RECORDING_ENCODING_FRAMERATE`        | capsfilter        | `framerate=F/1`                    |
-| `RECORDING_ENCODING_VIDEO_BITRATE_KBPS` | `x264enc`       | `bitrate=kbps` (kilobits)          |
-| `RECORDING_ENCODING_KEY_FRAME_INTERVAL_S` | `x264enc`     | `key-int-max = interval × fps`     |
-| `RECORDING_ENCODING_AUDIO_BITRATE_KBPS` | `faac`          | `bitrate = kbps × 1000` (bits)     |
+| Resolved value                            | GStreamer element | Property                           |
+| ----------------------------------------- | ----------------- | ---------------------------------- |
+| resolution `width` / `height`             | capsfilter        | `video/x-raw,width=W,height=H`     |
+| profile `fps`                             | capsfilter        | `framerate=F/1`                    |
+| profile `kbps[resolution]`                | `x264enc`         | `bitrate=kbps` (kilobits)          |
+| `RECORDING_ENCODING_KEY_FRAME_INTERVAL_S` | `x264enc`         | `key-int-max = interval × fps`     |
+| `RECORDING_ENCODING_AUDIO_BITRATE_KBPS`   | `faac`            | `bitrate = kbps × 1000` (bits)     |
 
 The H.264 profile is fixed to MAIN and the x264 `speed-preset` to `veryfast` by LiveKit (real-time constraint) — lowering the framerate is therefore the main lever to save CPU, while lowering the bitrate is the main lever to shrink the output file.
 
-### Reference profiles
+### Built-in profiles
 
-Rough 30-minute file-size estimates assume video + audio bitrate multiplied by duration. Actual sizes vary with content (static talking heads compress better than heavy screen motion). Egress CPU figures are indicative, measured on a single Ryzen laptop core saturated by the default preset (= 100 %); scaling is roughly linear with `framerate × bitrate` but the absolute numbers depend on the host hardware.
+The default `RECORDING_ENCODING_AVAILABLE_PROFILES` ship four profiles. Framerate is fixed per profile; video bitrate (kbps) scales with resolution so quality stays consistent across sizes. File size scales roughly with `framerate × bitrate`, and so does egress CPU cost.
 
-| Profile                | Resolution | FPS | Video (kbps) | Audio (kbps) | Keyframe (s) | ~ size / 30 min | Egress CPU (vs. default) | Suitable for                                        |
-| ---------------------- | ---------- | --- | ------------ | ------------ | ------------ | --------------- | ------------------------ | --------------------------------------------------- |
-| Default (preset)       | 1280×720   | 30  | 3000         | 128          | 4            | **~690 MB**     | 100 %                    | Unchanged LiveKit behaviour                         |
-| Balanced               | 1280×720   | 20  | 1000         | 96           | 4            | ~240 MB         | ~67 %                    | Mixed content, moderate motion                      |
-| **Low CPU / small file** | 1280×720 | 15  | 600          | 64           | 4            | **~150 MB**     | ~50 %                    | Talking-head dominant meetings + occasional slides ★ |
-| Slide-heavy            | 1280×720   | 15  | 900          | 64           | 4            | ~210 MB         | ~55 %                    | Frequent dense screen sharing (decks, IDE, docs)    |
-| Minimum CPU            | 960×540    | 15  | 500          | 64           | 4            | ~125 MB         | ~30 %                    | Voice-first meetings, readable text not required    |
-| Audio-heavy fallback   | 1280×720   | 10  | 400          | 96           | 4            | ~110 MB         | ~35 %                    | Long webinars, low motion                           |
+| Profile         | FPS | 540p (kbps) | 720p (kbps) | 1080p (kbps) | Suitable for                                       |
+| --------------- | --- | ----------- | ----------- | ------------ | -------------------------------------------------- |
+| `talking_heads` | 15  | 400         | 700         | 1200         | Talking-head dominant meetings + occasional slides |
+| `text`          | 15  | 600         | 1000        | 1800         | Frequent dense screen sharing (decks, IDE, docs)   |
+| `mixed`         | 20  | 900         | 1500        | 2500         | Mixed content, moderate motion                     |
+| `full`          | 30  | 2000        | 3000        | 4500         | Highest fidelity; closest to the LiveKit preset    |
 
-★ Recommended starting point for typical LaSuite Meet usage.
+To pick a profile per recording (requires `RECORDING_CUSTOM_ENCODING_ENABLED=True`), the client sends it in the start-recording request:
 
-Environment variables for the **Low CPU / small file** profile:
+```json
+{
+  "mode": "screen_recording",
+  "options": {"encoding": {"resolution": "720p", "profile": "talking_heads"}}
+}
+```
+
+To change the default encoding applied to every recording:
 
 ```bash
-RECORDING_ENCODING_ENABLED=True
-RECORDING_ENCODING_WIDTH=1280
-RECORDING_ENCODING_HEIGHT=720
-RECORDING_ENCODING_FRAMERATE=15
-RECORDING_ENCODING_VIDEO_BITRATE_KBPS=600
+RECORDING_ENCODING_DEFAULT_RESOLUTION=720p
+RECORDING_ENCODING_DEFAULT_PROFILE=talking_heads
 RECORDING_ENCODING_AUDIO_BITRATE_KBPS=64
 RECORDING_ENCODING_KEY_FRAME_INTERVAL_S=4.0
 ```
 
 ### Caveats
 
-- **Screen-share readability — think bits/frame, not bitrate**: at 720p, text legibility starts to break down below ~40 kbits/frame (= `bitrate ÷ framerate`). The recommended preset (600 kbps × 15 fps) sits at exactly that threshold, comfortable for talking heads with occasional slide sharing. The same 600 kbps at 30 fps would only deliver 20 kbits/frame and visibly blur dense slides — which is why **lowering framerate is a more screen-share-friendly lever than lowering bitrate**. For deck-heavy or IDE-share meetings, prefer the **Slide-heavy** profile (900 kbps × 15 fps ≈ 60 kbits/frame).
+- **Screen-share readability — think bits/frame, not bitrate**: at 720p, text legibility starts to break down below ~40 kbits/frame (= `bitrate ÷ framerate`). The `talking_heads` profile (700 kbps × 15 fps) sits just above that threshold, comfortable for talking heads with occasional slide sharing. The same bitrate at 30 fps would only deliver ~23 kbits/frame and visibly blur dense slides — which is why **lowering framerate is a more screen-share-friendly lever than lowering bitrate**. For deck-heavy or IDE-share meetings, prefer the **`text`** profile (1000 kbps × 15 fps ≈ 67 kbits/frame).
 - **Motion handling**: the `veryfast` x264 preset is set by LiveKit and cannot be overridden here. Low-bitrate settings will therefore show more artefacts on fast motion than an offline re-encode with a slower preset would. This is the other reason FPS reduction is the safer tuning lever for meeting recordings.
 - **Audio**: AAC at 64 kbps stereo is transparent for voice but starts to compress music noticeably. Keep 128 kbps if you expect music playback in meetings.
 - **Codec choice**: H.264 MAIN is hardcoded on purpose. Switching to HEVC or VP9 would increase egress CPU cost 2×–5×, defeating the goal of this tuning.

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -69,16 +69,30 @@ SUMMARY_SERVICE_WEBHOOK_API_TOKEN=webhook-password
 RECORDING_DOWNLOAD_BASE_URL=http://localhost:3000/recording
 
 # Recording encoding (LiveKit Egress advanced options).
-# When RECORDING_ENCODING_ENABLED is False (default), LiveKit uses its built-in
-# H264_720P_30 preset (1280x720, 30fps, 3000 kbps). Enable and tune to reduce
-# file size and CPU load on the egress worker.
-# RECORDING_ENCODING_ENABLED=False
-# RECORDING_ENCODING_WIDTH=1280
-# RECORDING_ENCODING_HEIGHT=720
-# RECORDING_ENCODING_FRAMERATE=30
-# RECORDING_ENCODING_VIDEO_BITRATE_KBPS=3000
+# Encoding is described by a named resolution (width/height) and a named profile
+# (framerate + video bitrate per resolution) instead of raw encoder values. The
+# start-recording API accepts a pair per recording, e.g.
+# options.encoding={"resolution": "720p", "profile": "talking_heads"}; only keys
+# declared in the two maps below are accepted, "profile" is optional.
+# Both maps are read as a one-line Python dict literal (ast.literal_eval): double
+# quoted keys, no outer quotes, no trailing comma. Every profile must define a
+# kbps entry for exactly the resolutions of the resolutions map, or startup fails.
+# RECORDING_ENCODING_AVAILABLE_RESOLUTIONS={"540p": {"width": 960, "height": 540}, "720p": {"width": 1280, "height": 720}, "1080p": {"width": 1920, "height": 1080}}
+# RECORDING_ENCODING_AVAILABLE_PROFILES={"talking_heads": {"fps": 15, "kbps": {"540p": 400, "720p": 700, "1080p": 1200}}, "text": {"fps": 15, "kbps": {"540p": 600, "720p": 1000, "1080p": 1800}}, "mixed": {"fps": 20, "kbps": {"540p": 900, "720p": 1500, "1080p": 2500}}, "full": {"fps": 30, "kbps": {"540p": 2000, "720p": 3000, "1080p": 4500}}}
+
+# Defaults for recordings that don't carry an encoding. Must be keys of the maps
+# above. Declared but not yet read by the recording code at this commit.
+# RECORDING_ENCODING_DEFAULT_RESOLUTION=720p
+# RECORDING_ENCODING_DEFAULT_PROFILE=full
+
+# Applied to every resolved encoding, independent of resolution and profile.
 # RECORDING_ENCODING_AUDIO_BITRATE_KBPS=128
 # RECORDING_ENCODING_KEY_FRAME_INTERVAL_S=4.0
+
+# Server-wide encoding used when a recording carries no encoding of its own.
+# Keep False: when True, the worker factory still reads RECORDING_ENCODING_WIDTH,
+# _HEIGHT, _FRAMERATE and _VIDEO_BITRATE_KBPS, which no longer exist.
+# RECORDING_ENCODING_ENABLED=False
 
 # Telephony
 ROOM_TELEPHONY_ENABLED=True

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -13,7 +13,12 @@ from django.core.exceptions import SuspiciousOperation
 from django.utils.translation import gettext_lazy as _
 
 from django_pydantic_field.rest_framework import SchemaField
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import (
+    BaseModel,
+    Field,
+    field_serializer,
+    field_validator,
+)
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
@@ -227,6 +232,49 @@ class BaseValidationOnlySerializer(serializers.Serializer):
         raise NotImplementedError(f"{self.__class__.__name__} is validation-only")
 
 
+class EncodingConfig(BaseModel):
+    """Configuration options for recording encoding.
+
+    The allowed `resolution` and `profile` values are derived at validation time
+    from ``settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS`` and
+    ``settings.RECORDING_ENCODING_AVAILABLE_PROFILES``, so adding a resolution or profile
+    to those maps is enough to make it accepted here.
+
+    Attributes:
+        resolution: Target video resolution.
+        profile: Encoding profile to balance quality and CPU usage. When `None`,
+        LiveKit default framerate/bitrate are used for the resolution.
+    """
+
+    resolution: str
+    profile: str | None = None
+    model_config = {"extra": "forbid"}
+
+    @field_validator("resolution")
+    @classmethod
+    def _validate_resolution(cls, value):
+        """Reject resolutions absent from RECORDING_ENCODING_AVAILABLE_RESOLUTIONS."""
+        allowed = set(settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS)
+        if value not in allowed:
+            raise ValueError(
+                f"Invalid resolution '{value}'. Choose from {sorted(allowed)}."
+            )
+        return value
+
+    @field_validator("profile")
+    @classmethod
+    def _validate_profile(cls, value):
+        """Reject profiles absent from RECORDING_ENCODING_AVAILABLE_PROFILES."""
+        if value is None:
+            return None
+        allowed = set(settings.RECORDING_ENCODING_AVAILABLE_PROFILES)
+        if value not in allowed:
+            raise ValueError(
+                f"Invalid profile '{value}'. Choose from {sorted(allowed)}."
+            )
+        return value
+
+
 class RecordingOptions(BaseModel):
     """Configuration options for recording.
 
@@ -247,7 +295,7 @@ class RecordingOptions(BaseModel):
     transcribe: bool | None = None
     collect_metadata: bool | None = None
     original_mode: Literal["screen_recording", "transcript"] | None = None
-
+    encoding: EncodingConfig | None = None
     model_config = {"extra": "forbid"}
 
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -13,7 +13,12 @@ from django.core.exceptions import SuspiciousOperation
 from django.utils.translation import gettext_lazy as _
 
 from django_pydantic_field.rest_framework import SchemaField
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import (
+    BaseModel,
+    Field,
+    field_serializer,
+    field_validator,
+)
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
@@ -244,6 +249,49 @@ class BaseValidationOnlySerializer(serializers.Serializer):
         raise NotImplementedError(f"{self.__class__.__name__} is validation-only")
 
 
+class EncodingConfig(BaseModel):
+    """Configuration options for recording encoding.
+
+    The allowed `resolution` and `profile` values are derived at validation time
+    from ``settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS`` and
+    ``settings.RECORDING_ENCODING_AVAILABLE_PROFILES``, so adding a resolution or profile
+    to those maps is enough to make it accepted here.
+
+    Attributes:
+        resolution: Target video resolution.
+        profile: Encoding profile to balance quality and CPU usage. When `None`,
+        LiveKit default framerate/bitrate are used for the resolution.
+    """
+
+    resolution: str
+    profile: str | None = None
+    model_config = {"extra": "forbid"}
+
+    @field_validator("resolution")
+    @classmethod
+    def _validate_resolution(cls, value):
+        """Reject resolutions absent from RECORDING_ENCODING_AVAILABLE_RESOLUTIONS."""
+        allowed = set(settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS)
+        if value not in allowed:
+            raise ValueError(
+                f"Invalid resolution '{value}'. Choose from {sorted(allowed)}."
+            )
+        return value
+
+    @field_validator("profile")
+    @classmethod
+    def _validate_profile(cls, value):
+        """Reject profiles absent from RECORDING_ENCODING_AVAILABLE_PROFILES."""
+        if value is None:
+            return None
+        allowed = set(settings.RECORDING_ENCODING_AVAILABLE_PROFILES)
+        if value not in allowed:
+            raise ValueError(
+                f"Invalid profile '{value}'. Choose from {sorted(allowed)}."
+            )
+        return value
+
+
 class RecordingOptions(BaseModel):
     """Configuration options for recording.
 
@@ -264,7 +312,7 @@ class RecordingOptions(BaseModel):
     transcribe: bool | None = None
     collect_metadata: bool | None = None
     original_mode: Literal["screen_recording", "transcript"] | None = None
-
+    encoding: EncodingConfig | None = None
     model_config = {"extra": "forbid"}
 
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -384,6 +384,20 @@ class RoomViewSet(
         options = serializer.validated_data.get("options")
         room = self.get_object()
 
+        if (
+            options is not None
+            and options.encoding is not None
+            and not settings.RECORDING_CUSTOM_ENCODING_ENABLED
+        ):
+            # Per-recording encoding selection is gated by
+            # RECORDING_CUSTOM_ENCODING_ENABLED. When disabled, recordings use
+            # encoding defined by RECORDING_ENCODING_DEFAULT_RESOLUTION
+            # and RECORDING_ENCODING_DEFAULT_PROFILE.
+            return drf_response.Response(
+                {"detail": "Per-recording encoding selection is disabled."},
+                status=drf_status.HTTP_400_BAD_REQUEST,
+            )
+
         options_data = options.model_dump(exclude_none=True) if options else {}
         if options is not None and options.encoding is not None:
             # Persist the resolved encoding (concrete width/height/framerate/

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -63,12 +63,12 @@ from core.recording.worker.exceptions import (
     RecordingStopError,
 )
 from core.recording.worker.factories import (
+    build_encoding_options,
     get_worker_service,
 )
 from core.recording.worker.mediator import (
     WorkerServiceMediator,
 )
-from core.recording.worker.services import resolve_encoding_config
 from core.services.invitation import InvitationService
 from core.services.livekit_events import (
     LiveKitEventsService,
@@ -402,8 +402,8 @@ class RoomViewSet(
         if options is not None and options.encoding is not None:
             # Persist the resolved encoding (concrete width/height/framerate/
             # bitrate) alongside the requested resolution/profile for traceability.
-            options_data["encoding"]["resolved"] = resolve_encoding_config(
-                options.encoding
+            options_data["encoding"]["resolved"] = build_encoding_options(
+                options.encoding.resolution, options.encoding.profile
             )
 
         try:

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -68,6 +68,7 @@ from core.recording.worker.factories import (
 from core.recording.worker.mediator import (
     WorkerServiceMediator,
 )
+from core.recording.worker.services import resolve_encoding_config
 from core.services.invitation import InvitationService
 from core.services.livekit_events import (
     LiveKitEventsService,
@@ -383,12 +384,20 @@ class RoomViewSet(
         options = serializer.validated_data.get("options")
         room = self.get_object()
 
+        options_data = options.model_dump(exclude_none=True) if options else {}
+        if options is not None and options.encoding is not None:
+            # Persist the resolved encoding (concrete width/height/framerate/
+            # bitrate) alongside the requested resolution/profile for traceability.
+            options_data["encoding"]["resolved"] = resolve_encoding_config(
+                options.encoding
+            )
+
         try:
             with transaction.atomic():
                 recording = models.Recording.objects.create(
                     room=room,
                     mode=mode,
-                    options=options.model_dump(exclude_none=True) if options else {},
+                    options=options_data,
                 )
                 models.RecordingAccess.objects.create(
                     user=self.request.user,

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -60,6 +60,7 @@ from core.recording.worker.factories import (
 from core.recording.worker.mediator import (
     WorkerServiceMediator,
 )
+from core.recording.worker.services import resolve_encoding_config
 from core.services.invitation import InvitationService
 from core.services.livekit_events import (
     LiveKitEventsService,
@@ -400,12 +401,20 @@ class RoomViewSet(
         options = serializer.validated_data.get("options")
         room = self.get_object()
 
+        options_data = options.model_dump(exclude_none=True) if options else {}
+        if options is not None and options.encoding is not None:
+            # Persist the resolved encoding (concrete width/height/framerate/
+            # bitrate) alongside the requested resolution/profile for traceability.
+            options_data["encoding"]["resolved"] = resolve_encoding_config(
+                options.encoding
+            )
+
         try:
             with transaction.atomic():
                 recording = models.Recording.objects.create(
                     room=room,
                     mode=mode,
-                    options=options.model_dump(exclude_none=True) if options else {},
+                    options=options_data,
                 )
                 models.RecordingAccess.objects.create(
                     user=self.request.user,

--- a/src/backend/core/recording/worker/factories.py
+++ b/src/backend/core/recording/worker/factories.py
@@ -78,7 +78,12 @@ class WorkerService(Protocol):
     def __init__(self, config: WorkerServiceConfig):
         """Initialize the service with the given configuration."""
 
-    def start(self, room_id: str, recording_id: str) -> str:
+    def start(
+        self,
+        room_id: str,
+        recording_id: str,
+        encoding_options: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """Start a recording for a specified room."""
 
     def stop(self, worker_id: str) -> str:

--- a/src/backend/core/recording/worker/factories.py
+++ b/src/backend/core/recording/worker/factories.py
@@ -22,6 +22,44 @@ _RECORDING_AUDIO_CODEC = livekit_api.AudioCodec.AAC
 _RECORDING_AUDIO_FREQUENCY_HZ = 48000
 
 
+def build_encoding_options(resolution, profile):
+    """Assemble the LiveKit ``EncodingOptions`` kwargs for a resolution/profile.
+
+    Single source of truth shared by the default encoding
+    (``WorkerServiceConfig.from_settings``) and the per-recording encoding
+    persisted by the start-recording API, so both paths always produce the
+    same shape.
+
+    The profile-independent fields (audio bitrate, keyframe interval and the
+    pinned codec / frequency constants) are always included.
+    The resolution-dependent fields are added only when they can be resolved:
+    width/height require a resolution; framerate/video_bitrate require both a
+    resolution and a profile (a resolution-only encoding leaves framerate and
+    bitrate to LiveKit's defaults).
+    """
+    options: Dict[str, Any] = {
+        "audio_bitrate": settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS,
+        "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
+        "video_codec": _RECORDING_VIDEO_CODEC,
+        "audio_codec": _RECORDING_AUDIO_CODEC,
+        "audio_frequency": _RECORDING_AUDIO_FREQUENCY_HZ,
+    }
+
+    if resolution:
+        resolution_config = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[
+            resolution
+        ]
+        options["width"] = resolution_config["width"]
+        options["height"] = resolution_config["height"]
+
+    if resolution and profile:
+        profile_config = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
+        options["framerate"] = profile_config["fps"]
+        options["video_bitrate"] = profile_config["kbps"][resolution]
+
+    return options
+
+
 @dataclass(frozen=True)
 class WorkerServiceConfig:
     """Declare Worker Service common configurations"""
@@ -47,21 +85,7 @@ class WorkerServiceConfig:
 
         encoding_options: Optional[Dict[str, Any]] = None
         if resolution and profile:
-            resolution_config = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[
-                resolution
-            ]
-            profile_config = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
-            encoding_options = {
-                "width": resolution_config["width"],
-                "height": resolution_config["height"],
-                "framerate": profile_config["fps"],
-                "video_bitrate": profile_config["kbps"][resolution],
-                "audio_bitrate": settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS,
-                "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
-                "video_codec": _RECORDING_VIDEO_CODEC,
-                "audio_codec": _RECORDING_AUDIO_CODEC,
-                "audio_frequency": _RECORDING_AUDIO_FREQUENCY_HZ,
-            }
+            encoding_options = build_encoding_options(resolution, profile)
 
         return cls(
             output_folder=settings.RECORDING_OUTPUT_FOLDER,

--- a/src/backend/core/recording/worker/factories.py
+++ b/src/backend/core/recording/worker/factories.py
@@ -38,16 +38,24 @@ class WorkerServiceConfig:
 
         logger.debug("Loading WorkerServiceConfig from settings.")
 
+        # The default encoding is resolved from the default profile/resolution and
+        # applied to every recording that carries no per-recording encoding.
+        # When either default is missing, we leave this as None so LiveKit falls
+        # back to its built-in preset.
+        resolution = settings.RECORDING_ENCODING_DEFAULT_RESOLUTION
+        profile = settings.RECORDING_ENCODING_DEFAULT_PROFILE
+
         encoding_options: Optional[Dict[str, Any]] = None
-        if settings.RECORDING_ENCODING_ENABLED:
-            # Single source of truth for the EncodingOptions kwargs:
-            # operator-tunable values live in Django settings, codec / frequency
-            # are pinned constants. The services layer only unpacks this dict.
+        if resolution and profile:
+            resolution_config = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[
+                resolution
+            ]
+            profile_config = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
             encoding_options = {
-                "width": settings.RECORDING_ENCODING_WIDTH,
-                "height": settings.RECORDING_ENCODING_HEIGHT,
-                "framerate": settings.RECORDING_ENCODING_FRAMERATE,
-                "video_bitrate": settings.RECORDING_ENCODING_VIDEO_BITRATE_KBPS,
+                "width": resolution_config["width"],
+                "height": resolution_config["height"],
+                "framerate": profile_config["fps"],
+                "video_bitrate": profile_config["kbps"][resolution],
                 "audio_bitrate": settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS,
                 "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
                 "video_codec": _RECORDING_VIDEO_CODEC,

--- a/src/backend/core/recording/worker/factories.py
+++ b/src/backend/core/recording/worker/factories.py
@@ -22,6 +22,37 @@ _RECORDING_AUDIO_CODEC = livekit_api.AudioCodec.AAC
 _RECORDING_AUDIO_FREQUENCY_HZ = 48000
 
 
+def _build_default_encoding_options() -> Optional[Dict[str, Any]]:
+    """Build the server-wide EncodingOptions kwargs, or None to keep LiveKit's preset.
+
+    Operator-tunable values live in Django settings; the default resolution gives
+    width / height, the default profile gives framerate and video bitrate, while
+    codec and frequency are pinned constants. Either default left empty means we
+    use the livekit defaults.
+    """
+
+    resolution = settings.RECORDING_ENCODING_DEFAULT_RESOLUTION
+    profile = settings.RECORDING_ENCODING_DEFAULT_PROFILE
+
+    if not resolution or not profile:
+        return None
+
+    dimensions = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[resolution]
+    profile_spec = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
+
+    return {
+        "width": dimensions["width"],
+        "height": dimensions["height"],
+        "framerate": profile_spec["fps"],
+        "video_bitrate": profile_spec["kbps"][resolution],
+        "audio_bitrate": settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS,
+        "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
+        "video_codec": _RECORDING_VIDEO_CODEC,
+        "audio_codec": _RECORDING_AUDIO_CODEC,
+        "audio_frequency": _RECORDING_AUDIO_FREQUENCY_HZ,
+    }
+
+
 @dataclass(frozen=True)
 class WorkerServiceConfig:
     """Declare Worker Service common configurations"""
@@ -38,22 +69,14 @@ class WorkerServiceConfig:
 
         logger.debug("Loading WorkerServiceConfig from settings.")
 
-        encoding_options: Optional[Dict[str, Any]] = None
-        if settings.RECORDING_ENCODING_ENABLED:
-            # Single source of truth for the EncodingOptions kwargs:
-            # operator-tunable values live in Django settings, codec / frequency
-            # are pinned constants. The services layer only unpacks this dict.
-            encoding_options = {
-                "width": settings.RECORDING_ENCODING_WIDTH,
-                "height": settings.RECORDING_ENCODING_HEIGHT,
-                "framerate": settings.RECORDING_ENCODING_FRAMERATE,
-                "video_bitrate": settings.RECORDING_ENCODING_VIDEO_BITRATE_KBPS,
-                "audio_bitrate": settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS,
-                "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
-                "video_codec": _RECORDING_VIDEO_CODEC,
-                "audio_codec": _RECORDING_AUDIO_CODEC,
-                "audio_frequency": _RECORDING_AUDIO_FREQUENCY_HZ,
-            }
+        # Single source of truth for the EncodingOptions kwargs; the services
+        # layer only unpacks this dict. Recordings carrying their own encoding
+        # resolve it per request and bypass this default.
+        encoding_options: Optional[Dict[str, Any]] = (
+            _build_default_encoding_options()
+            if settings.RECORDING_ENCODING_ENABLED
+            else None
+        )
 
         return cls(
             output_folder=settings.RECORDING_OUTPUT_FOLDER,

--- a/src/backend/core/recording/worker/mediator.py
+++ b/src/backend/core/recording/worker/mediator.py
@@ -47,8 +47,11 @@ class WorkerServiceMediator:
             raise RecordingStartError()
 
         room_name = str(recording.room.id)
+        encoding_options = (recording.options.get("encoding") or {}).get("resolved")
         try:
-            worker_id = self._worker_service.start(room_name, recording.id)
+            worker_id = self._worker_service.start(
+                room_name, recording.id, encoding_options=encoding_options
+            )
         except (WorkerRequestError, WorkerConnectionError, WorkerResponseError) as e:
             logger.exception(
                 "Failed to start recording for room %s: %s", recording.room.slug, e

--- a/src/backend/core/recording/worker/mediator.py
+++ b/src/backend/core/recording/worker/mediator.py
@@ -51,8 +51,11 @@ class WorkerServiceMediator:
             raise RecordingStartError()
 
         room_name = str(recording.room.id)
+        encoding_options = (recording.options.get("encoding") or {}).get("resolved")
         try:
-            worker_id = self._worker_service.start(room_name, recording.id)
+            worker_id = self._worker_service.start(
+                room_name, recording.id, encoding_options=encoding_options
+            )
         except (WorkerRequestError, WorkerConnectionError, WorkerResponseError) as e:
             logger.exception(
                 "Failed to start recording for room %s: %s", recording.room.slug, e

--- a/src/backend/core/recording/worker/services.py
+++ b/src/backend/core/recording/worker/services.py
@@ -2,6 +2,8 @@
 
 # pylint: disable=no-member
 
+from django.conf import settings
+
 from asgiref.sync import async_to_sync
 from livekit import api as livekit_api
 
@@ -9,6 +11,43 @@ from ... import utils
 from ..enums import FileExtension
 from .exceptions import WorkerConnectionError, WorkerResponseError
 from .factories import WorkerServiceConfig
+
+
+def resolve_encoding_config(encoding_config):
+    """Resolve a per-recording EncodingConfig to concrete encoding fields.
+
+    Returns a JSON-serializable dict of the LiveKit ``EncodingOptions`` kwargs
+    derived from the request's resolution / profile, or None when no
+    encoding_config is provided. This allows to derive width, height, fps, and
+    bitrate from (resolution, profile).
+
+    Only the fields that can actually be resolved are included: width/height
+    require a resolution, framerate/video_bitrate require both a resolution and a
+    profile.
+    """
+    if encoding_config is None:
+        return None
+
+    resolution = encoding_config.resolution
+    profile = encoding_config.profile
+
+    resolved = {
+        "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
+    }
+
+    if resolution:
+        width, height = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[resolution]
+        resolved["width"] = width
+        resolved["height"] = height
+
+    if resolution and profile:
+        fps, kbps_by_resolution = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[
+            profile
+        ]
+        resolved["framerate"] = fps
+        resolved["video_bitrate"] = kbps_by_resolution[resolution]
+
+    return resolved
 
 
 class BaseEgressService:
@@ -76,7 +115,7 @@ class BaseEgressService:
 
         return "FAILED_TO_STOP"
 
-    def start(self, room_name, recording_id):
+    def start(self, room_name, recording_id, encoding_options=None):
         """Start the egress process for a recording (not implemented in the base class).
         Each derived class must implement this method, providing the necessary parameters for
         its specific egress type (e.g. audio_only, streaming output).
@@ -99,13 +138,24 @@ class BaseEgressService:
 
         return livekit_api.EncodingOptions(**opts)
 
+    def _resolve_encoding_options(self, encoding_options):
+        """Build LiveKit EncodingOptions from a resolved per-recording dict, or None.
+
+        ``encoding_options`` is the dict persisted by the API in
+        ``recording.options["encoding"]["resolved"]``.
+        """
+        if not encoding_options:
+            return None
+
+        return livekit_api.EncodingOptions(**encoding_options)
+
 
 class VideoCompositeEgressService(BaseEgressService):
     """Record multiple participant video and audio tracks into a single output '.mp4' file."""
 
     hrid = "video-recording-composite-livekit-egress"
 
-    def start(self, room_name, recording_id):
+    def start(self, room_name, recording_id, encoding_options=None):
         """Start the video composite egress process for a recording."""
 
         # Save room's recording as a mp4 video file.
@@ -126,7 +176,10 @@ class VideoCompositeEgressService(BaseEgressService):
             "layout": "speaker-light",
         }
 
-        advanced = self._build_encoding_options()
+        advanced = (
+            self._resolve_encoding_options(encoding_options)
+            or self._build_encoding_options()
+        )
         if advanced is not None:
             request_kwargs["advanced"] = advanced
 
@@ -145,8 +198,13 @@ class AudioCompositeEgressService(BaseEgressService):
 
     hrid = "audio-recording-composite-livekit-egress"
 
-    def start(self, room_name, recording_id):
-        """Start the audio composite egress process for a recording."""
+    def start(self, room_name, recording_id, encoding_options=None):
+        """Start the audio composite egress process for a recording.
+
+        ``encoding_options`` is accepted for signature compatibility with the
+        WorkerService protocol but ignored: audio-only egress has no
+        encoding to configure.
+        """
 
         # Save room's recording as an ogg audio file.
         file_type = livekit_api.EncodedFileType.OGG

--- a/src/backend/core/recording/worker/services.py
+++ b/src/backend/core/recording/worker/services.py
@@ -36,16 +36,16 @@ def resolve_encoding_config(encoding_config):
     }
 
     if resolution:
-        width, height = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[resolution]
-        resolved["width"] = width
-        resolved["height"] = height
+        resolution_config = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[
+            resolution
+        ]
+        resolved["width"] = resolution_config["width"]
+        resolved["height"] = resolution_config["height"]
 
     if resolution and profile:
-        fps, kbps_by_resolution = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[
-            profile
-        ]
-        resolved["framerate"] = fps
-        resolved["video_bitrate"] = kbps_by_resolution[resolution]
+        profile_config = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
+        resolved["framerate"] = profile_config["fps"]
+        resolved["video_bitrate"] = profile_config["kbps"][resolution]
 
     return resolved
 

--- a/src/backend/core/recording/worker/services.py
+++ b/src/backend/core/recording/worker/services.py
@@ -2,8 +2,6 @@
 
 # pylint: disable=no-member
 
-from django.conf import settings
-
 from asgiref.sync import async_to_sync
 from livekit import api as livekit_api
 
@@ -11,43 +9,6 @@ from ... import utils
 from ..enums import FileExtension
 from .exceptions import WorkerConnectionError, WorkerResponseError
 from .factories import WorkerServiceConfig
-
-
-def resolve_encoding_config(encoding_config):
-    """Resolve a per-recording EncodingConfig to concrete encoding fields.
-
-    Returns a JSON-serializable dict of the LiveKit ``EncodingOptions`` kwargs
-    derived from the request's resolution / profile, or None when no
-    encoding_config is provided. This allows to derive width, height, fps, and
-    bitrate from (resolution, profile).
-
-    Only the fields that can actually be resolved are included: width/height
-    require a resolution, framerate/video_bitrate require both a resolution and a
-    profile.
-    """
-    if encoding_config is None:
-        return None
-
-    resolution = encoding_config.resolution
-    profile = encoding_config.profile
-
-    resolved = {
-        "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
-    }
-
-    if resolution:
-        resolution_config = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[
-            resolution
-        ]
-        resolved["width"] = resolution_config["width"]
-        resolved["height"] = resolution_config["height"]
-
-    if resolution and profile:
-        profile_config = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
-        resolved["framerate"] = profile_config["fps"]
-        resolved["video_bitrate"] = profile_config["kbps"][resolution]
-
-    return resolved
 
 
 class BaseEgressService:

--- a/src/backend/core/recording/worker/services.py
+++ b/src/backend/core/recording/worker/services.py
@@ -36,16 +36,14 @@ def resolve_encoding_config(encoding_config):
     }
 
     if resolution:
-        width, height = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[resolution]
-        resolved["width"] = width
-        resolved["height"] = height
+        dimensions = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[resolution]
+        resolved["width"] = dimensions["width"]
+        resolved["height"] = dimensions["height"]
 
     if resolution and profile:
-        fps, kbps_by_resolution = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[
-            profile
-        ]
-        resolved["framerate"] = fps
-        resolved["video_bitrate"] = kbps_by_resolution[resolution]
+        profile_spec = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
+        resolved["framerate"] = profile_spec["fps"]
+        resolved["video_bitrate"] = profile_spec["kbps"][resolution]
 
     return resolved
 

--- a/src/backend/core/tests/recording/worker/test_encoding_resolver.py
+++ b/src/backend/core/tests/recording/worker/test_encoding_resolver.py
@@ -1,0 +1,114 @@
+"""Tests for the per-recording encoding resolution in BaseEgressService."""
+
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+
+from unittest.mock import Mock
+
+from django.conf import settings
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from core.api.serializers import EncodingConfig
+from core.recording.worker.services import (
+    VideoCompositeEgressService,
+    resolve_encoding_config,
+)
+
+
+def make_config():
+    """Build a minimal WorkerServiceConfig-like mock for service instantiation."""
+    config = Mock()
+    config.bucket_args = {
+        "endpoint": "https://s3.test.com",
+        "access_key": "test_key",
+        "secret": "test_secret",
+        "region": "test-region",
+        "bucket": "test-bucket",
+        "force_path_style": True,
+    }
+    config.encoding_options = None
+    return config
+
+
+@pytest.fixture
+def service():
+    """Return a VideoCompositeEgressService with mocked handle_request."""
+    svc = VideoCompositeEgressService(make_config())
+    svc._handle_request = Mock()
+    return svc
+
+
+# --- resolve_encoding_config ---
+
+
+def test_resolve_config_returns_none_without_config():
+    """Resolver should return None when no encoding config is provided."""
+    assert resolve_encoding_config(None) is None
+
+
+def test_resolve_config_without_profile_omits_profile_fields():
+    """A resolution-only config should resolve dimensions but no framerate/bitrate."""
+    resolved = resolve_encoding_config(EncodingConfig(resolution="720p"))
+
+    assert resolved == {
+        "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
+        "width": 1280,
+        "height": 720,
+    }
+
+
+def test_encoding_config_requires_resolution():
+    """A profile-only or empty encoding config should be rejected at validation."""
+    with pytest.raises(PydanticValidationError):
+        EncodingConfig(profile="mixed")
+    with pytest.raises(PydanticValidationError):
+        EncodingConfig()
+
+
+# --- _resolve_encoding_options ---
+
+
+@pytest.mark.parametrize("encoding_options", [None, {}])
+def test_resolve_options_returns_none_when_empty(service, encoding_options):
+    """Resolver should return None when the resolved dict is empty or missing."""
+    assert service._resolve_encoding_options(encoding_options) is None
+
+
+@pytest.mark.parametrize(
+    "resolution",
+    list(settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS),
+)
+@pytest.mark.parametrize(
+    "profile",
+    list(settings.RECORDING_ENCODING_AVAILABLE_PROFILES),
+)
+def test_resolve_profile_resolution_combinations(service, profile, resolution):
+    """Every (profile, resolution) pair should resolve to the values from settings."""
+    expected_width, expected_height = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[
+        resolution
+    ]
+    expected_fps, kbps_by_resolution = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[
+        profile
+    ]
+    expected_bitrate = kbps_by_resolution[resolution]
+
+    resolved = resolve_encoding_config(
+        EncodingConfig(resolution=resolution, profile=profile)
+    )
+    result = service._resolve_encoding_options(resolved)
+
+    assert result.width == expected_width
+    assert result.height == expected_height
+    assert result.framerate == expected_fps
+    assert result.video_bitrate == expected_bitrate
+
+
+def test_resolve_options_none_profile_uses_livekit_defaults(service):
+    """Missing profile should pass 0 fps/bitrate (LiveKit protobuf default)."""
+    resolved = resolve_encoding_config(EncodingConfig(resolution="720p"))
+    result = service._resolve_encoding_options(resolved)
+    assert result.width == 1280
+    assert result.height == 720
+    assert result.framerate == 0
+    assert result.video_bitrate == 0

--- a/src/backend/core/tests/recording/worker/test_encoding_resolver.py
+++ b/src/backend/core/tests/recording/worker/test_encoding_resolver.py
@@ -1,6 +1,6 @@
 """Tests for the per-recording encoding resolution in BaseEgressService."""
 
-# pylint: disable=protected-access,redefined-outer-name,unused-argument
+# pylint: disable=protected-access,redefined-outer-name,unused-argument,no-member
 
 from unittest.mock import Mock
 

--- a/src/backend/core/tests/recording/worker/test_encoding_resolver.py
+++ b/src/backend/core/tests/recording/worker/test_encoding_resolver.py
@@ -7,13 +7,12 @@ from unittest.mock import Mock
 from django.conf import settings
 
 import pytest
+from livekit import api as livekit_api
 from pydantic import ValidationError as PydanticValidationError
 
 from core.api.serializers import EncodingConfig
-from core.recording.worker.services import (
-    VideoCompositeEgressService,
-    resolve_encoding_config,
-)
+from core.recording.worker.factories import build_encoding_options
+from core.recording.worker.services import VideoCompositeEgressService
 
 
 def make_config():
@@ -39,23 +38,28 @@ def service():
     return svc
 
 
-# --- resolve_encoding_config ---
+# --- build_encoding_options ---
 
 
-def test_resolve_config_returns_none_without_config():
-    """Resolver should return None when no encoding config is provided."""
-    assert resolve_encoding_config(None) is None
+def test_build_options_without_profile_omits_profile_fields():
+    """A resolution-only config should resolve dimensions but no framerate/bitrate.
 
-
-def test_resolve_config_without_profile_omits_profile_fields():
-    """A resolution-only config should resolve dimensions but no framerate/bitrate."""
-    resolved = resolve_encoding_config(EncodingConfig(resolution="720p"))
+    The profile-independent fields (audio bitrate, keyframe interval, codec /
+    frequency pins) are always present, matching the default encoding.
+    """
+    resolved = build_encoding_options("720p", None)
 
     assert resolved == {
+        "audio_bitrate": settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS,
         "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
+        "video_codec": livekit_api.VideoCodec.H264_MAIN,
+        "audio_codec": livekit_api.AudioCodec.AAC,
+        "audio_frequency": 48000,
         "width": 1280,
         "height": 720,
     }
+    assert "framerate" not in resolved
+    assert "video_bitrate" not in resolved
 
 
 def test_encoding_config_requires_resolution():
@@ -92,22 +96,31 @@ def test_resolve_profile_resolution_combinations(service, profile, resolution):
     expected_fps = profile_config["fps"]
     expected_bitrate = profile_config["kbps"][resolution]
 
-    resolved = resolve_encoding_config(
-        EncodingConfig(resolution=resolution, profile=profile)
-    )
+    resolved = build_encoding_options(resolution, profile)
     result = service._resolve_encoding_options(resolved)
 
     assert result.width == expected_width
     assert result.height == expected_height
     assert result.framerate == expected_fps
     assert result.video_bitrate == expected_bitrate
+    # Profile-independent fields match the default encoding, never dropped.
+    assert result.audio_bitrate == settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS
+    assert result.video_codec == livekit_api.VideoCodec.H264_MAIN
+    assert result.audio_codec == livekit_api.AudioCodec.AAC
+    assert result.audio_frequency == 48000
 
 
 def test_resolve_options_none_profile_uses_livekit_defaults(service):
-    """Missing profile should pass 0 fps/bitrate (LiveKit protobuf default)."""
-    resolved = resolve_encoding_config(EncodingConfig(resolution="720p"))
+    """Missing profile should pass 0 fps/bitrate (LiveKit protobuf default).
+
+    The pinned codec / audio fields are still applied even without a profile.
+    """
+    resolved = build_encoding_options("720p", None)
     result = service._resolve_encoding_options(resolved)
     assert result.width == 1280
     assert result.height == 720
     assert result.framerate == 0
     assert result.video_bitrate == 0
+    assert result.audio_bitrate == settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS
+    assert result.video_codec == livekit_api.VideoCodec.H264_MAIN
+    assert result.audio_codec == livekit_api.AudioCodec.AAC

--- a/src/backend/core/tests/recording/worker/test_encoding_resolver.py
+++ b/src/backend/core/tests/recording/worker/test_encoding_resolver.py
@@ -85,13 +85,12 @@ def test_resolve_options_returns_none_when_empty(service, encoding_options):
 )
 def test_resolve_profile_resolution_combinations(service, profile, resolution):
     """Every (profile, resolution) pair should resolve to the values from settings."""
-    expected_width, expected_height = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[
-        resolution
-    ]
-    expected_fps, kbps_by_resolution = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[
-        profile
-    ]
-    expected_bitrate = kbps_by_resolution[resolution]
+    resolution_config = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[resolution]
+    expected_width = resolution_config["width"]
+    expected_height = resolution_config["height"]
+    profile_config = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
+    expected_fps = profile_config["fps"]
+    expected_bitrate = profile_config["kbps"][resolution]
 
     resolved = resolve_encoding_config(
         EncodingConfig(resolution=resolution, profile=profile)

--- a/src/backend/core/tests/recording/worker/test_encoding_resolver.py
+++ b/src/backend/core/tests/recording/worker/test_encoding_resolver.py
@@ -85,23 +85,18 @@ def test_resolve_options_returns_none_when_empty(service, encoding_options):
 )
 def test_resolve_profile_resolution_combinations(service, profile, resolution):
     """Every (profile, resolution) pair should resolve to the values from settings."""
-    expected_width, expected_height = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[
-        resolution
-    ]
-    expected_fps, kbps_by_resolution = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[
-        profile
-    ]
-    expected_bitrate = kbps_by_resolution[resolution]
+    dimensions = settings.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS[resolution]
+    profile_spec = settings.RECORDING_ENCODING_AVAILABLE_PROFILES[profile]
 
     resolved = resolve_encoding_config(
         EncodingConfig(resolution=resolution, profile=profile)
     )
     result = service._resolve_encoding_options(resolved)
 
-    assert result.width == expected_width
-    assert result.height == expected_height
-    assert result.framerate == expected_fps
-    assert result.video_bitrate == expected_bitrate
+    assert result.width == dimensions["width"]
+    assert result.height == dimensions["height"]
+    assert result.framerate == profile_spec["fps"]
+    assert result.video_bitrate == profile_spec["kbps"][resolution]
 
 
 def test_resolve_options_none_profile_uses_livekit_defaults(service):

--- a/src/backend/core/tests/recording/worker/test_factories.py
+++ b/src/backend/core/tests/recording/worker/test_factories.py
@@ -121,9 +121,7 @@ def test_config_encoding_options_default(custom_encoding_enabled):
     per-recording API, so both toggle states produce the same default.
     """
 
-    with override_settings(
-        RECORDING_CUSTOM_ENCODING_ENABLED=custom_encoding_enabled
-    ):
+    with override_settings(RECORDING_CUSTOM_ENCODING_ENABLED=custom_encoding_enabled):
         WorkerServiceConfig.from_settings.cache_clear()
         config = WorkerServiceConfig.from_settings()
 

--- a/src/backend/core/tests/recording/worker/test_factories.py
+++ b/src/backend/core/tests/recording/worker/test_factories.py
@@ -40,6 +40,16 @@ def test_settings():
         "AWS_S3_SECRET_ACCESS_KEY": "test_secret",
         "AWS_S3_REGION_NAME": "test-region",
         "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+        "RECORDING_ENCODING_AVAILABLE_RESOLUTIONS": {
+            "720p": {"width": 1280, "height": 720}
+        },
+        "RECORDING_ENCODING_AVAILABLE_PROFILES": {
+            "full": {"fps": 30, "kbps": {"720p": 3000}}
+        },
+        "RECORDING_ENCODING_DEFAULT_RESOLUTION": "720p",
+        "RECORDING_ENCODING_DEFAULT_PROFILE": "full",
+        "RECORDING_ENCODING_AUDIO_BITRATE_KBPS": 128,
+        "RECORDING_ENCODING_KEY_FRAME_INTERVAL_S": 4.0,
     }
 
     # Use override_settings to properly patch Django settings
@@ -66,8 +76,18 @@ def test_config_initialization(default_config):
         "bucket": "test-bucket",
         "force_path_style": True,
     }
-    # Encoding override is opt-in; disabled by default.
-    assert default_config.encoding_options is None
+    # The default encoding is always resolved from the default profile/resolution.
+    assert default_config.encoding_options == {
+        "width": 1280,
+        "height": 720,
+        "framerate": 30,
+        "video_bitrate": 3000,
+        "audio_bitrate": 128,
+        "key_frame_interval": 4.0,
+        "video_codec": livekit_api_codec.VideoCodec.H264_MAIN,
+        "audio_codec": livekit_api_codec.AudioCodec.AAC,
+        "audio_frequency": 48000,
+    }
 
 
 def test_config_immutability(default_config):
@@ -76,6 +96,7 @@ def test_config_immutability(default_config):
         default_config.output_folder = "new/path"
 
 
+@pytest.mark.parametrize("custom_encoding_enabled", [True, False])
 @override_settings(
     RECORDING_OUTPUT_FOLDER="/test/output",
     LIVEKIT_CONFIGURATION={"server": "test.example.com"},
@@ -84,23 +105,27 @@ def test_config_immutability(default_config):
     AWS_S3_SECRET_ACCESS_KEY="test_secret",
     AWS_S3_REGION_NAME="test-region",
     AWS_STORAGE_BUCKET_NAME="test-bucket",
-    RECORDING_ENCODING_ENABLED=True,
-    RECORDING_ENCODING_WIDTH=1280,
-    RECORDING_ENCODING_HEIGHT=720,
-    RECORDING_ENCODING_FRAMERATE=15,
-    RECORDING_ENCODING_VIDEO_BITRATE_KBPS=600,
+    RECORDING_ENCODING_AVAILABLE_RESOLUTIONS={"720p": {"width": 1280, "height": 720}},
+    RECORDING_ENCODING_AVAILABLE_PROFILES={"low": {"fps": 15, "kbps": {"720p": 600}}},
+    RECORDING_ENCODING_DEFAULT_RESOLUTION="720p",
+    RECORDING_ENCODING_DEFAULT_PROFILE="low",
     RECORDING_ENCODING_AUDIO_BITRATE_KBPS=64,
     RECORDING_ENCODING_KEY_FRAME_INTERVAL_S=10.0,
 )
-def test_config_encoding_options_enabled():
-    """When RECORDING_ENCODING_ENABLED is True, encoding options are populated.
+def test_config_encoding_options_default(custom_encoding_enabled):
+    """The default encoding is always resolved from the default profile/resolution.
 
-    The dict mixes operator-tunable values from settings with pinned codec /
-    frequency constants, so the services layer can simply unpack it.
+    The default fallback resolves the default profile/resolution and mixes those
+    operator-tunable values with pinned codec / frequency constants. This works
+    regardless of RECORDING_CUSTOM_ENCODING_ENABLED, which only gates the
+    per-recording API, so both toggle states produce the same default.
     """
 
-    WorkerServiceConfig.from_settings.cache_clear()
-    config = WorkerServiceConfig.from_settings()
+    with override_settings(
+        RECORDING_CUSTOM_ENCODING_ENABLED=custom_encoding_enabled
+    ):
+        WorkerServiceConfig.from_settings.cache_clear()
+        config = WorkerServiceConfig.from_settings()
 
     assert config.encoding_options == {
         "width": 1280,
@@ -113,6 +138,27 @@ def test_config_encoding_options_enabled():
         "audio_codec": livekit_api_codec.AudioCodec.AAC,
         "audio_frequency": 48000,
     }
+
+
+@pytest.mark.parametrize(
+    ("default_resolution", "default_profile"),
+    [("", "full"), ("720p", ""), ("", "")],
+)
+def test_config_encoding_options_none_when_default_missing(
+    test_settings, default_resolution, default_profile
+):
+    """A missing default resolution/profile leaves encoding_options None.
+
+    The service then omits the `advanced` field so LiveKit uses its built-in preset.
+    """
+    with override_settings(
+        RECORDING_ENCODING_DEFAULT_RESOLUTION=default_resolution,
+        RECORDING_ENCODING_DEFAULT_PROFILE=default_profile,
+    ):
+        WorkerServiceConfig.from_settings.cache_clear()
+        config = WorkerServiceConfig.from_settings()
+
+    assert config.encoding_options is None
 
 
 @override_settings(

--- a/src/backend/core/tests/recording/worker/test_factories.py
+++ b/src/backend/core/tests/recording/worker/test_factories.py
@@ -85,18 +85,22 @@ def test_config_immutability(default_config):
     AWS_S3_REGION_NAME="test-region",
     AWS_STORAGE_BUCKET_NAME="test-bucket",
     RECORDING_ENCODING_ENABLED=True,
-    RECORDING_ENCODING_WIDTH=1280,
-    RECORDING_ENCODING_HEIGHT=720,
-    RECORDING_ENCODING_FRAMERATE=15,
-    RECORDING_ENCODING_VIDEO_BITRATE_KBPS=600,
+    RECORDING_ENCODING_AVAILABLE_RESOLUTIONS={
+        "720p": {"width": 1280, "height": 720},
+    },
+    RECORDING_ENCODING_AVAILABLE_PROFILES={
+        "talking_heads": {"fps": 15, "kbps": {"720p": 600}},
+    },
+    RECORDING_ENCODING_DEFAULT_RESOLUTION="720p",
+    RECORDING_ENCODING_DEFAULT_PROFILE="talking_heads",
     RECORDING_ENCODING_AUDIO_BITRATE_KBPS=64,
     RECORDING_ENCODING_KEY_FRAME_INTERVAL_S=10.0,
 )
 def test_config_encoding_options_enabled():
     """When RECORDING_ENCODING_ENABLED is True, encoding options are populated.
 
-    The dict mixes operator-tunable values from settings with pinned codec /
-    frequency constants, so the services layer can simply unpack it.
+    The dict mixes values resolved from the default resolution / profile with
+    pinned codec / frequency constants, so the services layer can simply unpack it.
     """
 
     WorkerServiceConfig.from_settings.cache_clear()
@@ -113,6 +117,27 @@ def test_config_encoding_options_enabled():
         "audio_codec": livekit_api_codec.AudioCodec.AAC,
         "audio_frequency": 48000,
     }
+
+
+@override_settings(
+    RECORDING_OUTPUT_FOLDER="/test/output",
+    LIVEKIT_CONFIGURATION={"server": "test.example.com"},
+    AWS_S3_ENDPOINT_URL="https://s3.test.com",
+    AWS_S3_ACCESS_KEY_ID="test_key",
+    AWS_S3_SECRET_ACCESS_KEY="test_secret",
+    AWS_S3_REGION_NAME="test-region",
+    AWS_STORAGE_BUCKET_NAME="test-bucket",
+    RECORDING_ENCODING_ENABLED=True,
+    RECORDING_ENCODING_DEFAULT_RESOLUTION="",
+    RECORDING_ENCODING_DEFAULT_PROFILE="",
+)
+def test_config_encoding_options_without_defaults():
+    """An empty default resolution or profile leaves the encoding to LiveKit."""
+
+    WorkerServiceConfig.from_settings.cache_clear()
+    config = WorkerServiceConfig.from_settings()
+
+    assert config.encoding_options is None
 
 
 @override_settings(

--- a/src/backend/core/tests/recording/worker/test_mediator.py
+++ b/src/backend/core/tests/recording/worker/test_mediator.py
@@ -52,7 +52,7 @@ def test_start_recording_success(
     # Verify worker service call
     expected_room_name = str(mock_recording.room.id)
     mock_worker_service.start.assert_called_once_with(
-        expected_room_name, mock_recording.id
+        expected_room_name, mock_recording.id, encoding_options=None
     )
 
     # Verify recording updates
@@ -63,6 +63,38 @@ def test_start_recording_success(
     mock_update_room_metadata.assert_called_once_with(
         str(mock_recording.room.id),
         {"recording_mode": mock_recording.mode, "recording_status": "starting"},
+    )
+
+
+@mock.patch("core.utils.update_room_metadata")
+def test_start_recording_passes_resolved_encoding(
+    mock_update_room_metadata, mediator, mock_worker_service
+):
+    """The resolved encoding persisted in recording.options reaches the worker."""
+    mock_worker_service.start.return_value = "test-worker-123"
+
+    resolved = {
+        "key_frame_interval": 4.0,
+        "width": 1280,
+        "height": 720,
+        "framerate": 15,
+        "video_bitrate": 700,
+    }
+    mock_recording = RecordingFactory(
+        status=RecordingStatusChoices.INITIATED,
+        worker_id=None,
+        options={
+            "encoding": {
+                "resolution": "720p",
+                "profile": "talking_heads",
+                "resolved": resolved,
+            }
+        },
+    )
+    mediator.start(mock_recording)
+
+    mock_worker_service.start.assert_called_once_with(
+        str(mock_recording.room.id), mock_recording.id, encoding_options=resolved
     )
 
 

--- a/src/backend/core/tests/recording/worker/test_mediator.py
+++ b/src/backend/core/tests/recording/worker/test_mediator.py
@@ -50,7 +50,7 @@ def test_start_recording_success(mock_update_metadata, mediator, mock_worker_ser
     # Verify worker service call
     expected_room_name = str(mock_recording.room.id)
     mock_worker_service.start.assert_called_once_with(
-        expected_room_name, mock_recording.id
+        expected_room_name, mock_recording.id, encoding_options=None
     )
 
     # Verify recording updates
@@ -61,6 +61,38 @@ def test_start_recording_success(mock_update_metadata, mediator, mock_worker_ser
     mock_update_metadata.assert_called_once_with(
         str(mock_recording.room.id),
         {"recording_mode": mock_recording.mode, "recording_status": "starting"},
+    )
+
+
+@mock.patch("core.utils.update_room_metadata")
+def test_start_recording_passes_resolved_encoding(
+    mock_update_room_metadata, mediator, mock_worker_service
+):
+    """The resolved encoding persisted in recording.options reaches the worker."""
+    mock_worker_service.start.return_value = "test-worker-123"
+
+    resolved = {
+        "key_frame_interval": 4.0,
+        "width": 1280,
+        "height": 720,
+        "framerate": 15,
+        "video_bitrate": 700,
+    }
+    mock_recording = RecordingFactory(
+        status=RecordingStatusChoices.INITIATED,
+        worker_id=None,
+        options={
+            "encoding": {
+                "resolution": "720p",
+                "profile": "talking_heads",
+                "resolved": resolved,
+            }
+        },
+    )
+    mediator.start(mock_recording)
+
+    mock_worker_service.start.assert_called_once_with(
+        str(mock_recording.room.id), mock_recording.id, encoding_options=resolved
     )
 
 

--- a/src/backend/core/tests/rooms/test_api_rooms_start_recording.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_start_recording.py
@@ -470,6 +470,160 @@ def test_start_recording_options_unknown_field_rejected(settings):
     assert response.status_code == 400
 
 
+def test_start_recording_options_encoding_valid(
+    settings, mock_worker_service_factory, mock_worker_manager
+):
+    """Should accept a valid encoding configuration."""
+    settings.RECORDING_ENABLE = True
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role="owner")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/start-recording/",
+        {
+            "mode": "screen_recording",
+            "options": {"encoding": {"resolution": "720p", "profile": "talking_heads"}},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201
+
+
+def test_start_recording_persists_resolved_encoding(
+    settings, mock_worker_service_factory, mock_worker_manager
+):
+    """The resolved encoding should be persisted in recording.options alongside
+    the requested resolution/profile for traceability."""
+    settings.RECORDING_ENABLE = True
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role="owner")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/start-recording/",
+        {
+            "mode": "screen_recording",
+            "options": {"encoding": {"resolution": "720p", "profile": "talking_heads"}},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201
+    recording = Recording.objects.get(room=room)
+    assert recording.options["encoding"] == {
+        "resolution": "720p",
+        "profile": "talking_heads",
+        "resolved": {
+            "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
+            "width": 1280,
+            "height": 720,
+            "framerate": 15,
+            "video_bitrate": 700,
+        },
+    }
+
+
+def test_start_recording_forwards_resolved_encoding_to_worker(
+    settings, mock_worker_service, mock_worker_service_factory
+):
+    """The resolved encoding should passed on to the worker."""
+    settings.RECORDING_ENABLE = True
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role="owner")
+    client = APIClient()
+    client.force_login(user)
+
+    mock_worker_service.start.return_value = "egress-123"
+
+    with mock.patch("core.utils.update_room_metadata"):
+        response = client.post(
+            f"/api/v1.0/rooms/{room.id}/start-recording/",
+            {
+                "mode": "screen_recording",
+                "options": {
+                    "encoding": {"resolution": "720p", "profile": "talking_heads"}
+                },
+            },
+            format="json",
+        )
+
+    assert response.status_code == 201
+    recording = Recording.objects.get(room=room)
+    mock_worker_service.start.assert_called_once_with(
+        str(room.id),
+        recording.id,
+        encoding_options=recording.options["encoding"]["resolved"],
+    )
+
+
+def test_start_recording_options_encoding_invalid_resolution(settings):
+    """Should reject invalid encoding resolution values."""
+    settings.RECORDING_ENABLE = True
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role="owner")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/start-recording/",
+        {"mode": "screen_recording", "options": {"encoding": {"resolution": "4K"}}},
+        format="json",
+    )
+
+    assert response.status_code == 400
+
+
+def test_start_recording_options_encoding_unknown_key_rejected(settings):
+    """Should reject unknown keys in encoding configuration."""
+    settings.RECORDING_ENABLE = True
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role="owner")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/start-recording/",
+        {
+            "mode": "screen_recording",
+            "options": {"encoding": {"bitrate": 9000}},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+
+
+def test_start_recording_options_without_encoding_unchanged(
+    settings, mock_worker_service_factory, mock_worker_manager
+):
+    """Requests without encoding should keep existing options behavior."""
+    settings.RECORDING_ENABLE = True
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role="owner")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/start-recording/",
+        {"mode": "screen_recording", "options": {"language": "fr"}},
+        format="json",
+    )
+
+    assert response.status_code == 201
+    recording = Recording.objects.get(room=room)
+    assert recording.options == {"language": "fr"}
+
+
 @pytest.mark.parametrize("value", ["foo", 12])
 def test_start_recording_options_invalid_transcribe_type(settings, value):
     """Should reject non-boolean transcribe values."""

--- a/src/backend/core/tests/rooms/test_api_rooms_start_recording.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_start_recording.py
@@ -475,6 +475,7 @@ def test_start_recording_options_encoding_valid(
 ):
     """Should accept a valid encoding configuration."""
     settings.RECORDING_ENABLE = True
+    settings.RECORDING_CUSTOM_ENCODING_ENABLED = True
     room = RoomFactory()
     user = UserFactory()
     room.accesses.create(user=user, role="owner")
@@ -493,12 +494,38 @@ def test_start_recording_options_encoding_valid(
     assert response.status_code == 201
 
 
+def test_start_recording_options_encoding_rejected_when_custom_encoding_disabled(
+    settings, mock_worker_service_factory, mock_worker_manager
+):
+    """Per-recording encoding is rejected when RECORDING_CUSTOM_ENCODING_ENABLED is off."""
+    settings.RECORDING_ENABLE = True
+    settings.RECORDING_CUSTOM_ENCODING_ENABLED = False
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role="owner")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/start-recording/",
+        {
+            "mode": "screen_recording",
+            "options": {"encoding": {"resolution": "720p", "profile": "talking_heads"}},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert not Recording.objects.filter(room=room).exists()
+
+
 def test_start_recording_persists_resolved_encoding(
     settings, mock_worker_service_factory, mock_worker_manager
 ):
     """The resolved encoding should be persisted in recording.options alongside
     the requested resolution/profile for traceability."""
     settings.RECORDING_ENABLE = True
+    settings.RECORDING_CUSTOM_ENCODING_ENABLED = True
     room = RoomFactory()
     user = UserFactory()
     room.accesses.create(user=user, role="owner")
@@ -534,6 +561,7 @@ def test_start_recording_forwards_resolved_encoding_to_worker(
 ):
     """The resolved encoding should passed on to the worker."""
     settings.RECORDING_ENABLE = True
+    settings.RECORDING_CUSTOM_ENCODING_ENABLED = True
     room = RoomFactory()
     user = UserFactory()
     room.accesses.create(user=user, role="owner")
@@ -566,6 +594,7 @@ def test_start_recording_forwards_resolved_encoding_to_worker(
 def test_start_recording_options_encoding_invalid_resolution(settings):
     """Should reject invalid encoding resolution values."""
     settings.RECORDING_ENABLE = True
+    settings.RECORDING_CUSTOM_ENCODING_ENABLED = True
     room = RoomFactory()
     user = UserFactory()
     room.accesses.create(user=user, role="owner")
@@ -584,6 +613,7 @@ def test_start_recording_options_encoding_invalid_resolution(settings):
 def test_start_recording_options_encoding_unknown_key_rejected(settings):
     """Should reject unknown keys in encoding configuration."""
     settings.RECORDING_ENABLE = True
+    settings.RECORDING_CUSTOM_ENCODING_ENABLED = True
     room = RoomFactory()
     user = UserFactory()
     room.accesses.create(user=user, role="owner")

--- a/src/backend/core/tests/rooms/test_api_rooms_start_recording.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_start_recording.py
@@ -2,7 +2,7 @@
 Test rooms API endpoints in the Meet core app: start recording.
 """
 
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name,unused-argument,no-member
 
 from unittest import mock
 

--- a/src/backend/core/tests/rooms/test_api_rooms_start_recording.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_start_recording.py
@@ -7,6 +7,7 @@ Test rooms API endpoints in the Meet core app: start recording.
 from unittest import mock
 
 import pytest
+from livekit import api as livekit_api
 from rest_framework.test import APIClient
 
 from ...factories import RoomFactory, UserFactory
@@ -547,7 +548,11 @@ def test_start_recording_persists_resolved_encoding(
         "resolution": "720p",
         "profile": "talking_heads",
         "resolved": {
+            "audio_bitrate": settings.RECORDING_ENCODING_AUDIO_BITRATE_KBPS,
             "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
+            "video_codec": livekit_api.VideoCodec.H264_MAIN,
+            "audio_codec": livekit_api.AudioCodec.AAC,
+            "audio_frequency": 48000,
             "width": 1280,
             "height": 720,
             "framerate": 15,

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -721,17 +721,25 @@ class Base(Configuration):
     # These settings affect screen recordings handled by VideoCompositeEgressService;
     # they are silently ignored by AudioCompositeEgressService (audio-only transcript
     # recordings), whose request never carries advanced EncodingOptions.
-    # When disabled, LiveKit falls back to its built-in H264_720P_30 preset
-    # (1280x720, 30 fps, 3000 kbps H.264 MAIN video, 128 kbps AAC audio).
-    # When enabled, the encoding parameters are resolved from the default profile
-    # and resolution below and passed to LiveKit as EncodingOptions (advanced),
-    # replacing the preset. Lowering framerate and bitrate reduces output file
-    # size and CPU load on the egress worker.
-    RECORDING_ENCODING_ENABLED = values.BooleanValue(
-        False, environ_name="RECORDING_ENCODING_ENABLED", environ_prefix=None
+    #
+    # A default encoding is applied to every recording: it is resolved from the default
+    # profile and resolution below and passed to LiveKit as EncodingOptions (advanced),
+    # replacing LiveKit's built-in H264_720P_30 preset. Lowering framerate and bitrate
+    # reduces output file size and CPU load on the egress worker. If either
+    # RECORDING_ENCODING_DEFAULT_RESOLUTION or RECORDING_ENCODING_DEFAULT_PROFILE is
+    # unset, no default encoding is built (a startup warning is emitted) and LiveKit's
+    # built-in preset is used instead.
+    #
+    # RECORDING_CUSTOM_ENCODING_ENABLED gates whether the start-recording API lets a
+    # client override that default per recording (via an `encoding` object selecting a
+    # resolution/profile). When False, the API rejects per-recording `encoding` and
+    # every recording uses the default; when True, clients may pick from the
+    # available resolutions/profiles below.
+    RECORDING_CUSTOM_ENCODING_ENABLED = values.BooleanValue(
+        False, environ_name="RECORDING_CUSTOM_ENCODING_ENABLED", environ_prefix=None
     )
 
-    # Map resolution string -> (width, height) in pixels.
+    # Map resolution string -> {"width", "height"} in pixels.
     RECORDING_ENCODING_AVAILABLE_RESOLUTIONS = values.DictValue(
         {
             "540p": {"width": 960, "height": 540},
@@ -742,6 +750,7 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # Map profile string -> {"fps", "kbps": {resolution: video_bitrate_kbps}}.
     # Bitrate scales with resolution so quality stays consistent across sizes.
     RECORDING_ENCODING_AVAILABLE_PROFILES = values.DictValue(
         {
@@ -1165,14 +1174,20 @@ class Base(Configuration):
 
         Every profile in RECORDING_ENCODING_AVAILABLE_PROFILES must define a bitrate for
         each resolution declared in RECORDING_ENCODING_AVAILABLE_RESOLUTIONS.
+
+        The default profile / resolution feed the default encoding. When either is
+        missing, no custom default encoding can be built: a warning is emitted and
+        recordings fall back to LiveKit's built-in preset. When both are set, they
+        must reference keys that actually exist in the maps above.
         """
         resolutions = set(cls.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS)
-        for profile, (
-            _fps,
-            kbps_by_resolution,
-            # DictValue resolves to a dict at runtime; pylint sees the descriptor.
+        profiles = set(cls.RECORDING_ENCODING_AVAILABLE_PROFILES)
+        # DictValue resolves to a dict at runtime; pylint sees the descriptor.
+        for (
+            profile,
+            profile_config,
         ) in cls.RECORDING_ENCODING_AVAILABLE_PROFILES.items():  # pylint: disable=no-member
-            profile_resolutions = set(kbps_by_resolution)
+            profile_resolutions = set(profile_config["kbps"])
             if profile_resolutions != resolutions:
                 raise ValueError(
                     f"Profile '{profile}' in RECORDING_ENCODING_AVAILABLE_PROFILES must "
@@ -1180,6 +1195,42 @@ class Base(Configuration):
                     "RECORDING_ENCODING_AVAILABLE_RESOLUTIONS, mismatch on: "
                     f"{resolutions ^ profile_resolutions}"
                 )
+
+        missing = [
+            name
+            for name, value in (
+                (
+                    "RECORDING_ENCODING_DEFAULT_RESOLUTION",
+                    cls.RECORDING_ENCODING_DEFAULT_RESOLUTION,
+                ),
+                (
+                    "RECORDING_ENCODING_DEFAULT_PROFILE",
+                    cls.RECORDING_ENCODING_DEFAULT_PROFILE,
+                ),
+            )
+            if not value
+        ]
+        if missing:
+            warnings.warn(
+                f"{' and '.join(missing)} not set; recordings will use LiveKit's "
+                "built-in encoding preset instead of a custom default encoding.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return
+
+        if cls.RECORDING_ENCODING_DEFAULT_RESOLUTION not in resolutions:
+            raise ValueError(
+                "RECORDING_ENCODING_DEFAULT_RESOLUTION "
+                f"'{cls.RECORDING_ENCODING_DEFAULT_RESOLUTION}' is not a key of "
+                f"RECORDING_ENCODING_AVAILABLE_RESOLUTIONS ({sorted(resolutions)})."
+            )
+        if cls.RECORDING_ENCODING_DEFAULT_PROFILE not in profiles:
+            raise ValueError(
+                "RECORDING_ENCODING_DEFAULT_PROFILE "
+                f"'{cls.RECORDING_ENCODING_DEFAULT_PROFILE}' is not a key of "
+                f"RECORDING_ENCODING_AVAILABLE_PROFILES ({sorted(profiles)})."
+            )
 
     @classmethod
     def post_setup(cls):

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -723,26 +723,63 @@ class Base(Configuration):
     # recordings), whose request never carries advanced EncodingOptions.
     # When disabled, LiveKit falls back to its built-in H264_720P_30 preset
     # (1280x720, 30 fps, 3000 kbps H.264 MAIN video, 128 kbps AAC audio).
-    # When enabled, the values below are passed to LiveKit as EncodingOptions
-    # (advanced) and replace the preset. Lowering framerate and bitrate reduces
-    # output file size and CPU load on the egress worker.
+    # When enabled, the encoding parameters are resolved from the default profile
+    # and resolution below and passed to LiveKit as EncodingOptions (advanced),
+    # replacing the preset. Lowering framerate and bitrate reduces output file
+    # size and CPU load on the egress worker.
     RECORDING_ENCODING_ENABLED = values.BooleanValue(
         False, environ_name="RECORDING_ENCODING_ENABLED", environ_prefix=None
     )
-    RECORDING_ENCODING_WIDTH = values.PositiveIntegerValue(
-        1280, environ_name="RECORDING_ENCODING_WIDTH", environ_prefix=None
-    )
-    RECORDING_ENCODING_HEIGHT = values.PositiveIntegerValue(
-        720, environ_name="RECORDING_ENCODING_HEIGHT", environ_prefix=None
-    )
-    RECORDING_ENCODING_FRAMERATE = values.PositiveIntegerValue(
-        30, environ_name="RECORDING_ENCODING_FRAMERATE", environ_prefix=None
-    )
-    RECORDING_ENCODING_VIDEO_BITRATE_KBPS = values.PositiveIntegerValue(
-        3000,
-        environ_name="RECORDING_ENCODING_VIDEO_BITRATE_KBPS",
+
+    # Map resolution string -> (width, height) in pixels.
+    RECORDING_ENCODING_AVAILABLE_RESOLUTIONS = values.DictValue(
+        {
+            "540p": {"width": 960, "height": 540},
+            "720p": {"width": 1280, "height": 720},
+            "1080p": {"width": 1920, "height": 1080},
+        },
+        environ_name="RECORDING_ENCODING_AVAILABLE_RESOLUTIONS",
         environ_prefix=None,
     )
+
+    # Bitrate scales with resolution so quality stays consistent across sizes.
+    RECORDING_ENCODING_AVAILABLE_PROFILES = values.DictValue(
+        {
+            "talking_heads": {
+                "fps": 15,
+                "kbps": {"540p": 400, "720p": 700, "1080p": 1200},
+            },
+            "text": {
+                "fps": 15,
+                "kbps": {"540p": 600, "720p": 1000, "1080p": 1800},
+            },
+            "mixed": {
+                "fps": 20,
+                "kbps": {"540p": 900, "720p": 1500, "1080p": 2500},
+            },
+            "full": {
+                "fps": 30,
+                "kbps": {"540p": 2000, "720p": 3000, "1080p": 4500},
+            },
+        },
+        environ_name="RECORDING_ENCODING_AVAILABLE_PROFILES",
+        environ_prefix=None,
+    )
+
+    # Defaults used when no profile/resolution is specified per recording.
+    # Must be keys of the two dicts above (validated at startup).
+    RECORDING_ENCODING_DEFAULT_PROFILE = values.Value(
+        "full",
+        environ_name="RECORDING_ENCODING_DEFAULT_PROFILE",
+        environ_prefix=None,
+    )
+    RECORDING_ENCODING_DEFAULT_RESOLUTION = values.Value(
+        "720p",
+        environ_name="RECORDING_ENCODING_DEFAULT_RESOLUTION",
+        environ_prefix=None,
+    )
+
+    # Settings independent of profile/resolution.
     RECORDING_ENCODING_AUDIO_BITRATE_KBPS = values.PositiveIntegerValue(
         128,
         environ_name="RECORDING_ENCODING_AUDIO_BITRATE_KBPS",
@@ -751,37 +788,6 @@ class Base(Configuration):
     RECORDING_ENCODING_KEY_FRAME_INTERVAL_S = values.FloatValue(
         4.0,
         environ_name="RECORDING_ENCODING_KEY_FRAME_INTERVAL_S",
-        environ_prefix=None,
-    )
-
-    # Per-recording encoding presets for the start-recording API.
-    # Unlike the global RECORDING_ENCODING_* values above (a single fixed
-    # preset), these maps let a recording request pick a resolution and a
-    # quality profile. To add a resolution: add one entry to
-    # RECORDING_ENCODING_AVAILABLE_RESOLUTIONS and one bitrate per profile in
-    # RECORDING_ENCODING_AVAILABLE_PROFILES. To add a profile: add one entry to
-    # RECORDING_ENCODING_AVAILABLE_PROFILES with a bitrate per resolution. No
-    # control-flow changes needed elsewhere.
-
-    # Map resolution string -> (width, height) in pixels.
-    RECORDING_ENCODING_AVAILABLE_RESOLUTIONS = values.DictValue(
-        {
-            "540p": (960, 540),
-            "720p": (1280, 720),
-            "1080p": (1920, 1080),
-        },
-        environ_name="RECORDING_ENCODING_AVAILABLE_RESOLUTIONS",
-        environ_prefix=None,
-    )
-    # Bitrate scales with resolution so quality stays consistent across sizes.
-    RECORDING_ENCODING_AVAILABLE_PROFILES = values.DictValue(
-        {
-            # profile: (fps, kbps per resolution)
-            "talking_heads": (15, {"540p": 400, "720p": 700, "1080p": 1200}),
-            "text": (15, {"540p": 600, "720p": 1000, "1080p": 1800}),
-            "mixed": (20, {"540p": 900, "720p": 1500, "1080p": 2500}),
-        },
-        environ_name="RECORDING_ENCODING_AVAILABLE_PROFILES",
         environ_prefix=None,
     )
 

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -754,9 +754,41 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # Per-recording encoding presets for the start-recording API.
+    # Unlike the global RECORDING_ENCODING_* values above (a single fixed
+    # preset), these maps let a recording request pick a resolution and a
+    # quality profile. To add a resolution: add one entry to
+    # RECORDING_ENCODING_AVAILABLE_RESOLUTIONS and one bitrate per profile in
+    # RECORDING_ENCODING_AVAILABLE_PROFILES. To add a profile: add one entry to
+    # RECORDING_ENCODING_AVAILABLE_PROFILES with a bitrate per resolution. No
+    # control-flow changes needed elsewhere.
+
+    # Map resolution string -> (width, height) in pixels.
+    RECORDING_ENCODING_AVAILABLE_RESOLUTIONS = values.DictValue(
+        {
+            "540p": (960, 540),
+            "720p": (1280, 720),
+            "1080p": (1920, 1080),
+        },
+        environ_name="RECORDING_ENCODING_AVAILABLE_RESOLUTIONS",
+        environ_prefix=None,
+    )
+    # Bitrate scales with resolution so quality stays consistent across sizes.
+    RECORDING_ENCODING_AVAILABLE_PROFILES = values.DictValue(
+        {
+            # profile: (fps, kbps per resolution)
+            "talking_heads": (15, {"540p": 400, "720p": 700, "1080p": 1200}),
+            "text": (15, {"540p": 600, "720p": 1000, "1080p": 1800}),
+            "mixed": (20, {"540p": 900, "720p": 1500, "1080p": 2500}),
+        },
+        environ_name="RECORDING_ENCODING_AVAILABLE_PROFILES",
+        environ_prefix=None,
+    )
+
     SUMMARY_SERVICE_VERSION = values.PositiveIntegerValue(
         1, environ_name="SUMMARY_SERVICE_VERSION", environ_prefix=None
     )
+
     SUMMARY_SERVICE_ENDPOINT = values.Value(
         None, environ_name="SUMMARY_SERVICE_ENDPOINT", environ_prefix=None
     )
@@ -1122,6 +1154,28 @@ class Base(Configuration):
         }
 
     @classmethod
+    def _check_recording_encoding_maps(cls):
+        """Ensure the per-recording encoding maps are mutually consistent.
+
+        Every profile in RECORDING_ENCODING_AVAILABLE_PROFILES must define a bitrate for
+        each resolution declared in RECORDING_ENCODING_AVAILABLE_RESOLUTIONS.
+        """
+        resolutions = set(cls.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS)
+        for profile, (
+            _fps,
+            kbps_by_resolution,
+            # DictValue resolves to a dict at runtime; pylint sees the descriptor.
+        ) in cls.RECORDING_ENCODING_AVAILABLE_PROFILES.items():  # pylint: disable=no-member
+            profile_resolutions = set(kbps_by_resolution)
+            if profile_resolutions != resolutions:
+                raise ValueError(
+                    f"Profile '{profile}' in RECORDING_ENCODING_AVAILABLE_PROFILES must "
+                    "define a bitrate for exactly the resolutions in "
+                    "RECORDING_ENCODING_AVAILABLE_RESOLUTIONS, mismatch on: "
+                    f"{resolutions ^ profile_resolutions}"
+                )
+
+    @classmethod
     def post_setup(cls):
         """Post setup configuration.
         This is the place where you can configure settings that require other
@@ -1133,6 +1187,8 @@ class Base(Configuration):
             raise ValueError(
                 "FILE_UPLOAD_TMP_PATH cannot be the same as FILE_UPLOAD_PATH"
             )
+
+        cls._check_recording_encoding_maps()
 
         if (
             cls.SUMMARY_SERVICE_VERSION == 1

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -747,26 +747,63 @@ class Base(Configuration):
     # recordings), whose request never carries advanced EncodingOptions.
     # When disabled, LiveKit falls back to its built-in H264_720P_30 preset
     # (1280x720, 30 fps, 3000 kbps H.264 MAIN video, 128 kbps AAC audio).
-    # When enabled, the values below are passed to LiveKit as EncodingOptions
-    # (advanced) and replace the preset. Lowering framerate and bitrate reduces
-    # output file size and CPU load on the egress worker.
+    # When enabled, the encoding parameters are resolved from the default profile
+    # and resolution below and passed to LiveKit as EncodingOptions (advanced),
+    # replacing the preset. Lowering framerate and bitrate reduces output file
+    # size and CPU load on the egress worker.
     RECORDING_ENCODING_ENABLED = values.BooleanValue(
         False, environ_name="RECORDING_ENCODING_ENABLED", environ_prefix=None
     )
-    RECORDING_ENCODING_WIDTH = values.PositiveIntegerValue(
-        1280, environ_name="RECORDING_ENCODING_WIDTH", environ_prefix=None
-    )
-    RECORDING_ENCODING_HEIGHT = values.PositiveIntegerValue(
-        720, environ_name="RECORDING_ENCODING_HEIGHT", environ_prefix=None
-    )
-    RECORDING_ENCODING_FRAMERATE = values.PositiveIntegerValue(
-        30, environ_name="RECORDING_ENCODING_FRAMERATE", environ_prefix=None
-    )
-    RECORDING_ENCODING_VIDEO_BITRATE_KBPS = values.PositiveIntegerValue(
-        3000,
-        environ_name="RECORDING_ENCODING_VIDEO_BITRATE_KBPS",
+
+    # Map resolution string -> (width, height) in pixels.
+    RECORDING_ENCODING_AVAILABLE_RESOLUTIONS = values.DictValue(
+        {
+            "540p": {"width": 960, "height": 540},
+            "720p": {"width": 1280, "height": 720},
+            "1080p": {"width": 1920, "height": 1080},
+        },
+        environ_name="RECORDING_ENCODING_AVAILABLE_RESOLUTIONS",
         environ_prefix=None,
     )
+
+    # Bitrate scales with resolution so quality stays consistent across sizes.
+    RECORDING_ENCODING_AVAILABLE_PROFILES = values.DictValue(
+        {
+            "talking_heads": {
+                "fps": 15,
+                "kbps": {"540p": 400, "720p": 700, "1080p": 1200},
+            },
+            "text": {
+                "fps": 15,
+                "kbps": {"540p": 600, "720p": 1000, "1080p": 1800},
+            },
+            "mixed": {
+                "fps": 20,
+                "kbps": {"540p": 900, "720p": 1500, "1080p": 2500},
+            },
+            "full": {
+                "fps": 30,
+                "kbps": {"540p": 2000, "720p": 3000, "1080p": 4500},
+            },
+        },
+        environ_name="RECORDING_ENCODING_AVAILABLE_PROFILES",
+        environ_prefix=None,
+    )
+
+    # Defaults used when no profile/resolution is specified per recording.
+    # Must be keys of the two dicts above (validated at startup).
+    RECORDING_ENCODING_DEFAULT_PROFILE = values.Value(
+        "full",
+        environ_name="RECORDING_ENCODING_DEFAULT_PROFILE",
+        environ_prefix=None,
+    )
+    RECORDING_ENCODING_DEFAULT_RESOLUTION = values.Value(
+        "720p",
+        environ_name="RECORDING_ENCODING_DEFAULT_RESOLUTION",
+        environ_prefix=None,
+    )
+
+    # Settings independent of profile/resolution.
     RECORDING_ENCODING_AUDIO_BITRATE_KBPS = values.PositiveIntegerValue(
         128,
         environ_name="RECORDING_ENCODING_AUDIO_BITRATE_KBPS",
@@ -781,6 +818,7 @@ class Base(Configuration):
     SUMMARY_SERVICE_VERSION = values.PositiveIntegerValue(
         1, environ_name="SUMMARY_SERVICE_VERSION", environ_prefix=None
     )
+
     SUMMARY_SERVICE_ENDPOINT = values.Value(
         None, environ_name="SUMMARY_SERVICE_ENDPOINT", environ_prefix=None
     )
@@ -1170,6 +1208,28 @@ class Base(Configuration):
         }
 
     @classmethod
+    def _check_recording_encoding_maps(cls):
+        """Ensure the per-recording encoding maps are mutually consistent.
+
+        Every profile in RECORDING_ENCODING_AVAILABLE_PROFILES must define a bitrate for
+        each resolution declared in RECORDING_ENCODING_AVAILABLE_RESOLUTIONS.
+        """
+        resolutions = set(cls.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS)
+        for profile, (
+            _fps,
+            kbps_by_resolution,
+            # DictValue resolves to a dict at runtime; pylint sees the descriptor.
+        ) in cls.RECORDING_ENCODING_AVAILABLE_PROFILES.items():  # pylint: disable=no-member
+            profile_resolutions = set(kbps_by_resolution)
+            if profile_resolutions != resolutions:
+                raise ValueError(
+                    f"Profile '{profile}' in RECORDING_ENCODING_AVAILABLE_PROFILES must "
+                    "define a bitrate for exactly the resolutions in "
+                    "RECORDING_ENCODING_AVAILABLE_RESOLUTIONS, mismatch on: "
+                    f"{resolutions ^ profile_resolutions}"
+                )
+
+    @classmethod
     def post_setup(cls):
         """Post setup configuration.
         This is the place where you can configure settings that require other
@@ -1181,6 +1241,8 @@ class Base(Configuration):
             raise ValueError(
                 "FILE_UPLOAD_TMP_PATH cannot be the same as FILE_UPLOAD_PATH"
             )
+
+        cls._check_recording_encoding_maps()
 
         if (
             cls.SUMMARY_SERVICE_VERSION == 1

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -755,7 +755,7 @@ class Base(Configuration):
         False, environ_name="RECORDING_ENCODING_ENABLED", environ_prefix=None
     )
 
-    # Map resolution string -> (width, height) in pixels.
+    # Map resolution name -> {"width": ..., "height": ...} in pixels.
     RECORDING_ENCODING_AVAILABLE_RESOLUTIONS = values.DictValue(
         {
             "540p": {"width": 960, "height": 540},
@@ -1211,16 +1211,21 @@ class Base(Configuration):
     def _check_recording_encoding_maps(cls):
         """Ensure the per-recording encoding maps are mutually consistent.
 
-        Every profile in RECORDING_ENCODING_AVAILABLE_PROFILES must define a bitrate for
-        each resolution declared in RECORDING_ENCODING_AVAILABLE_RESOLUTIONS.
+        Every profile in RECORDING_ENCODING_AVAILABLE_PROFILES must declare an fps and
+        a bitrate for each resolution declared in RECORDING_ENCODING_AVAILABLE_RESOLUTIONS,
+        and each non-empty default must name an entry of its map.
         """
+        # DictValue resolves to a dict at runtime; pylint sees the descriptor.
+        # pylint: disable=no-member
         resolutions = set(cls.RECORDING_ENCODING_AVAILABLE_RESOLUTIONS)
-        for profile, (
-            _fps,
-            kbps_by_resolution,
-            # DictValue resolves to a dict at runtime; pylint sees the descriptor.
-        ) in cls.RECORDING_ENCODING_AVAILABLE_PROFILES.items():  # pylint: disable=no-member
-            profile_resolutions = set(kbps_by_resolution)
+        for profile, spec in cls.RECORDING_ENCODING_AVAILABLE_PROFILES.items():
+            if "fps" not in spec or "kbps" not in spec:
+                raise ValueError(
+                    f"Profile '{profile}' in RECORDING_ENCODING_AVAILABLE_PROFILES must "
+                    "define both 'fps' and 'kbps'."
+                )
+
+            profile_resolutions = set(spec["kbps"])
             if profile_resolutions != resolutions:
                 raise ValueError(
                     f"Profile '{profile}' in RECORDING_ENCODING_AVAILABLE_PROFILES must "
@@ -1228,6 +1233,22 @@ class Base(Configuration):
                     "RECORDING_ENCODING_AVAILABLE_RESOLUTIONS, mismatch on: "
                     f"{resolutions ^ profile_resolutions}"
                 )
+
+        default_resolution = cls.RECORDING_ENCODING_DEFAULT_RESOLUTION
+        if default_resolution and default_resolution not in resolutions:
+            raise ValueError(
+                f"RECORDING_ENCODING_DEFAULT_RESOLUTION '{default_resolution}' is not a "
+                "key of RECORDING_ENCODING_AVAILABLE_RESOLUTIONS, choose from "
+                f"{sorted(resolutions)}."
+            )
+
+        profiles = set(cls.RECORDING_ENCODING_AVAILABLE_PROFILES)
+        default_profile = cls.RECORDING_ENCODING_DEFAULT_PROFILE
+        if default_profile and default_profile not in profiles:
+            raise ValueError(
+                f"RECORDING_ENCODING_DEFAULT_PROFILE '{default_profile}' is not a key of "
+                f"RECORDING_ENCODING_AVAILABLE_PROFILES, choose from {sorted(profiles)}."
+            )
 
     @classmethod
     def post_setup(cls):


### PR DESCRIPTION
## Purpose

https://github.com/suitenumerique/meet/issues/1344

NB: Work based on https://github.com/suitenumerique/meet/pull/1357 by @sarthakbahal

## Proposal

Changes on the original PR:

- encoding.py goes into settings
- profile settings are validated
- profile encoding serializers are validated and no longer use hardcoded variables
- profiles are video only and do not apply to audio
- persist query and resolved encoding settings: 
```
recording.options["encoding"] == {
        "resolution": "720p",
        "profile": "talking_heads",
        "resolved": {
            "key_frame_interval": settings.RECORDING_ENCODING_KEY_FRAME_INTERVAL_S,
            "width": 1280,
            "height": 720,
            "framerate": 15,
            "video_bitrate": 700,
        },
    }
    ```
