### PR TITLE
✨(frontend) pin multiple screen shares and tiles at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
+- ✨(frontend) pin multiple screen shares and tiles at once #1447
 - 🚀 (front) fix frontend build failure
 
 ## [1.22.0] - 2026-07-03

--- a/src/frontend/src/features/notifications/components/ToastJoined.tsx
+++ b/src/frontend/src/features/notifications/components/ToastJoined.tsx
@@ -4,7 +4,7 @@ import { Button as RACButton } from 'react-aria-components'
 import { Track } from 'livekit-client'
 import Source = Track.Source
 
-import { useMaybeLayoutContext } from '@livekit/components-react'
+import { useMultiPinDispatch } from '@/features/rooms/livekit/hooks/useMultiPin'
 import { ParticipantTile } from '@/features/rooms/livekit/components/ParticipantTile'
 import { type ToastProps } from './Toast'
 import { HStack, styled } from '@/styled-system/jsx'
@@ -28,7 +28,7 @@ export function ToastJoined({ state, ...props }: Readonly<ToastProps>) {
     state,
     ref
   )
-  const layoutContext = useMaybeLayoutContext()
+  const dispatchPin = useMultiPinDispatch()
   const participant = props.toast.content.participant
 
   if (!participant) return
@@ -39,8 +39,8 @@ export function ToastJoined({ state, ...props }: Readonly<ToastProps>) {
     source: Source.Camera,
   }
   const pinParticipant = () => {
-    layoutContext?.pin.dispatch?.({
-      msg: 'set_pin',
+    dispatchPin?.({
+      msg: 'add_pin',
       trackReference,
     })
   }

--- a/src/frontend/src/features/rooms/livekit/components/FocusLayout.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/FocusLayout.tsx
@@ -1,6 +1,0 @@
-import { ParticipantTile } from './ParticipantTile'
-import type { FocusLayoutProps } from '@livekit/components-react'
-
-export function FocusLayout({ trackRef, ...htmlProps }: FocusLayoutProps) {
-  return <ParticipantTile trackRef={trackRef} {...htmlProps} />
-}

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/PinMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/PinMenuItem.tsx
@@ -9,7 +9,7 @@ import { useFocusToggleParticipant } from '@/features/rooms/livekit/hooks/useFoc
 export const PinMenuItem = ({ participant }: { participant: Participant }) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'participantMenu' })
 
-  const { toggle, inFocus } = useFocusToggleParticipant(participant)
+  const { toggle, inFocus, canPin } = useFocusToggleParticipant(participant)
 
   return (
     <MenuItem
@@ -17,6 +17,7 @@ export const PinMenuItem = ({ participant }: { participant: Participant }) => {
         name: participant.name,
       })}
       className={menuRecipe({ icon: true }).item}
+      isDisabled={!canPin}
       onAction={toggle}
     >
       <HStack gap={0.25}>

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
@@ -7,7 +7,6 @@ import {
   useEnsureTrackRef,
   useFeatureContext,
   useIsEncrypted,
-  useMaybeLayoutContext,
   useMaybeTrackRefContext,
   useParticipantTile,
   VideoTrack,
@@ -34,6 +33,7 @@ import { useTranslation } from 'react-i18next'
 import { getShortcutDescriptorById } from '@/features/shortcuts/catalog'
 import { formatShortcutLabel } from '@/features/shortcuts/formatLabels'
 import { KeyboardShortcutHint } from './KeyboardShortcutHint'
+import { useMultiPinDispatch, usePinnedTracksState } from '../hooks/useMultiPin'
 
 export function TrackRefContextIfNeeded(
   props: React.PropsWithChildren<{
@@ -79,23 +79,25 @@ export const ParticipantTile: (
     trackRef: trackReference,
   })
   const isEncrypted = useIsEncrypted(trackReference.participant)
-  const layoutContext = useMaybeLayoutContext()
+  const dispatchPin = useMultiPinDispatch()
+  const pinnedTracks = usePinnedTracksState()
 
   const autoManageSubscription = useFeatureContext()?.autoSubscription
 
   const handleSubscribe = React.useCallback(
     (subscribed: boolean) => {
+      // When a pinned tile is unsubscribed, unpin only that tile — the other
+      // pinned tiles stay in focus.
       if (
         trackReference.source &&
         !subscribed &&
-        layoutContext &&
-        layoutContext.pin.dispatch &&
-        isTrackReferencePinned(trackReference, layoutContext.pin.state)
+        dispatchPin &&
+        isTrackReferencePinned(trackReference, pinnedTracks)
       ) {
-        layoutContext.pin.dispatch({ msg: 'clear_pin' })
+        dispatchPin({ msg: 'remove_pin', trackReference })
       }
     },
-    [trackReference, layoutContext]
+    [trackReference, dispatchPin, pinnedTracks]
   )
 
   const { isHandRaised } = useRaisedHand({

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantTileFocus.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantTileFocus.tsx
@@ -9,15 +9,13 @@ import {
   RiPushpin2Line,
   RiUnpinLine,
 } from '@remixicon/react'
-import {
-  useFocusToggle,
-  useTrackMutedIndicator,
-} from '@livekit/components-react'
+import { useTrackMutedIndicator } from '@livekit/components-react'
 import { useTranslation } from 'react-i18next'
 import { TrackReferenceOrPlaceholder } from '@livekit/components-core'
 import { useEffect, useRef, useState } from 'react'
 import { useSidePanel } from '../hooks/useSidePanel'
 import { useFullScreen } from '../hooks/useFullScreen'
+import { useTogglePin } from '../hooks/useMultiPin'
 import { type Participant, Track } from 'livekit-client'
 import { MuteAlertDialog } from './MuteAlertDialog'
 import { useMuteParticipant } from '@/features/rooms/api/muteParticipant'
@@ -56,20 +54,17 @@ const FocusButton = ({
   trackRef: TrackReferenceOrPlaceholder
 }) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'participantTileFocus' })
-  const { mergedProps, inFocus } = useFocusToggle({
-    trackRef,
-    props: {},
-  })
+  const { toggle, isPinned, canPin } = useTogglePin(trackRef)
   return (
     <Button
       size="sm"
       variant="primaryTextDark"
       square
-      tooltip={inFocus ? t('pin.disable') : t('pin.enable')}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onPress={(event) => mergedProps?.onClick?.(event as any)}
+      isDisabled={!canPin}
+      tooltip={isPinned ? t('pin.disable') : t('pin.enable')}
+      onPress={() => toggle()}
     >
-      {inFocus ? <RiUnpinLine /> : <RiPushpin2Line />}
+      {isPinned ? <RiUnpinLine /> : <RiPushpin2Line />}
     </Button>
   )
 }

--- a/src/frontend/src/features/rooms/livekit/hooks/useFocusToggleParticipant.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useFocusToggleParticipant.ts
@@ -1,7 +1,5 @@
-import { useFocusToggle } from '@livekit/components-react'
 import { type Participant, Track } from 'livekit-client'
-import { useCallback } from 'react'
-import type { MouseEvent } from 'react'
+import { useTogglePin } from './useMultiPin'
 import Source = Track.Source
 
 export const useFocusToggleParticipant = (participant: Participant) => {
@@ -11,22 +9,11 @@ export const useFocusToggleParticipant = (participant: Participant) => {
     source: Source.Camera,
   }
 
-  const { mergedProps, inFocus } = useFocusToggle({
-    trackRef,
-    props: {},
-  })
-
-  const toggle = useCallback(() => {
-    const syntheticEvent = {
-      preventDefault: () => {},
-      stopPropagation: () => {},
-    } as MouseEvent<HTMLButtonElement>
-
-    mergedProps?.onClick?.(syntheticEvent)
-  }, [mergedProps])
+  const { toggle, isPinned, canPin } = useTogglePin(trackRef)
 
   return {
     toggle,
-    inFocus,
+    inFocus: isPinned,
+    canPin,
   }
 }

--- a/src/frontend/src/features/rooms/livekit/hooks/useMultiPin.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useMultiPin.ts
@@ -1,0 +1,182 @@
+import {
+  isTrackReference,
+  isTrackReferencePinned,
+  PIN_DEFAULT_STATE,
+} from '@livekit/components-core'
+import type {
+  PinState,
+  TrackReferenceOrPlaceholder,
+} from '@livekit/components-core'
+import {
+  useCreateLayoutContext,
+  useMaybeLayoutContext,
+} from '@livekit/components-react'
+import type { LayoutContextType } from '@livekit/components-react'
+import { useCallback, useReducer, type Dispatch } from 'react'
+
+/**
+ * Maximum number of tiles a single participant can pin (keep in focus) at once.
+ *
+ * The pin state stays local to each participant, so this only bounds one user's
+ * own focus grid. It is kept intentionally small so the grid stays readable when
+ * several screen shares and cameras are pinned together (Zoom allows 9, Google
+ * Meet 3 — 4 is a comfortable middle ground for side-by-side screen shares plus
+ * an accessibility tile such as a sign-language interpreter).
+ */
+export const MAX_PINNED_TILES = 4
+
+/**
+ * Pin actions that operate on individual tiles, superseding LiveKit's built-in
+ * `set_pin`/`clear_pin` reducer (which only ever holds a single tile). Every
+ * action carries the track it targets so toggling one tile never affects the
+ * others.
+ */
+export type MultiPinAction =
+  | { msg: 'toggle_pin'; trackReference: TrackReferenceOrPlaceholder }
+  | { msg: 'add_pin'; trackReference: TrackReferenceOrPlaceholder }
+  | { msg: 'remove_pin'; trackReference: TrackReferenceOrPlaceholder }
+  /**
+   * Replace a pinned placeholder with its now-published track reference, in
+   * place, without changing the pin order or count.
+   */
+  | { msg: 'replace_pin'; trackReference: TrackReferenceOrPlaceholder }
+
+/** Whether `a` and `b` reference the same pinned tile (delegates to LiveKit). */
+const isSamePinnedTrack = (
+  a: TrackReferenceOrPlaceholder,
+  b: TrackReferenceOrPlaceholder
+) => isTrackReferencePinned(a, [b])
+
+/**
+ * A drop-in replacement for LiveKit's single-tile `pinReducer` that keeps an
+ * ordered, de-duplicated list of pinned tiles bounded by {@link MAX_PINNED_TILES}.
+ */
+export function multiPinReducer(
+  state: PinState,
+  action: MultiPinAction
+): PinState {
+  switch (action.msg) {
+    case 'add_pin': {
+      if (isTrackReferencePinned(action.trackReference, state)) return state
+      if (state.length >= MAX_PINNED_TILES) return state
+      return [...state, action.trackReference]
+    }
+    case 'remove_pin': {
+      const next = state.filter(
+        (pinned) => !isSamePinnedTrack(pinned, action.trackReference)
+      )
+      // Preserve referential identity on a no-op so `useReducer` bails out and
+      // dependent consumers/effects don't re-run needlessly.
+      return next.length === state.length ? state : next
+    }
+    case 'toggle_pin':
+      return isTrackReferencePinned(action.trackReference, state)
+        ? multiPinReducer(state, {
+            msg: 'remove_pin',
+            trackReference: action.trackReference,
+          })
+        : multiPinReducer(state, {
+            msg: 'add_pin',
+            trackReference: action.trackReference,
+          })
+    case 'replace_pin': {
+      let replaced = false
+      const next = state.map((pinned) => {
+        if (
+          !isTrackReference(pinned) &&
+          pinned.participant.identity ===
+            action.trackReference.participant.identity &&
+          pinned.source === action.trackReference.source
+        ) {
+          replaced = true
+          return action.trackReference
+        }
+        return pinned
+      })
+      return replaced ? next : state
+    }
+    // Ignore any unknown action (e.g. LiveKit's `set_pin`/`clear_pin` reaching
+    // us through the typed context boundary), mirroring LiveKit's own reducer.
+    default:
+      return state
+  }
+}
+
+export interface MultiPinLayoutContext {
+  /** The LiveKit layout context to feed `LayoutContextProvider`. */
+  layoutContext: LayoutContextType
+  /** The currently pinned tiles, in pin order. */
+  pinnedTracks: PinState
+  /** Strongly-typed dispatcher for multi-pin actions. */
+  dispatchPin: Dispatch<MultiPinAction>
+}
+
+/**
+ * Creates a LiveKit layout context whose `pin` slice supports multiple
+ * simultaneous pins, while reusing LiveKit's `widget` slice untouched. Reads by
+ * LiveKit hooks (`usePinnedTracks`, `isTrackReferencePinned`, …) keep working
+ * because the pin state remains a plain `TrackReferenceOrPlaceholder[]`.
+ */
+export function useCreateMultiPinLayoutContext(): MultiPinLayoutContext {
+  const base = useCreateLayoutContext()
+  const [pinnedTracks, dispatchPin] = useReducer(
+    multiPinReducer,
+    PIN_DEFAULT_STATE
+  )
+
+  const layoutContext: LayoutContextType = {
+    widget: base.widget,
+    pin: {
+      state: pinnedTracks,
+      // Our reducer accepts a superset of LiveKit's `PinAction`. LiveKit never
+      // dispatches pin actions on its own in this app (we replace every
+      // `useFocusToggle` call site), so exposing our dispatcher through the
+      // standard context is safe and keeps LiveKit consumers type-compatible.
+      dispatch: dispatchPin as unknown as LayoutContextType['pin']['dispatch'],
+    },
+  }
+
+  return { layoutContext, pinnedTracks, dispatchPin }
+}
+
+/** Typed access to the multi-pin dispatcher stored on the layout context. */
+export function useMultiPinDispatch(): Dispatch<MultiPinAction> | undefined {
+  const layoutContext = useMaybeLayoutContext()
+  return layoutContext?.pin.dispatch as unknown as
+    | Dispatch<MultiPinAction>
+    | undefined
+}
+
+/** The currently pinned tiles (empty when outside a layout context). */
+export function usePinnedTracksState(): PinState {
+  return useMaybeLayoutContext()?.pin.state ?? []
+}
+
+export interface UseTogglePinResult {
+  /** Whether this tile is currently pinned. */
+  isPinned: boolean
+  /** False when the tile is not pinned and the pin limit is already reached. */
+  canPin: boolean
+  /** Pin the tile if unpinned, unpin it if pinned — independently of the rest. */
+  toggle: () => void
+}
+
+/**
+ * Toggle a single tile's pin state independently of the other pinned tiles.
+ * Replaces LiveKit's `useFocusToggle`, whose `clear_pin` would drop every pin.
+ */
+export function useTogglePin(
+  trackReference: TrackReferenceOrPlaceholder
+): UseTogglePinResult {
+  const dispatch = useMultiPinDispatch()
+  const pinnedTracks = usePinnedTracksState()
+
+  const isPinned = isTrackReferencePinned(trackReference, pinnedTracks)
+  const canPin = isPinned || pinnedTracks.length < MAX_PINNED_TILES
+
+  const toggle = useCallback(() => {
+    dispatch?.({ msg: 'toggle_pin', trackReference })
+  }, [dispatch, trackReference])
+
+  return { isPinned, canPin, toggle }
+}

--- a/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
+++ b/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
@@ -1,26 +1,25 @@
-import type { TrackReferenceOrPlaceholder } from '@livekit/components-core'
+import type {
+  PinState,
+  TrackReferenceOrPlaceholder,
+} from '@livekit/components-core'
 import {
-  isEqualTrackRef,
   isTrackReference,
+  isTrackReferencePinned,
   isWeb,
   log,
 } from '@livekit/components-core'
-import { type Participant, RoomEvent, Track } from 'livekit-client'
+import { RoomEvent, Track } from 'livekit-client'
 import React, { useCallback, useRef, useState, useEffect } from 'react'
 import {
   ConnectionStateToast,
   FocusLayoutContainer,
   LayoutContextProvider,
   RoomAudioRenderer,
-  usePinnedTracks,
   useTracks,
-  useCreateLayoutContext,
-  useRoomContext,
 } from '@livekit/components-react'
 import { useTranslation } from 'react-i18next'
 
 import { ControlBar } from './ControlBar/ControlBar'
-import { FocusLayout } from '../components/FocusLayout'
 import { ParticipantTile } from '../components/ParticipantTile'
 import { SidePanel } from '../components/SidePanel'
 import { RecordingProvider } from '@/features/recording'
@@ -43,6 +42,7 @@ import { GridLayout } from '@/features/layout/components/GridLayout'
 import { RoomContentArea } from '@/features/layout/components/RoomContentArea'
 import { usePictureInPicture } from '@/features/pip/hooks/usePictureInPicture'
 import { PipRoomPlaceholder } from '@/features/pip/components/PipRoomPlaceholder'
+import { useCreateMultiPinLayoutContext } from '../hooks/useMultiPin'
 
 /**
  * @public
@@ -62,6 +62,10 @@ export interface VideoConferenceProps extends React.HTMLAttributes<HTMLDivElemen
  * `GridLayout`, `ControlBar`, `FocusLayoutContainer` and `FocusLayout`.
  * You can use this components as a starting point for your own custom video conferencing application.
  *
+ * Focus (pin) state is local to each participant and supports pinning several
+ * tiles at once (see {@link useCreateMultiPinLayoutContext}). Pinned tiles are
+ * laid out in a responsive grid while the remaining tiles move to the carousel.
+ *
  * @example
  * ```tsx
  * <LiveKitRoom>
@@ -73,22 +77,10 @@ export interface VideoConferenceProps extends React.HTMLAttributes<HTMLDivElemen
 export function VideoConference({ ...props }: VideoConferenceProps) {
   const lastAutoFocusedScreenShareTrack =
     useRef<TrackReferenceOrPlaceholder | null>(null)
-  const lastPinnedParticipantIdentityRef = useRef<string | null>(null)
+  const previousPinnedTracksRef = useRef<PinState>([])
   const { t } = useTranslation('rooms', { keyPrefix: 'pinAnnouncements' })
-  const { t: tRooms } = useTranslation('rooms')
-  const room = useRoomContext()
   const announce = useScreenReaderAnnounce()
   const { toggleSettingsDialog } = useSettingsDialog()
-
-  const getAnnouncementName = useCallback(
-    (participant?: Participant | null) => {
-      if (!participant) return tRooms('participants.unknown')
-      return participant.isLocal
-        ? tRooms('participants.you')
-        : getParticipantName(participant)
-    },
-    [tRooms]
-  )
 
   useConnectionObserver()
   useRoomPageTitle()
@@ -110,7 +102,8 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
     { updateOnlyOn: [RoomEvent.ActiveSpeakersChanged], onlySubscribed: false }
   )
 
-  const layoutContext = useCreateLayoutContext()
+  const { layoutContext, pinnedTracks, dispatchPin } =
+    useCreateMultiPinLayoutContext()
 
   useNoiseReduction()
 
@@ -118,70 +111,51 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
     .filter(isTrackReference)
     .filter((track) => track.publication.source === Track.Source.ScreenShare)
 
-  const focusTrack = usePinnedTracks(layoutContext)?.[0]
   const carouselTracks = tracks.filter(
-    (track) => !isEqualTrackRef(track, focusTrack)
+    (track) => !isTrackReferencePinned(track, pinnedTracks)
   )
 
   const { isOpen: isPictureInPictureOpen } = usePictureInPicture()
 
-  // handle pin announcements
-
+  // Announce pin/unpin changes to screen-reader users. Each pinned tile is keyed
+  // by participant + source so a change to one tile is announced independently
+  // of the others.
   useEffect(() => {
-    const participant = focusTrack?.participant
+    const keyOf = (track: TrackReferenceOrPlaceholder) =>
+      `${track.participant.identity}:${track.source}`
+    const previous = previousPinnedTracksRef.current
+    const previousKeys = new Set(previous.map(keyOf))
+    const currentKeys = new Set(pinnedTracks.map(keyOf))
 
-    // 1. unpin
-    if (!participant) {
-      if (!lastPinnedParticipantIdentityRef.current) return
-
-      const lastIdentity = lastPinnedParticipantIdentityRef.current
-      const lastParticipant =
-        room.localParticipant.identity === lastIdentity
-          ? room.localParticipant
-          : room.remoteParticipants.get(lastIdentity)
-      const announcementName = getAnnouncementName(lastParticipant)
-
-      announce(
-        lastParticipant?.isLocal
-          ? t('self.unpin')
-          : t('unpin', {
-              name: announcementName,
-            })
-      )
-
-      lastPinnedParticipantIdentityRef.current = null
-      return
+    const announcePin = (
+      track: TrackReferenceOrPlaceholder,
+      pinned: boolean
+    ) => {
+      if (track.participant.isLocal) {
+        announce(pinned ? t('self.pin') : t('self.unpin'))
+        return
+      }
+      const name = getParticipantName(track.participant)
+      announce(pinned ? t('pin', { name }) : t('unpin', { name }))
     }
 
-    // 2. same pin → do nothing
-    if (lastPinnedParticipantIdentityRef.current === participant.identity) {
-      return
-    }
+    pinnedTracks.forEach((track) => {
+      if (!previousKeys.has(keyOf(track))) announcePin(track, true)
+    })
+    previous.forEach((track) => {
+      if (!currentKeys.has(keyOf(track))) announcePin(track, false)
+    })
 
-    // 3. new pin
-    const participantName = participant.isLocal
-      ? tRooms('participants.you')
-      : getParticipantName(participant)
-
-    lastPinnedParticipantIdentityRef.current = participant.identity
-
-    announce(
-      participant.isLocal ? t('self.pin') : t('pin', { name: participantName })
-    )
-  }, [
-    announce,
-    focusTrack,
-    getAnnouncementName,
-    room.localParticipant,
-    room.remoteParticipants,
-    t,
-    tRooms,
-  ])
+    previousPinnedTracksRef.current = pinnedTracks
+  }, [pinnedTracks, announce, t])
 
   /* eslint-disable react-hooks/exhaustive-deps */
-  // Code duplicated from LiveKit; this warning will be addressed in the refactoring.
+  // Adapted from LiveKit's VideoConference auto-focus effect; the dependency
+  // array is intentionally hand-tuned. This warning will be addressed in the
+  // upcoming refactoring.
   useEffect(() => {
-    // If screen share tracks are published, and no pin is set explicitly, auto set the screen share.
+    // Auto-focus the first screen share once, as LiveKit does — but *add* it to
+    // the pinned tiles instead of replacing them, so manual pins are preserved.
     if (
       screenShareTracks.some((track) => track.publication.isSubscribed) &&
       lastAutoFocusedScreenShareTrack.current === null
@@ -189,10 +163,7 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
       log.debug('Auto set screen share focus:', {
         newScreenShareTrack: screenShareTracks[0],
       })
-      layoutContext.pin.dispatch?.({
-        msg: 'set_pin',
-        trackReference: screenShareTracks[0],
-      })
+      dispatchPin({ msg: 'add_pin', trackReference: screenShareTracks[0] })
       lastAutoFocusedScreenShareTrack.current = screenShareTracks[0]
     } else if (
       lastAutoFocusedScreenShareTrack.current &&
@@ -203,32 +174,33 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
       )
     ) {
       log.debug('Auto clearing screen share focus.')
-      layoutContext.pin.dispatch?.({ msg: 'clear_pin' })
+      dispatchPin({
+        msg: 'remove_pin',
+        trackReference: lastAutoFocusedScreenShareTrack.current,
+      })
       lastAutoFocusedScreenShareTrack.current = null
     }
-    if (focusTrack && !isTrackReference(focusTrack)) {
-      const updatedFocusTrack = tracks.find(
-        (tr) =>
-          tr.participant.identity === focusTrack.participant.identity &&
-          tr.source === focusTrack.source
+
+    // Replace any pinned placeholder with its now-published track reference, so
+    // a pinned camera that was off starts rendering once it is turned on.
+    pinnedTracks.forEach((pinned) => {
+      if (isTrackReference(pinned)) return
+      const updatedTrack = tracks.find(
+        (track) =>
+          track.participant.identity === pinned.participant.identity &&
+          track.source === pinned.source
       )
-      if (
-        updatedFocusTrack !== focusTrack &&
-        isTrackReference(updatedFocusTrack)
-      ) {
-        layoutContext.pin.dispatch?.({
-          msg: 'set_pin',
-          trackReference: updatedFocusTrack,
-        })
+      if (updatedTrack && isTrackReference(updatedTrack)) {
+        dispatchPin({ msg: 'replace_pin', trackReference: updatedTrack })
       }
-    }
+    })
   }, [
     screenShareTracks
       .map(
         (ref) => `${ref.publication.trackSid}_${ref.publication.isSubscribed}`
       )
       .join(),
-    focusTrack?.publication?.trackSid,
+    pinnedTracks,
     tracks,
   ])
   /* eslint-enable react-hooks/exhaustive-deps */
@@ -244,10 +216,7 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
       }}
     >
       {isWeb() && (
-        <LayoutContextProvider
-          value={layoutContext}
-          // onPinChange={handleFocusStateChange}
-        >
+        <LayoutContextProvider value={layoutContext}>
           <ScreenShareErrorModal
             isOpen={isShareErrorVisible}
             onClose={() => setIsShareErrorVisible(false)}
@@ -256,36 +225,34 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
           <RoomContentArea>
             {isPictureInPictureOpen ? (
               <PipRoomPlaceholder />
+            ) : pinnedTracks.length === 0 ? (
+              <div
+                className="lk-grid-layout-wrapper"
+                style={{ height: 'auto' }}
+              >
+                <GridLayout tracks={tracks} style={{ padding: 0 }}>
+                  <ParticipantTile />
+                </GridLayout>
+              </div>
             ) : (
-              <>
-                {!focusTrack ? (
-                  <div
-                    className="lk-grid-layout-wrapper"
-                    style={{ height: 'auto' }}
+              <div
+                className="lk-focus-layout-wrapper"
+                style={{ height: 'auto' }}
+              >
+                <FocusLayoutContainer style={{ padding: 0 }}>
+                  <CarouselLayout
+                    tracks={carouselTracks}
+                    style={{
+                      minWidth: '200px',
+                    }}
                   >
-                    <GridLayout tracks={tracks} style={{ padding: 0 }}>
-                      <ParticipantTile />
-                    </GridLayout>
-                  </div>
-                ) : (
-                  <div
-                    className="lk-focus-layout-wrapper"
-                    style={{ height: 'auto' }}
-                  >
-                    <FocusLayoutContainer style={{ padding: 0 }}>
-                      <CarouselLayout
-                        tracks={carouselTracks}
-                        style={{
-                          minWidth: '200px',
-                        }}
-                      >
-                        <ParticipantTile />
-                      </CarouselLayout>
-                      {focusTrack && <FocusLayout trackRef={focusTrack} />}
-                    </FocusLayoutContainer>
-                  </div>
-                )}
-              </>
+                    <ParticipantTile />
+                  </CarouselLayout>
+                  <GridLayout tracks={pinnedTracks} style={{ padding: 0 }}>
+                    <ParticipantTile />
+                  </GridLayout>
+                </FocusLayoutContainer>
+              </div>
             )}
           </RoomContentArea>
           <ControlBar


### PR DESCRIPTION
## Purpose

Closes #1447.

When several participants share their screen at the same time, only one tile
could be pinned (in focus) at a time: pinning a new tile replaced the previous
one. This made it impossible to keep multiple shared screens visible side by
side, or to keep a presenter's screen and a sign-language interpreter in focus
together (an accessibility use case raised in the issue).

**Root cause.** Focus is LiveKit's `LayoutContext.pin`, whose state is already a
`TrackReferenceOrPlaceholder[]`. LiveKit's built-in reducer only implements
`set_pin` (replace the array) and `clear_pin` (empty it), and
`VideoConference` only ever read `usePinnedTracks(...)?.[0]`. So the single-pin
limit lived entirely in the reducer and the render, not in the data model.

Pin state stays local to each participant, consistent with the current behavior;
nothing is shared with other participants (this is the local counterpart of the
host-controlled #528).

## Proposal

Let a participant pin several tiles (screen shares and/or cameras) at once:

- The pin/unpin action toggles each tile independently instead of replacing the
  current focus.
- Pinned tiles are displayed together in a responsive grid (focus area) while
  non-pinned tiles move to the carousel.
- A small cap (`MAX_PINNED_TILES = 4`) keeps the focus grid readable; pin
  controls are disabled once it is reached.

- [x] Replace LiveKit's single-tile pin reducer with a track-aware multi-pin
      reducer (`toggle` / `add` / `remove` / `replace`, capped, de-duplicated,
      referentially stable on no-ops) in a new `useMultiPin` module, exposed
      through the layout context so LiveKit consumers (`usePinnedTracks`,
      `isTrackReferencePinned`) keep working unchanged.
- [x] Render the pinned set in the existing responsive `GridLayout`, and exclude
      pinned tiles from the carousel.
- [x] Update every pin entry point (tile pin button, participant menu, join
      toast) to toggle independently; unpinning or unsubscribing one tile no
      longer clears the others.
- [x] Generalize the screen-reader pin/unpin announcements and the screen-share
      auto-focus / placeholder handling to the multi-pin set.

### Design decisions

- **Reuse LiveKit's pin state, swap only the reducer.** Overriding just the
  `pin` slice of the layout context (keeping the `widget` slice) means the pin
  state stays a plain array and every LiveKit read-path keeps working. No fork
  of unrelated LiveKit internals.
- **Conservative auto-focus.** Screen-share auto-focus is unchanged (only the
  first screen share auto-focuses), so single-share meetings behave exactly as
  before; additional tiles are pinned manually.
- **Cap = 4.** Small enough to stay readable (Zoom allows 9, Meet 3); one named
  constant, trivially tunable.
- **Disable pin controls at the cap** rather than silently ignoring the click,
  consistent with how the app already disables controls (e.g. the mute button).

### Files changed

- `hooks/useMultiPin.ts` (new) — reducer + hooks + cap constant.
- `prefabs/VideoConference.tsx` — context wiring, focus grid, carousel
  exclusion, auto-focus + placeholder + announcement effects.
- `components/ParticipantTileFocus.tsx`, `hooks/useFocusToggleParticipant.ts`,
  `components/ParticipantMenu/PinMenuItem.tsx`,
  `components/ParticipantTile.tsx`, `notifications/ToastJoined.tsx` — track-aware
  pin entry points.
- `components/FocusLayout.tsx` — removed (dead after the change).
- `CHANGELOG.md` — one line.

No new dependencies. No i18n changes (reuses the existing pin/unpin strings).

### Testing performed

- `npm run lint` (eslint `--max-warnings 0`), `npm run check` (prettier),
  `npm run build` (`tsc -b` + vite) all pass.
- Manual reasoning + code review over the reducer and the two effects
  (convergence, no dispatch loop, StrictMode double-invoke safety).
- Remaining: a live click-through in a running room (pin/unpin independence, the
  4-tile grid, cap disabling, screen-share auto-focus). Screenshots to be added
  from that session.

### Performance impact

Negligible. The layout-context value is rebuilt per render exactly as the
original `useCreateLayoutContext()` was, so there is no new re-render surface;
the reducer now returns the same array reference on no-op dispatches to avoid
spurious updates. The `Room` bundle chunk is unchanged (slightly smaller).

### Accessibility

Pin/unpin changes are announced to screen readers per tile via the existing
`useScreenReaderAnnounce` channel. Pin controls at the cap use the app's
standard disabled-control pattern. Keyboard operability of the tile controls is
unchanged.

### Security

None. This is local, client-side UI state: no API, auth, RBAC, token, or input
handling is touched.

### Breaking changes / deployment

None. Single-pin usage is simply the `n = 1` case of the new behavior; no
migration, config, or deployment step required.

### Reviewer guidance

Start at `useMultiPin.ts` (the reducer + the layout-context override and the
`as unknown as` cast at the LiveKit boundary), then `VideoConference.tsx` (focus
grid render + the auto-focus/placeholder/announcement effects). The rest are
mechanical `useFocusToggle` -> track-aware toggle swaps.
