### PR TITLE
[DRAFT] tool-plugin framework with deploy-time bundles and host ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- ✨(frontend) tool plugin framework with deploy-time external bundles
+- ✨(frontend) host-owned caption bus, banner and caption-button surfaces
+- ✨(backend) native-agent stop endpoint and plugins config surface
 - ✨(backend) extend analytics module to support feature flags
 - ✨(backend) implement feature flags in Posthog analytics backend
 - ✨(agents) report errors to Sentry for all LiveKit agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 - ✨(frontend) tool plugin framework with deploy-time external bundles
 - ✨(frontend) host-owned caption bus, banner and caption-button surfaces
+- ✨(frontend) showcase example plugin exercising the full plugin host ABI
 - ✨(backend) native-agent stop endpoint and plugins config surface
 - ✨(backend) extend analytics module to support feature flags
 - ✨(backend) implement feature flags in Posthog analytics backend

--- a/src/backend/core/api/__init__.py
+++ b/src/backend/core/api/__init__.py
@@ -62,6 +62,8 @@ def get_frontend_configuration(request):
         },
         "telephony": build_telephony_config(),
         "subtitle": {"enabled": settings.ROOM_SUBTITLE_ENABLED},
+        # Kill-list of tool plugin ids the frontend hides (merged at the config root).
+        "hidden_tools": settings.HIDDEN_TOOLS,
         "livekit": {
             "url": settings.LIVEKIT_CONFIGURATION["url"],
             "force_wss_protocol": settings.LIVEKIT_FORCE_WSS_PROTOCOL,

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -669,6 +669,30 @@ class RoomViewSet(
     @decorators.action(
         detail=True,
         methods=["post"],
+        url_path="stop-subtitle",
+        permission_classes=[
+            permissions.HasLiveKitRoomAccess,
+        ],
+        authentication_classes=[LiveKitTokenAuthentication],
+    )
+    @FeatureFlag.require("subtitle")
+    def stop_subtitle(self, request, pk=None):  # pylint: disable=unused-argument
+        """Stop the room's native realtime-transcription agent.
+
+        Symmetric inverse of start-subtitle: tears down the room-wide native
+        subtitle agent. Idempotent + best-effort — no error if no agent is
+        running. Requires a valid LiveKit room token, like start-subtitle.
+        """
+
+        room = self.get_object()
+        SubtitleService().stop_subtitle(room)
+        return drf_response.Response(
+            {"status": "success"}, status=drf_status.HTTP_200_OK
+        )
+
+    @decorators.action(
+        detail=True,
+        methods=["post"],
         url_path="mute-participant",
         url_name="mute-participant",
         permission_classes=[permissions.CanMuteParticipant],

--- a/src/backend/core/services/subtitle.py
+++ b/src/backend/core/services/subtitle.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from django.conf import settings
 
 from asgiref.sync import async_to_sync
+from livekit.api import RoomParticipantIdentity
 from livekit.protocol.agent_dispatch import CreateAgentDispatchRequest
 
 from core import utils
@@ -42,6 +43,55 @@ class SubtitleService:
 
     @async_to_sync
     async def stop_subtitle(self, room) -> None:
-        """Stop subtitle agent for the specified room."""
+        """Stop the native subtitle agent for a room (best-effort, idempotent).
 
-        raise NotImplementedError("Subtitle agent stopping not yet implemented")
+        Native captions are ROOM-WIDE (one agent per room), so this tears down
+        the pipeline for ALL participants. Two levers, both room-scoped to
+        ``str(room.id)`` and safe to call when the agent is already gone:
+        - delete every agent dispatch for ``ROOM_SUBTITLE_AGENT_NAME`` in the room;
+        - evict the hidden agent participant ``f"{AGENT_NAME}-{room.id}"``.
+
+        A failure of either lever is logged and swallowed (non-fatal): callers
+        only want best-effort teardown.
+        """
+
+        room_name = str(room.id)
+        agent_name = settings.ROOM_SUBTITLE_AGENT_NAME
+        lkapi = utils.create_livekit_client()
+
+        try:
+            # Delete the dispatch(es) that spawned the agent for this room.
+            try:
+                dispatches = await lkapi.agent_dispatch.list_dispatch(
+                    room_name=room_name
+                )
+                for dispatch in dispatches:
+                    if dispatch.agent_name != agent_name:
+                        continue
+                    await lkapi.agent_dispatch.delete_dispatch(
+                        dispatch_id=dispatch.id, room_name=room_name
+                    )
+            except Exception:  # noqa: BLE001 — best-effort teardown, never raise
+                logger.warning(
+                    "Failed to delete subtitle agent dispatch(es) for room %s",
+                    room_name,
+                    exc_info=True,
+                )
+
+            # Evict the hidden agent participant (covers an agent still present
+            # even when no dispatch remains). Not-found is a no-op → idempotent.
+            try:
+                await lkapi.room.remove_participant(
+                    RoomParticipantIdentity(
+                        room=room_name, identity=f"{agent_name}-{room_name}"
+                    )
+                )
+            except Exception:  # noqa: BLE001 — best-effort teardown, never raise
+                logger.warning(
+                    "Failed to evict subtitle agent participant for room %s",
+                    room_name,
+                    exc_info=True,
+                )
+
+        finally:
+            await lkapi.aclose()

--- a/src/backend/core/tests/rooms/test_api_rooms_subtitle.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_subtitle.py
@@ -161,6 +161,43 @@ def test_start_subtitle_valid_token(
     assert call_args.room == "d2aeb774-1ecd-4d73-a3ac-3d3530cad7ff"
 
 
+def test_stop_subtitle_valid_token(
+    settings, mock_livekit_client, mock_livekit_token, mock_room_id
+):
+    """Stop-subtitle succeeds (best-effort) with a valid token + enabled feature."""
+
+    settings.ROOM_SUBTITLE_ENABLED = True
+
+    room = RoomFactory(id=mock_room_id)
+    client = APIClient()
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/stop-subtitle/",
+        {},
+        HTTP_AUTHORIZATION=f"Bearer {mock_livekit_token}",
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "success"}
+
+
+def test_stop_subtitle_disabled_by_default(mock_livekit_token):
+    """Stop-subtitle is gated on the SAME feature flag as start-subtitle."""
+
+    room = RoomFactory()
+    user = UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/stop-subtitle/",
+        {},
+        HTTP_AUTHORIZATION=f"Bearer {mock_livekit_token}",
+    )
+
+    assert response.status_code == 404
+
+
 def test_start_subtitle_twirp_error(
     settings, mock_livekit_client, mock_livekit_token, mock_room_id
 ):

--- a/src/backend/core/tests/services/test_subtitle.py
+++ b/src/backend/core/tests/services/test_subtitle.py
@@ -37,12 +37,62 @@ def test_start_subtitle_settings(mock_livekit_client, settings):
     assert call_args.room == str(room.id)
 
 
-def test_stop_subtitle_not_implemented():
-    """Test that stop_subtitle raises NotImplementedError."""
+def test_stop_subtitle_deletes_dispatch_and_evicts_agent(mock_livekit_client, settings):
+    """stop_subtitle deletes the room's matching dispatch and evicts the agent."""
+
+    settings.ROOM_SUBTITLE_AGENT_NAME = "multi-user-transcriber"
 
     room = RoomFactory(name="my room")
 
-    with pytest.raises(
-        NotImplementedError, match="Subtitle agent stopping not yet implemented"
-    ):
-        SubtitleService().stop_subtitle(room)
+    matching = mock.Mock(id="disp-1", agent_name="multi-user-transcriber")
+    other = mock.Mock(id="disp-2", agent_name="some-other-agent")
+    mock_livekit_client.agent_dispatch.list_dispatch.return_value = [matching, other]
+
+    SubtitleService().stop_subtitle(room)
+
+    # list_dispatch is scoped to the room id.
+    mock_livekit_client.agent_dispatch.list_dispatch.assert_called_once_with(
+        room_name=str(room.id)
+    )
+    # Only the matching dispatch is deleted (the foreign agent is left alone).
+    mock_livekit_client.agent_dispatch.delete_dispatch.assert_called_once_with(
+        dispatch_id="disp-1", room_name=str(room.id)
+    )
+    # The hidden agent participant is evicted by its per-room identity.
+    mock_livekit_client.room.remove_participant.assert_called_once()
+    remove_arg = mock_livekit_client.room.remove_participant.call_args[0][0]
+    assert remove_arg.room == str(room.id)
+    assert remove_arg.identity == f"multi-user-transcriber-{room.id}"
+
+    mock_livekit_client.aclose.assert_awaited_once()
+
+
+def test_stop_subtitle_idempotent_when_nothing_exists(mock_livekit_client, settings):
+    """With no dispatches, stop_subtitle deletes nothing yet still evicts + closes."""
+
+    settings.ROOM_SUBTITLE_AGENT_NAME = "multi-user-transcriber"
+
+    room = RoomFactory(name="my room")
+    mock_livekit_client.agent_dispatch.list_dispatch.return_value = []
+
+    # Must not raise even though there is nothing to delete.
+    SubtitleService().stop_subtitle(room)
+
+    mock_livekit_client.agent_dispatch.delete_dispatch.assert_not_called()
+    mock_livekit_client.room.remove_participant.assert_called_once()
+    mock_livekit_client.aclose.assert_awaited_once()
+
+
+def test_stop_subtitle_is_best_effort_on_failures(mock_livekit_client, settings):
+    """A failure of either lever is swallowed (non-fatal) and the client is closed."""
+
+    settings.ROOM_SUBTITLE_AGENT_NAME = "multi-user-transcriber"
+
+    room = RoomFactory(name="my room")
+    mock_livekit_client.agent_dispatch.list_dispatch.side_effect = RuntimeError("boom")
+    mock_livekit_client.room.remove_participant.side_effect = RuntimeError("boom")
+
+    # Both levers fail, but stop_subtitle must not raise (best-effort).
+    SubtitleService().stop_subtitle(room)
+
+    mock_livekit_client.aclose.assert_awaited_once()

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -17,6 +17,7 @@ import warnings
 from os import path
 from socket import gethostbyname, gethostname
 
+from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 import dj_database_url
@@ -51,6 +52,51 @@ def get_release():
             return json.load(version)["version"]
     except FileNotFoundError:
         return "NA"  # Default: not available
+
+
+class PluginsValue(values.ValidationMixin, values.DictValue):
+    """A ``DictValue`` for the frontend ``plugins`` namespace that validates the
+    config *envelope* (only) at boot.
+
+    The frontend reads ``config.plugins[<vendorId>]`` (e.g.
+    ``plugins['acme.transcription']``). The Django core knows nothing about any
+    particular plugin, so it validates only the shared envelope and leaves
+    plugin-specific extras to the frontend, per plugin:
+
+    * ``plugins`` is a dict,
+    * each entry is a dict,
+    * if present, ``enabled`` is a real ``bool`` (the truthy string ``"false"``
+      is rejected).
+
+    Golden rule: absent/empty is silently off (OK); present-but-malformed is
+    loud — the validator raises ``ValidationError`` and fails the boot fast.
+    """
+
+    @staticmethod
+    def validator(value):
+        """Validate the plugins envelope; raise ``ValidationError`` if malformed."""
+        if not isinstance(value, dict):
+            raise ValidationError("FRONTEND plugins config must be a dict.")
+        for plugin_id, plugin_config in value.items():
+            if not isinstance(plugin_config, dict):
+                raise ValidationError(
+                    f"FRONTEND plugins[{plugin_id!r}] must be a dict."
+                )
+            if "enabled" in plugin_config and not isinstance(
+                plugin_config["enabled"], bool
+            ):
+                raise ValidationError(
+                    f"FRONTEND plugins[{plugin_id!r}].enabled must be a real "
+                    f"boolean, got {plugin_config['enabled']!r}."
+                )
+
+    def to_python(self, value):
+        # ``DictValue`` runs ``ast.literal_eval`` on the env string; the default
+        # is already a dict, so only parse strings.
+        if isinstance(value, str):
+            value = values.DictValue.to_python(self, value)
+        self._validator(value)
+        return value
 
 
 class Base(Configuration):
@@ -419,7 +465,18 @@ class Base(Configuration):
         "auto_mute_on_join_threshold": values.PositiveIntegerValue(
             50, environ_name="FRONTEND_AUTO_MUTE_ON_JOIN_THRESHOLD", environ_prefix=None
         ),
+        # Plugins namespace: core validates only the envelope (``PluginsValue``);
+        # each plugin's extras are validated frontend-side.
+        "plugins": PluginsValue(
+            {}, environ_name="FRONTEND_PLUGINS", environ_prefix=None
+        ),
     }
+
+    # Kill-list of tool plugin ids the frontend must hide; surfaced at the
+    # runtime-config root as ``hidden_tools``.
+    HIDDEN_TOOLS = values.ListValue(
+        [], environ_name="FRONTEND_HIDDEN_TOOLS", environ_prefix=None
+    )
 
     # Mail
     EMAIL_BACKEND = values.Value("django.core.mail.backends.smtp.EmailBackend")

--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -26,3 +26,9 @@ styled-system-studio
 *.njsproj
 *.sln
 *.sw?
+
+# Deploy-time plugin bundles (built by vite.plugin.config.ts)
+dist-plugins
+
+# Built deploy-time plugin bundles (regenerable via the plugins/* vite build)
+/public/plugins/

--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -12,9 +12,14 @@ export default tseslint.config(
   {
     ignores: [
       'dist/**',
+      'dist-plugins/**',
       'node_modules/**',
       'coverage/**',
       'src/styled-system/**',
+      // Built deploy-time plugin bundles (build output, not source).
+      'public/plugins/**',
+      // Deploy-time plugin bundle sources (built by vite.plugin.config.ts, not the app graph).
+      'plugin-examples/**',
     ],
   },
 

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -63,7 +63,8 @@
         "typescript": "6.0.3",
         "typescript-eslint": "8.60.1",
         "vite": "8.0.14",
-        "vite-plugin-svgr": "5.2.0"
+        "vite-plugin-svgr": "5.2.0",
+        "vitest": "3.2.6"
       }
     },
     "node_modules/@adobe/react-spectrum": {
@@ -490,6 +491,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2069,6 +2512,356 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@spectrum-icons/ui": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/@spectrum-icons/ui/-/ui-3.7.1.tgz",
@@ -2439,6 +3232,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dom-mediacapture-record": {
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
@@ -2464,9 +3275,9 @@
       "peer": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2717,6 +3528,120 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -3082,6 +4007,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -4050,6 +4985,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4065,6 +5017,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -4546,6 +5508,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4959,6 +5931,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5013,6 +5992,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -5459,6 +6480,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -8133,6 +9164,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -8829,6 +9867,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -9612,6 +10660,51 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rollup-plugin-visualizer": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
@@ -10026,6 +11119,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -10100,6 +11200,13 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10109,6 +11216,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -10312,6 +11426,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10416,6 +11550,20 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10462,6 +11610,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -11137,6 +12315,135 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-plugin-svgr": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-5.2.0.tgz",
@@ -11426,6 +12733,222 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -11609,6 +13132,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,6 +7,8 @@
     "dev": "panda codegen && vite",
     "build": "panda codegen && tsc -b && vite build",
     "build:debug": "VITE_ANALYZE=true npm run build -- --debug",
+    "build:plugin": "vite build --config vite.plugin.config.ts",
+    "build:plugin-showcase": "PLUGIN_ENTRY=plugin-examples/showcase/index.tsx PLUGIN_NAME=showcase npm run build:plugin",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
+    "test": "vitest run",
     "i18n:extract": "npx i18next -c i18next-parser.config.json",
     "format": "prettier --write ./src",
     "check": "prettier --check ./src"
@@ -70,6 +71,7 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.1",
     "vite": "8.0.14",
-    "vite-plugin-svgr": "5.2.0"
+    "vite-plugin-svgr": "5.2.0",
+    "vitest": "3.2.6"
   }
 }

--- a/src/frontend/panda.config.ts
+++ b/src/frontend/panda.config.ts
@@ -73,6 +73,13 @@ const config: Config = {
         },
       },
       fade: { from: { opacity: 0 }, to: { opacity: 1 } },
+      // Pulsing "live" ring for a decorated caption button: an outline that
+      // expands and fades outward. Colored by the caller via `currentColor`.
+      caption_live_ring: {
+        '0%': { transform: 'scale(1)', opacity: '0.7' },
+        '70%': { transform: 'scale(1.55)', opacity: '0' },
+        '100%': { transform: 'scale(1.55)', opacity: '0' },
+      },
       pulse: {
         '0%': { boxShadow: '0 0 0 0 rgba(255, 255, 255, 0.7)' },
         '75%': { boxShadow: '0 0 0 30px rgba(255, 255, 255, 0)' },

--- a/src/frontend/panda.config.ts
+++ b/src/frontend/panda.config.ts
@@ -7,6 +7,7 @@ import {
   defineTextStyles,
   defineTokens,
 } from '@pandacss/dev'
+import { toneColor } from './src/primitives/tone'
 
 const spacing: Tokens['spacing'] = {
   0: { value: '0rem' },
@@ -35,6 +36,18 @@ const config: Config = {
   exclude: [],
   jsxFramework: 'react',
   outdir: 'src/styled-system',
+  // Tone classes are looked up at runtime (toneColor[tone]), invisible to static
+  // extraction — generate them unconditionally.
+  staticCss: {
+    css: [
+      {
+        properties: {
+          color: Object.values(toneColor),
+          backgroundColor: Object.values(toneColor),
+        },
+      },
+    ],
+  },
   globalFontface: {},
   theme: {
     ...pandaPreset.theme,

--- a/src/frontend/plugin-examples/README.md
+++ b/src/frontend/plugin-examples/README.md
@@ -1,0 +1,105 @@
+# Meet plugins — authoring guide
+
+A plugin extends a running meeting (a tool sub-panel, a live-caption source, a
+banner, a CC-button decoration…) without forking the app. This folder holds the
+reference examples the framework is built against.
+
+- **`smoke/`** — the minimal "hello world": a single tool panel. The CI gate builds
+  it to prove the external-bundle preset stays loadable and its externals bind to
+  the host singletons.
+- **`showcase/`** — the exhaustive reference: one plugin that exercises **every**
+  seam of the host ABI. It does nothing useful (it only generates test data); copy
+  the call you need. Unit-tested in `showcase/index.test.ts`.
+
+## The two ways a plugin loads
+
+1. **Built-in** — bundled with the app and registered in `src/main.tsx` via
+   `registerPlugin(manifest)`. This is how the shipped `record`/`transcribe` tools
+   are expressed (`src/features/recording/*.plugin.tsx`).
+2. **Deploy-time external bundle** — a self-contained UMD/IIFE served at a URL and
+   listed in the `VITE_PLUGIN_BUNDLES` env. No rebuild of the app to add one. This
+   is the path the examples here demonstrate.
+
+## Anatomy of an external bundle
+
+A bundle is a module that self-registers on eval and exposes `activate(host)`:
+
+```ts
+import type { MeetPluginHost } from '@/features/plugins/host'
+import type { Plugin } from '@/features/plugins/types'
+
+export function activate(host: MeetPluginHost): void {
+  host.i18n.addResourceBundle('en', 'acme-notes', { tool: { title: 'Notes' } }, true, true)
+  const manifest: Plugin = {
+    id: 'acme.notes',              // stable reverse-DNS id
+    apiVersion: '1.0.0',           // caret-matched against the host's HOST_API_VERSION
+    i18nNamespace: 'acme-notes',
+    isEnabled: () => true,         // runtime gate read from GET config/
+    contributes: { tool: { icon: /* … */, panel: { Component: NotesPanel } } },
+  }
+  host.registerPlugin(manifest)
+}
+
+// Self-register as soon as the bundle evaluates.
+;(globalThis as { __meetRegisterPlugin__?: (id: string, mod: { activate: typeof activate }) => void })
+  .__meetRegisterPlugin__?.('acme.notes', { activate })
+```
+
+Two golden rules:
+
+- **Reach everything through `host`.** The object passed to `activate(host)` is the
+  whole contract (see `src/features/plugins/host.ts#MeetPluginHost`): caption bus,
+  banner, notify, captionButton, broadcast, primitives, the data hooks
+  (`useConfig`/`useRoomData`/`useUser`/…), `fetchApi`, `pluginContext`, and more.
+- **Import host internals as types only.** `import type { … }` is erased at build,
+  so there is no runtime coupling. The only runtime imports are the shared
+  singletons (`react`, `valtio`, `livekit-client`), which the preset marks
+  `external` and binds to the host's copies — so a plugin's `react` IS the host's
+  React (identity-stable hooks/proxies).
+
+## Building a bundle
+
+The shared preset `vite.plugin.config.ts` builds any entry into a self-registering
+UMD, its singletons externalized:
+
+```sh
+# the showcase (also: npm run build:plugin-showcase)
+PLUGIN_ENTRY=plugin-examples/showcase/index.tsx PLUGIN_NAME=showcase \
+  npm run build:plugin
+# -> dist-plugins/showcase.umd.js
+```
+
+## Wiring it into a deployment
+
+Point the frontend at one or more built bundles via `VITE_PLUGIN_BUNDLES`, a JSON
+array of refs (`{ id, url, apiVersion, peers? }`):
+
+```sh
+VITE_PLUGIN_BUNDLES='[{"id":"example.showcase","url":"/plugins/showcase.umd.js","apiVersion":"1.0.0"}]'
+```
+
+A plugin is a **static file mounted into the stock frontend image** — the image is
+never rebuilt to add one. The production frontend image injects `VITE_*` env into a
+runtime `config.js` at container startup, so:
+
+```yaml
+services:
+  frontend:
+    image: meet-frontend:latest          # stock image, unmodified
+    environment:
+      VITE_PLUGIN_BUNDLES: '[{"id":"acme.notes","url":"/plugins/notes.umd.js","apiVersion":"1.0.0"}]'
+    volumes:
+      - ./my-plugins:/usr/share/nginx/html/plugins:ro   # your built .umd.js file(s)
+```
+
+The bundle is served at `/plugins/notes.umd.js` and loaded at boot. Adding, updating
+or removing a plugin is a volume + env change — no application rebuild.
+
+Each ref is loaded independently and gated: an incompatible `apiVersion`, a
+mismatched `peers` major, a slow, or a throwing bundle is skipped without taking the
+app down. Related knobs:
+
+- **`FRONTEND_HIDDEN_TOOLS`** — kill-list of tool-plugin ids the frontend must hide.
+
+The showcase is meant to be loaded in **dev/CI only** (it produces test data); never
+add it to the production `main.tsx`.

--- a/src/frontend/plugin-examples/showcase/index.test.ts
+++ b/src/frontend/plugin-examples/showcase/index.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { MeetPluginHost } from '@/features/plugins/host'
+import { demos, activate, buildManifest } from './index'
+
+// A minimal spy host: enough of the ABI for the imperative demos + activate().
+const token = Symbol('showcase-token')
+function mockHost() {
+  const captionBus = {
+    claim: vi.fn(() => token),
+    release: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    current: vi.fn(() => null),
+  }
+  const banner = { show: vi.fn(), hide: vi.fn() }
+  const captionButton = {
+    setDecoration: vi.fn(),
+    clearDecoration: vi.fn(),
+    popover: vi.fn(),
+  }
+  const ctxStore: Record<string, unknown> = {}
+  const host = {
+    apiVersion: '1.0.0',
+    registerPlugin: vi.fn(),
+    captionBus,
+    banner,
+    captionButton,
+    notify: vi.fn(),
+    i18n: { addResourceBundle: vi.fn() },
+    pluginContext: vi.fn(() => ctxStore),
+    primitives: { Icon: () => null },
+  } as unknown as MeetPluginHost
+  return { host, captionBus, banner, captionButton, ctxStore }
+}
+
+describe('showcase demos exercise each imperative seam', () => {
+  it('banner.show / banner.hide for every tone', () => {
+    const { host, banner } = mockHost()
+    demos.showBanners(host)
+    demos.hideBanners(host)
+    expect(banner.show).toHaveBeenCalledTimes(4)
+    expect(banner.show).toHaveBeenCalledWith(
+      'showcase-danger',
+      expect.objectContaining({ tone: 'danger' })
+    )
+    expect(banner.hide).toHaveBeenCalledTimes(4)
+  })
+
+  it('notify', () => {
+    const { host } = mockHost()
+    demos.toast(host)
+    expect(host.notify).toHaveBeenCalledWith(expect.any(String))
+  })
+
+  it('captionButton decoration + popover', () => {
+    const { host, captionButton } = mockHost()
+    demos.decorate(host)
+    demos.clearDecoration(host)
+    demos.popover(host)
+    expect(captionButton.setDecoration).toHaveBeenCalledWith('showcase', expect.objectContaining({ live: true }))
+    expect(captionButton.clearDecoration).toHaveBeenCalledWith('showcase')
+    expect(captionButton.popover).toHaveBeenCalledWith('showcase', expect.objectContaining({ text: expect.any(String) }))
+  })
+
+  it('pushLine appends via captionBus.push on a held token', () => {
+    const { host, captionBus } = mockHost()
+    demos.pushLine(host, token)
+    expect(captionBus.push).toHaveBeenCalledWith(
+      token,
+      expect.arrayContaining([expect.objectContaining({ text: expect.any(String) })])
+    )
+  })
+
+  it('replaceLine swaps via captionBus.replace on a held token', () => {
+    const { host, captionBus } = mockHost()
+    demos.replaceLine(host, token)
+    expect(captionBus.replace).toHaveBeenCalledWith(token, expect.any(Array))
+  })
+})
+
+describe('showcase activate() wires the registry/i18n/context seams', () => {
+  it('registers a manifest with both contributions + seeds context + i18n', () => {
+    const { host, ctxStore } = mockHost()
+    activate(host)
+
+    expect(host.i18n.addResourceBundle).toHaveBeenCalledWith(
+      'en',
+      'example-showcase',
+      expect.any(Object),
+      true,
+      true
+    )
+    expect(ctxStore).toEqual({ captionsDemo: false, captionMode: 'append' })
+
+    const registerPlugin = host.registerPlugin as ReturnType<typeof vi.fn>
+    expect(registerPlugin).toHaveBeenCalledTimes(1)
+    const manifest = registerPlugin.mock.calls[0][0]
+    expect(manifest.id).toBe('example.showcase')
+    expect(manifest.apiVersion).toBe('1.0.0')
+    expect(manifest.contributes.tool?.panel.Component).toBeTypeOf('function')
+    expect(manifest.contributes.captionController?.Controller).toBeTypeOf('function')
+  })
+
+  it('buildManifest is stable and enabled by default', () => {
+    const { host } = mockHost()
+    activate(host) // sets the module host used by buildManifest's JSX icon
+    const manifest = buildManifest()
+    expect(manifest.isEnabled()).toBe(true)
+    expect(manifest.order).toBe(100)
+  })
+})

--- a/src/frontend/plugin-examples/showcase/index.tsx
+++ b/src/frontend/plugin-examples/showcase/index.tsx
@@ -1,0 +1,355 @@
+// Showcase plugin — the reference example for authoring a deploy-time meet plugin.
+//
+// It is NOT a product feature: it does nothing useful, only generates test data.
+// Its single job is to touch EVERY seam of the host ABI so plugin authors can copy
+// a working call for each capability, and so the framework ships no frozen contract
+// without an in-tree consumer + test.
+//
+// Build it as a self-registering UMD bundle with the shared external-bundle preset:
+//   PLUGIN_ENTRY=plugin-examples/showcase/index.tsx PLUGIN_NAME=showcase \
+//     npx vite build --config vite.plugin.config.ts
+// then point the host at the emitted `dist-plugins/showcase.umd.js` via the
+// `VITE_PLUGIN_BUNDLES` env (see plugin-examples/README.md). It is loaded in dev/CI
+// only — never registered in the production `main.tsx`.
+//
+// The golden rule an author learns here: a plugin imports ONLY the shared singletons
+// (react/valtio/livekit, bound to the host at runtime) and reaches everything else
+// through the `host` object from `activate(host)`. Host internals are imported
+// `import type` only — types are erased at build, so there is no runtime coupling.
+import * as React from 'react'
+import type { MeetPluginHost } from '@/features/plugins/host'
+import type { Plugin } from '@/features/plugins/types'
+import type { NormalizedCaption } from '@/features/subtitle/captionBus'
+
+const PLUGIN_ID = 'example.showcase'
+const NS = 'example-showcase'
+
+// Captured from `activate(host)` and read by the panel/controller components below.
+// A bundle's code-split surfaces cannot share a module-local store across the
+// host↔bundle boundary, so anything cross-surface lives on `host.pluginContext`.
+let host: MeetPluginHost
+
+/** Cross-surface state shared between the panel and the headless controller. */
+interface ShowcaseContext {
+  captionsDemo: boolean
+  /** 'append' shows captionBus.push (lines accumulate); 'replace' shows captionBus.replace (one line). */
+  captionMode: 'append' | 'replace'
+}
+const context = (): ShowcaseContext =>
+  host.pluginContext(PLUGIN_ID) as unknown as ShowcaseContext
+
+// A rotating cast of fake speakers + phrases so the demo looks like a real
+// multi-person transcription: each speaker renders as its own coloured turn
+// (avatar + name) in the overlay, instead of one run-on block.
+const SPEAKERS = [
+  { key: 'alice', name: 'Alice', color: '#e5484d' },
+  { key: 'bob', name: 'Bob', color: '#4c86ff' },
+  { key: 'carol', name: 'Carol', color: '#30a46c' },
+  { key: 'dave', name: 'Dave', color: '#f5a623' },
+]
+const PHRASES = [
+  'Let me share my screen for a second.',
+  'Sounds good — I agree with that approach.',
+  'Can everyone see the slides okay?',
+  "I'll take the action item on the API.",
+  'We should follow up on this next week.',
+  'Any objections before we move on?',
+  'Good point, let me note that down.',
+  'Sorry, you cut out — could you repeat?',
+]
+
+let captionSeq = 0
+const demoCaption = (final: boolean): NormalizedCaption => {
+  const speaker = SPEAKERS[captionSeq % SPEAKERS.length]
+  const text = PHRASES[captionSeq % PHRASES.length]
+  captionSeq += 1
+  const now = Date.now()
+  return {
+    id: `${PLUGIN_ID}-${captionSeq}`,
+    speaker,
+    text,
+    final,
+    firstReceivedTime: now,
+    lastReceivedTime: now,
+    language: 'en',
+  }
+}
+
+// One banner per severity tone, so the demo shows every type at once.
+const BANNER_TONES = [
+  { tone: 'info', icon: 'info', text: 'Info banner' },
+  { tone: 'success', icon: 'check_circle', text: 'Success banner' },
+  { tone: 'warning', icon: 'warning', text: 'Warning banner' },
+  { tone: 'danger', icon: 'error', text: 'Danger banner' },
+] as const
+
+// ---------------------------------------------------------------------------
+// Imperative ABI demos — one call per capability. Kept as plain functions of
+// `host` (not buried in JSX handlers) so the panel buttons AND the unit test
+// exercise the exact same seam call. Copy any of these into a real plugin.
+// ---------------------------------------------------------------------------
+export const demos = {
+  /** banner seam: one ambient pill per tone (distinct ids, so they stack). */
+  showBanners: (h: MeetPluginHost) => {
+    for (const b of BANNER_TONES)
+      h.banner.show(`showcase-${b.tone}`, { text: b.text, icon: b.icon, tone: b.tone })
+  },
+  hideBanners: (h: MeetPluginHost) => {
+    for (const b of BANNER_TONES) h.banner.hide(`showcase-${b.tone}`)
+  },
+
+  /** notify seam: a generic toast. */
+  toast: (h: MeetPluginHost) => h.notify('Showcase toast'),
+
+  /** captionButton seam: decorate the CC button + a one-time popover. */
+  decorate: (h: MeetPluginHost) =>
+    h.captionButton.setDecoration('showcase', {
+      live: true,
+      badge: 'demo',
+      tone: 'info',
+      label: 'Showcase is decorating the CC button',
+    }),
+  clearDecoration: (h: MeetPluginHost) => h.captionButton.clearDecoration('showcase'),
+  // `once: 'per-meeting'` + roomId would show a hint at most once per meeting;
+  // omitted here so the demo button is repeatable.
+  popover: (h: MeetPluginHost) =>
+    h.captionButton.popover('showcase', {
+      text: 'Popover anchored to the CC button — click outside to dismiss.',
+    }),
+
+  // captionBus is TOP-OWNER-GATED: push/replace only work while you HOLD a claim,
+  // so these run inside the controller's held claim (below), never as one-shots
+  // (a one-shot claim→push→release would blank the stream on release).
+  /** captionBus.push — append one speaker's line; different speakers stack as turns. */
+  pushLine: (h: MeetPluginHost, token: symbol) =>
+    h.captionBus.push(token, [demoCaption(true)]),
+  /** captionBus.replace — swap the whole stream for a single latest line. */
+  replaceLine: (h: MeetPluginHost, token: symbol) =>
+    h.captionBus.replace(token, [demoCaption(true)]),
+}
+
+// ---------------------------------------------------------------------------
+// Headless caption controller: contributed via `contributes.captionController`,
+// the host mounts it inside RoomContext. It owns the caption bus ONLY while the
+// panel's "Demo captions" switch is on (state read from `pluginContext`), which
+// demonstrates claim/release/push + cross-surface context in one place.
+// ---------------------------------------------------------------------------
+function ShowcaseCaptionController(): null {
+  const ctx = host.valtio.useSnapshot(
+    context() as unknown as object
+  ) as ShowcaseContext
+
+  React.useEffect(() => {
+    if (!ctx.captionsDemo) return
+    // claim() at priority 10 overrides the native source (priority 0): a takeover.
+    // The claim is HELD for the whole demo — push/replace only work while on top.
+    const token = host.captionBus.claim(PLUGIN_ID, { priority: 10 })
+    if (!token) return
+    const tick = () =>
+      ctx.captionMode === 'replace'
+        ? demos.replaceLine(host, token)
+        : demos.pushLine(host, token)
+    tick()
+    const timer = setInterval(tick, 1500)
+    return () => {
+      clearInterval(timer)
+      host.captionBus.release(token) // hand the bus back to the native source
+    }
+  }, [ctx.captionsDemo, ctx.captionMode])
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Tool panel: a sub-panel "app" contributed via `contributes.tool`. Rendered in
+// the Tools menu; drives the imperative demos + reflects the read seams.
+// ---------------------------------------------------------------------------
+function ShowcasePanel(): React.ReactElement {
+  const { Text, Button, Switch, Icon } = host.primitives
+
+  // --- Read seams: config, plugin config slice, room/user/rights/metadata. ---
+  const { data: config } = host.useConfig()
+  const pluginSlice = host.usePluginConfig(PLUGIN_ID as never)
+  const room = host.useRoomData()
+  const user = host.useUser()
+  const isAdmin = host.useIsAdminOrOwner()
+  const metadata = host.useRoomMetadata()
+
+  // --- Peer broadcast: propagate a counter to every participant, no server. ---
+  const broadcast = host.useBroadcast<{ hello: number }>(PLUGIN_ID)
+
+  // --- Cross-surface context that gates the headless caption controller. ---
+  const ctx = host.valtio.useSnapshot(
+    context() as unknown as object
+  ) as ShowcaseContext
+
+  // --- Data seam: an authenticated fetch, with the host's typed error. ---
+  const [fetchState, setFetchState] = React.useState('idle')
+  const ping = async () => {
+    try {
+      await host.fetchApi('config/')
+      setFetchState('ok')
+    } catch (error) {
+      setFetchState(
+        error instanceof host.ApiError ? `error ${error.statusCode}` : 'error'
+      )
+    }
+  }
+
+  // --- accessGate: the generic "no access" surface, shown to non-admins.
+  // An author supplies their own i18n keys, image and request handler. ---
+  if (!isAdmin) {
+    const AccessGate = host.accessGate
+    return (
+      <AccessGate
+        i18nKeyPrefix="example-showcase"
+        i18nKey="noAccess"
+        imagePath="/icon.png"
+        isActive={false}
+        handleRequest={async () => host.notify('Access requested')}
+      />
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      <Text variant="h3" margin={false}>
+        <Icon type="symbols" name="extension" aria-hidden /> Plugin ABI showcase
+      </Text>
+
+      <Button size="sm" onPress={() => demos.showBanners(host)}>
+        Show banners (all tones)
+      </Button>
+      <Button size="sm" variant="tertiary" onPress={() => demos.hideBanners(host)}>
+        Hide banners
+      </Button>
+      <Button size="sm" onPress={() => demos.toast(host)}>
+        Toast (notify)
+      </Button>
+      <Button size="sm" onPress={() => demos.decorate(host)}>
+        Decorate CC button
+      </Button>
+      <Button
+        size="sm"
+        variant="tertiary"
+        onPress={() => demos.clearDecoration(host)}
+      >
+        Clear decoration
+      </Button>
+      <Button size="sm" onPress={() => demos.popover(host)}>
+        CC popover
+      </Button>
+
+      {/* caption bus: a headless controller HOLDS a claim (a takeover) and, each
+          tick, either pushes (append) or replaces (single line) per the mode. */}
+      <Switch
+        isSelected={ctx.captionsDemo}
+        onChange={(on) => {
+          context().captionsDemo = on
+        }}
+      >
+        Demo captions — take over the bus + generate test lines
+      </Switch>
+      <Switch
+        isSelected={ctx.captionMode === 'replace'}
+        onChange={(on) => {
+          context().captionMode = on ? 'replace' : 'append'
+        }}
+      >
+        Replace mode (single line) instead of append
+      </Switch>
+      <Text variant="note">Current bus owner: {host.captionBus.current() ?? 'idle'}</Text>
+
+      {/* broadcast seam */}
+      <Button
+        size="sm"
+        onPress={() => broadcast.publish({ hello: Math.floor(Date.now() / 1000) })}
+      >
+        Broadcast to peers
+      </Button>
+      <Text variant="note">
+        Peers broadcasting: {Object.keys(broadcast.peers).length}
+      </Text>
+
+      {/* fetchApi + ApiError seams */}
+      <Button size="sm" onPress={ping}>
+        Ping API (fetchApi)
+      </Button>
+      <Text variant="note">Fetch: {fetchState}</Text>
+
+      {/* Read-only reflection of the data seams + analytics enum. */}
+      <Text variant="note">Room: {room?.id ?? '—'}</Text>
+      <Text variant="note">User: {user.user?.email ?? 'anonymous'}</Text>
+      <Text variant="note">Recording: {metadata?.status ?? '—'}</Text>
+      <Text variant="note">
+        Config subtitle: {String(config?.subtitle?.enabled ?? false)}
+      </Text>
+      <Text variant="note">Plugin config slice: {JSON.stringify(pluginSlice ?? null)}</Text>
+      <Text variant="note">Gated on flag: {host.analytics.FeatureFlags.Transcript}</Text>
+    </div>
+  )
+}
+
+/** The manifest this plugin registers — exported so a test can assert its shape. */
+export const buildManifest = (): Plugin => ({
+  id: PLUGIN_ID,
+  apiVersion: '1.0.0',
+  i18nNamespace: NS,
+  order: 100,
+  isEnabled: () => true,
+  contributes: {
+    tool: {
+      icon: <host.primitives.Icon type="symbols" name="extension" />,
+      titleKey: 'tool.title',
+      descriptionKey: 'tool.body',
+      panel: {
+        Component: ShowcasePanel,
+        headingKey: 'panel.heading',
+        contentKey: 'panel.content',
+      },
+    },
+    captionController: {
+      priority: 10,
+      Controller: ShowcaseCaptionController,
+    },
+  },
+})
+
+/** Entry point the host calls after the bundle self-registers. */
+export function activate(pluginHost: MeetPluginHost): void {
+  host = pluginHost
+
+  // i18n seam: contribute this plugin's namespace for the languages meet ships.
+  // (fallbackLng is 'fr', so registering en + fr also covers de/nl.)
+  const strings: Record<string, object> = {
+    en: {
+      tool: {
+        title: 'ABI Showcase',
+        body: 'Reference plugin exercising every host capability.',
+      },
+      panel: { heading: 'ABI Showcase', content: 'Close the showcase panel' },
+    },
+    fr: {
+      tool: {
+        title: 'Showcase de l’ABI',
+        body: 'Plugin de référence qui exerce chaque capacité de l’hôte.',
+      },
+      panel: { heading: 'Showcase de l’ABI', content: 'Fermer le panneau showcase' },
+    },
+  }
+  for (const lng of Object.keys(strings)) {
+    host.i18n.addResourceBundle(lng, NS, strings[lng], true, true)
+  }
+
+  // Seed the cross-surface context before either surface reads it.
+  Object.assign(context(), { captionsDemo: false, captionMode: 'append' })
+
+  host.registerPlugin(buildManifest())
+}
+
+// Self-register with the host as soon as the bundle evaluates.
+;(
+  globalThis as {
+    __meetRegisterPlugin__?: (id: string, mod: { activate: typeof activate }) => void
+  }
+).__meetRegisterPlugin__?.(PLUGIN_ID, { activate })

--- a/src/frontend/plugin-examples/smoke/index.tsx
+++ b/src/frontend/plugin-examples/smoke/index.tsx
@@ -1,0 +1,47 @@
+// Minimal smoke plugin the CI gate builds through `vite.plugin.config.ts` to
+// prove the external-bundle preset stays loadable and its externals bind to host
+// globals. Self-registering UMD/IIFE: on eval it hands the host `{ activate }`.
+import { proxy, useSnapshot } from 'valtio'
+
+const PLUGIN_ID = 'example.smoke'
+
+// Uses the host valtio singleton (external) — proves cross-boundary identity.
+const state = proxy({ activated: false })
+
+// Trivial panel; its JSX exercises `react/jsx-runtime` (external) to prove React is shared.
+function SmokePanel() {
+  const snap = useSnapshot(state)
+  return <div data-testid="smoke-panel">smoke: {snap.activated ? 'on' : 'off'}</div>
+}
+
+interface PluginHostLike {
+  registerPlugin(plugin: unknown): void
+}
+
+function activate(host: PluginHostLike): void {
+  state.activated = true
+  host.registerPlugin({
+    id: PLUGIN_ID,
+    apiVersion: '1.0.0',
+    i18nNamespace: 'example-smoke',
+    isEnabled: () => true,
+    contributes: {
+      tool: {
+        icon: null,
+        panel: { Component: SmokePanel },
+      },
+    },
+  })
+}
+
+interface RegisterHost {
+  __meetRegisterPlugin__?: (
+    id: string,
+    mod: { activate: (host: PluginHostLike) => void }
+  ) => void
+}
+
+// Self-register with the host as soon as the bundle evaluates.
+;(globalThis as RegisterHost).__meetRegisterPlugin__?.(PLUGIN_ID, { activate })
+
+export { activate }

--- a/src/frontend/src/api/useConfig.ts
+++ b/src/frontend/src/api/useConfig.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { RecordingMode } from '@/features/recording'
 import type { Track } from 'livekit-client'
 type Source = Track.Source
+import type { KnownPluginId, PluginConfigMap } from '@/features/plugins/config'
 
 export interface ApiConfig {
   analytics?: {
@@ -58,6 +59,12 @@ export interface ApiConfig {
   transcription_destination?: string
   max_participants_for_sound: number
   auto_mute_on_join_threshold: number
+  /** Tool plugin ids force-hidden by the deployment, on top of isEnabled + replaces. */
+  hidden_tools?: string[]
+  /** Plugin config namespace, typed per-plugin via `PluginConfigMap` declaration merging. */
+  plugins?: {
+    [K in KnownPluginId]?: PluginConfigMap[K]
+  } & Record<string, { enabled?: boolean }>
 }
 
 const fetchConfig = (): Promise<ApiConfig> => {

--- a/src/frontend/src/features/banner/Banners.tsx
+++ b/src/frontend/src/features/banner/Banners.tsx
@@ -1,0 +1,71 @@
+import { useSnapshot } from 'valtio'
+import { css } from '@/styled-system/css'
+import { Icon, Text } from '@/primitives'
+import { toneColor } from '@/primitives/tone'
+import { bannerStore } from './bannerStore'
+
+/**
+ * Host-owned ambient-banner overlay: one fixed pill per active banner in
+ * `bannerStore`. Positioned under the recording egress banner so both coexist;
+ * multiple banners stack vertically.
+ */
+export const Banners = () => {
+  const { banners } = useSnapshot(bannerStore)
+
+  if (banners.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className={css({
+        position: 'fixed',
+        top: '48px',
+        left: '10px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        zIndex: 1,
+      })}
+    >
+      {banners.map((banner) => (
+        <div
+          key={banner.id}
+          data-attr={banner.testId ?? `banner-${banner.id}`}
+          className={css({
+            display: 'flex',
+            paddingY: '0.25rem',
+            paddingX: '0.75rem',
+            backgroundColor: toneColor[banner.tone ?? 'info'],
+            borderColor: 'white',
+            border: '1px solid',
+            color: 'white',
+            borderRadius: '4px',
+            gap: '0.5rem',
+            alignItems: 'center',
+          })}
+        >
+          <span
+            aria-hidden="true"
+            className={css({
+              width: '0.5rem',
+              height: '0.5rem',
+              borderRadius: '50%',
+              backgroundColor: 'white',
+              flexShrink: 0,
+            })}
+          />
+          {banner.icon && <Icon type="symbols" name={banner.icon} />}
+          <Text
+            variant="sm"
+            className={css({
+              fontWeight: '500 !important',
+            })}
+          >
+            {banner.text}
+          </Text>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/frontend/src/features/banner/bannerStore.test.ts
+++ b/src/frontend/src/features/banner/bannerStore.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { bannerStore, showBanner, hideBanner } from './bannerStore'
+
+const ids = (): string[] => bannerStore.banners.map((b) => b.id)
+
+beforeEach(() => {
+  bannerStore.banners.splice(0)
+})
+
+describe('bannerStore show / hide', () => {
+  it('shows a banner and lists it', () => {
+    expect(ids()).toEqual([])
+    showBanner('a', { text: 'hello' })
+    expect(ids()).toEqual(['a'])
+    expect(bannerStore.banners[0]).toMatchObject({ id: 'a', text: 'hello' })
+  })
+
+  it('carries icon and tone through', () => {
+    showBanner('a', { text: 'hi', icon: 'speech_to_text', tone: 'danger' })
+    expect(bannerStore.banners[0]).toMatchObject({
+      icon: 'speech_to_text',
+      tone: 'danger',
+    })
+  })
+
+  it('carries an optional producer-supplied testId through', () => {
+    showBanner('a', { text: 'hi', testId: 'acme-banner' })
+    expect(bannerStore.banners[0]).toMatchObject({ testId: 'acme-banner' })
+  })
+
+  it('leaves testId undefined when the producer omits it', () => {
+    showBanner('a', { text: 'hi' })
+    expect(bannerStore.banners[0].testId).toBeUndefined()
+  })
+
+  it('hides a banner by id', () => {
+    showBanner('a', { text: 'hello' })
+    hideBanner('a')
+    expect(ids()).toEqual([])
+  })
+
+  it('hide is a no-op for an unknown id', () => {
+    showBanner('a', { text: 'hello' })
+    hideBanner('nope')
+    expect(ids()).toEqual(['a'])
+  })
+})
+
+describe('bannerStore dedup by id', () => {
+  it('replaces content in place when re-showing the same id', () => {
+    showBanner('a', { text: 'first' })
+    showBanner('a', { text: 'second', tone: 'info' })
+    expect(ids()).toEqual(['a'])
+    expect(bannerStore.banners[0]).toMatchObject({
+      text: 'second',
+      tone: 'info',
+    })
+  })
+
+  it('keeps distinct ids as separate entries', () => {
+    showBanner('a', { text: 'A' })
+    showBanner('b', { text: 'B' })
+    expect(ids()).toEqual(['a', 'b'])
+  })
+})

--- a/src/frontend/src/features/banner/bannerStore.ts
+++ b/src/frontend/src/features/banner/bannerStore.ts
@@ -1,0 +1,44 @@
+import { proxy } from 'valtio'
+import type { Tone } from '@/primitives/tone'
+
+/** Banner severity the host maps to a themed background color in `<Banners/>`. */
+export type BannerTone = Tone
+
+/** A single ambient banner. `id` is the stable dedup key owned by its producer. */
+export interface Banner {
+  id: string
+  text: string
+  icon?: string
+  tone?: BannerTone
+  /** Optional DOM hook for automation; falls back to `banner-<id>`. */
+  testId?: string
+}
+
+interface BannerState {
+  banners: Banner[]
+}
+
+/** The banner payload a producer passes to `showBanner` (everything but `id`). */
+export type ShowBannerOptions = Omit<Banner, 'id'>
+
+/** Host-owned valtio store backing the ambient-banner surface. */
+export const bannerStore = proxy<BannerState>({ banners: [] })
+
+/** Show or replace-in-place the banner registered under `id`. */
+export const showBanner = (id: string, opts: ShowBannerOptions): void => {
+  const banner: Banner = { id, ...opts }
+  const idx = bannerStore.banners.findIndex((b) => b.id === id)
+  if (idx === -1) {
+    bannerStore.banners.push(banner)
+  } else {
+    bannerStore.banners[idx] = banner
+  }
+}
+
+/** Hide the banner registered under `id`. A no-op when none is active for it. */
+export const hideBanner = (id: string): void => {
+  const idx = bannerStore.banners.findIndex((b) => b.id === id)
+  if (idx !== -1) {
+    bannerStore.banners.splice(idx, 1)
+  }
+}

--- a/src/frontend/src/features/layout/components/RoomContentArea.tsx
+++ b/src/frontend/src/features/layout/components/RoomContentArea.tsx
@@ -6,6 +6,7 @@ import { cva } from '@/styled-system/css'
 import { useSubtitles } from '@/features/subtitle/hooks/useSubtitles'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
 import { Subtitles } from '@/features/subtitle/component/Subtitles'
+import { CaptionSources } from '@/features/subtitle/CaptionSources'
 import { MainNotificationToast } from '@/features/notifications/MainNotificationToast'
 import { useReactionsToolbar } from '@/features/reactions/hooks/useReactionsToolbar'
 
@@ -80,6 +81,7 @@ export function RoomContentArea({ children }: RoomContentAreaProps) {
         {children}
       </TrackAreaContainer>
       <Subtitles />
+      <CaptionSources />
       <MainNotificationToast />
     </RoomViewport>
   )

--- a/src/frontend/src/features/notifications/NotificationType.ts
+++ b/src/frontend/src/features/notifications/NotificationType.ts
@@ -17,4 +17,5 @@ export enum NotificationType {
   ScreenRecordingLimitReached = 'screenRecordingLimitReached',
   RecordingSaving = 'recordingSaving',
   PermissionsRemoved = 'permissionsRemoved',
+  Generic = 'generic',
 }

--- a/src/frontend/src/features/notifications/components/ToastRecordingRequest.tsx
+++ b/src/frontend/src/features/notifications/components/ToastRecordingRequest.tsx
@@ -9,6 +9,9 @@ import { Button } from '@/primitives'
 import { css } from '@/styled-system/css'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
 import { StyledToastContainer } from './StyledToastContainer'
+import { TRANSCRIPT_PLUGIN_ID } from '@/features/recording/transcript.plugin'
+import { SCREEN_RECORDING_PLUGIN_ID } from '@/features/recording/screenRecording.plugin'
+import { useIsToolVisible } from '@/features/plugins'
 
 export function ToastRecordingRequest({
   state,
@@ -20,36 +23,35 @@ export function ToastRecordingRequest({
   const participant = props.toast.content.participant
   const type = props.toast.content.type
 
-  const {
-    isTranscriptOpen,
-    openTranscript,
-    isScreenRecordingOpen,
-    openScreenRecording,
-  } = useSidePanel()
+  const { isSubPanelOpen, openSubPanel } = useSidePanel()
+  const isTranscriptToolVisible = useIsToolVisible(TRANSCRIPT_PLUGIN_ID)
+  const isScreenToolVisible = useIsToolVisible(SCREEN_RECORDING_PLUGIN_ID)
 
   const options = useMemo(() => {
     switch (type) {
       case NotificationType.TranscriptionRequested:
         return {
           key: 'transcript.requested',
-          isMenuOpen: isTranscriptOpen,
-          openMenu: openTranscript,
+          isMenuOpen: isSubPanelOpen(TRANSCRIPT_PLUGIN_ID),
+          canOpenMenu: isTranscriptToolVisible,
+          openMenu: () => openSubPanel(TRANSCRIPT_PLUGIN_ID),
         }
       case NotificationType.ScreenRecordingRequested:
         return {
           key: 'screenRecording.requested',
-          isMenuOpen: isScreenRecordingOpen,
-          openMenu: openScreenRecording,
+          isMenuOpen: isSubPanelOpen(SCREEN_RECORDING_PLUGIN_ID),
+          canOpenMenu: isScreenToolVisible,
+          openMenu: () => openSubPanel(SCREEN_RECORDING_PLUGIN_ID),
         }
       default:
         return
     }
   }, [
     type,
-    isTranscriptOpen,
-    isScreenRecordingOpen,
-    openTranscript,
-    openScreenRecording,
+    isSubPanelOpen,
+    openSubPanel,
+    isTranscriptToolVisible,
+    isScreenToolVisible,
   ])
 
   if (!options) return
@@ -66,7 +68,7 @@ export function ToastRecordingRequest({
         {t(options.key, {
           name: participant?.name,
         })}
-        {!options.isMenuOpen && (
+        {!options.isMenuOpen && options.canOpenMenu && (
           <div
             className={css({
               marginLeft: '0.5rem',

--- a/src/frontend/src/features/notifications/notify.ts
+++ b/src/frontend/src/features/notifications/notify.ts
@@ -1,0 +1,11 @@
+import { toastQueue } from './components/ToastProvider'
+import { NotificationType } from './NotificationType'
+import { NotificationDuration } from './NotificationDuration'
+
+/** Enqueue a plain toast; the thin surface `host.notify` exposes. */
+export const notify = (message: string): void => {
+  toastQueue.add(
+    { type: NotificationType.Generic, message },
+    { timeout: NotificationDuration.MESSAGE }
+  )
+}

--- a/src/frontend/src/features/plugins/PanelErrorBoundary.tsx
+++ b/src/frontend/src/features/plugins/PanelErrorBoundary.tsx
@@ -1,0 +1,23 @@
+import { Component, type ReactNode } from 'react'
+
+interface Props {
+  fallback: ReactNode
+  children: ReactNode
+}
+
+/**
+ * Contains a plugin panel failure (lazy chunk 404 after a redeploy, or a render
+ * error in third-party code) instead of letting it unmount the whole app.
+ * Class component: error boundaries have no hook equivalent.
+ */
+export class PanelErrorBoundary extends Component<Props, { hasError: boolean }> {
+  state = { hasError: false }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children
+  }
+}

--- a/src/frontend/src/features/plugins/broadcast.ts
+++ b/src/frontend/src/features/plugins/broadcast.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { proxy, useSnapshot } from 'valtio'
+import {
+  RoomEvent,
+  type Participant,
+  type RemoteParticipant,
+} from 'livekit-client'
+import { useRoomContext } from '@livekit/components-react'
+
+/**
+ * Generic peer-to-peer broadcast over LiveKit participant data: propagate a small
+ * JSON state to every participant with no server. `publishData` rides the
+ * per-participant `canPublishData` grant, not the room-admin secret, so a
+ * frontend-only plugin can drive shared all-participants state.
+ *
+ * Durability (LiveKit does not replay data messages to joiners): the producer
+ * heartbeats every {@link HEARTBEAT_MS} and resyncs targeted state on join;
+ * subscribers evict a peer after {@link TTL_MS}, an explicit clear, or disconnect.
+ */
+const HEARTBEAT_MS = 4000
+const TTL_MS = 11000 // ~2.75 heartbeats: survives a couple of dropped beats
+
+interface Envelope {
+  ns: string
+  /** `null` is an explicit tombstone (stop producing). */
+  v: unknown
+}
+
+/**
+ * One channel per namespace. `store` (reactive) holds only the payloads, so its
+ * snapshot identity changes only on a real payload change; `seen` (non-reactive)
+ * tracks liveness for TTL eviction, so heartbeats never churn the snapshot.
+ */
+interface Channel {
+  store: { peers: Record<string, unknown> }
+  seen: Map<string, number>
+}
+const channels = new Map<string, Channel>()
+const channelFor = (ns: string): Channel => {
+  let c = channels.get(ns)
+  if (!c) {
+    c = {
+      store: proxy<{ peers: Record<string, unknown> }>({ peers: {} }),
+      seen: new Map(),
+    }
+    channels.set(ns, c)
+  }
+  return c
+}
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+const encode = (env: Envelope): Uint8Array =>
+  textEncoder.encode(JSON.stringify(env))
+const decode = (data: Uint8Array): Envelope | null => {
+  try {
+    return JSON.parse(textDecoder.decode(data)) as Envelope
+  } catch {
+    return null
+  }
+}
+
+/** Refresh liveness always; write the reactive store only when the payload changed. */
+const setPeer = (ch: Channel, id: string, payload: unknown): void => {
+  ch.seen.set(id, Date.now())
+  const prev = ch.store.peers[id]
+  if (prev === undefined || JSON.stringify(prev) !== JSON.stringify(payload)) {
+    ch.store.peers[id] = payload
+  }
+}
+const dropPeer = (ch: Channel, id: string): void => {
+  ch.seen.delete(id)
+  delete ch.store.peers[id]
+}
+
+export interface Broadcast<T> {
+  /** Set THIS client's produced state for the namespace; `null` clears it. */
+  publish: (payload: T | null) => void
+  /** Current live states keyed by producer identity (includes self while producing). */
+  peers: Record<string, T>
+}
+
+/** Subscribe to and produce a namespaced peer-broadcast; `peers` is reactive. */
+export function useBroadcast<T = unknown>(namespace: string): Broadcast<T> {
+  const room = useRoomContext()
+  const ch = channelFor(namespace)
+  const snap = useSnapshot(ch.store)
+  const selfRef = useRef<T | null>(null)
+
+  useEffect(() => {
+    if (!room) return
+
+    const onData = (data: Uint8Array, participant?: Participant) => {
+      const env = decode(data)
+      if (!env || env.ns !== namespace || !participant) return
+      if (env.v === null) dropPeer(ch, participant.identity)
+      else setPeer(ch, participant.identity, env.v)
+    }
+    const onJoin = (p: RemoteParticipant) => {
+      if (selfRef.current != null) {
+        room.localParticipant
+          .publishData(encode({ ns: namespace, v: selfRef.current }), {
+            reliable: true,
+            destinationIdentities: [p.identity],
+          })
+          .catch(() => {})
+      }
+    }
+    const onLeave = (p: RemoteParticipant) => dropPeer(ch, p.identity)
+    // Stores are module-level: drop the whole room's state on disconnect so a
+    // meeting joined later in the same tab never sees the previous one's peers.
+    const onDisconnect = () => {
+      ch.seen.clear()
+      ch.store.peers = {}
+    }
+
+    room.on(RoomEvent.DataReceived, onData)
+    room.on(RoomEvent.ParticipantConnected, onJoin)
+    room.on(RoomEvent.ParticipantDisconnected, onLeave)
+    room.on(RoomEvent.Disconnected, onDisconnect)
+
+    const hb = setInterval(() => {
+      if (selfRef.current != null) {
+        room.localParticipant
+          .publishData(encode({ ns: namespace, v: selfRef.current }), {
+            reliable: true,
+          })
+          .catch(() => {})
+      }
+      const now = Date.now()
+      for (const [id, ts] of ch.seen) {
+        if (now - ts > TTL_MS) dropPeer(ch, id)
+      }
+    }, HEARTBEAT_MS)
+
+    return () => {
+      room.off(RoomEvent.DataReceived, onData)
+      room.off(RoomEvent.ParticipantConnected, onJoin)
+      room.off(RoomEvent.ParticipantDisconnected, onLeave)
+      room.off(RoomEvent.Disconnected, onDisconnect)
+      clearInterval(hb)
+    }
+  }, [room, namespace, ch])
+
+  const publish = useCallback(
+    (payload: T | null) => {
+      selfRef.current = payload
+      // Write self into the SHARED store so every consumer of the namespace in
+      // this tab sees one consistent view — not just this hook instance.
+      if (room) {
+        const id = room.localParticipant.identity
+        if (payload === null) dropPeer(ch, id)
+        else setPeer(ch, id, payload)
+      }
+      room?.localParticipant
+        .publishData(encode({ ns: namespace, v: payload }), { reliable: true })
+        .catch(() => {})
+    },
+    [room, namespace, ch]
+  )
+
+  const peers = useMemo(() => {
+    const out: Record<string, T> = {}
+    for (const [id, payload] of Object.entries(snap.peers)) out[id] = payload as T
+    return out
+  }, [snap])
+
+  return { publish, peers }
+}

--- a/src/frontend/src/features/plugins/config.ts
+++ b/src/frontend/src/features/plugins/config.ts
@@ -1,0 +1,20 @@
+import { useConfig } from '@/api/useConfig'
+
+/**
+ * Open interface each plugin augments via declaration merging to type its own
+ * config slice (TanStack Router's `Register` pattern).
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface PluginConfigMap {}
+
+/** Union of the ids that have declared a typed config slice. */
+export type KnownPluginId = keyof PluginConfigMap
+
+/** Typed accessor for a plugin's config slice from the `plugins` namespace. */
+export function usePluginConfig<K extends KnownPluginId>(
+  id: K
+): PluginConfigMap[K] | undefined {
+  const { data } = useConfig()
+  // Cast at the network boundary: `plugins` mixes typed slices with a Record fallback.
+  return data?.plugins?.[id] as PluginConfigMap[K] | undefined
+}

--- a/src/frontend/src/features/plugins/context.test.ts
+++ b/src/frontend/src/features/plugins/context.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { proxy } from 'valtio'
+import { pluginContext } from './context'
+
+describe('pluginContext', () => {
+  it('returns an identity-stable proxy per id', () => {
+    const a1 = pluginContext('vendor.alpha')
+    const a2 = pluginContext('vendor.alpha')
+    expect(a1).toBe(a2)
+  })
+
+  it('isolates distinct ids', () => {
+    const a = pluginContext('vendor.alpha')
+    const b = pluginContext('vendor.beta')
+    expect(a).not.toBe(b)
+  })
+
+  it('is a valtio proxy (writes are observable via a fresh snapshot)', () => {
+    const ctx = pluginContext('vendor.gamma') as { count?: number }
+    ctx.count = 1
+    // A separate proxy is NOT affected — proves per-id isolation, not a shared object.
+    const other = proxy<{ count?: number }>({})
+    expect(other.count).toBeUndefined()
+    expect(ctx.count).toBe(1)
+  })
+})

--- a/src/frontend/src/features/plugins/context.ts
+++ b/src/frontend/src/features/plugins/context.ts
@@ -1,0 +1,17 @@
+import { proxy } from 'valtio'
+
+/**
+ * One lazily-created valtio proxy per plugin id — a host-owned store shared
+ * across a plugin's code-split surfaces (panel vs. headless controller), which
+ * can't share a bundle-local store. Lives on the one host valtio instance.
+ */
+const ctxByPlugin = new Map<string, object>()
+
+export const pluginContext = (id: string): object => {
+  let ctx = ctxByPlugin.get(id)
+  if (!ctx) {
+    ctx = proxy({})
+    ctxByPlugin.set(id, ctx)
+  }
+  return ctx
+}

--- a/src/frontend/src/features/plugins/host.ts
+++ b/src/frontend/src/features/plugins/host.ts
@@ -1,0 +1,191 @@
+// The narrow, framework-only host ABI a deploy-time plugin bundle receives from
+// `activate(host)`. Every field is a frozen contract external bundles compile against.
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import * as ReactDOMClient from 'react-dom/client'
+import * as ReactJSXRuntime from 'react/jsx-runtime'
+import * as Valtio from 'valtio'
+import { proxy, useSnapshot, subscribe } from 'valtio'
+import * as LivekitClient from 'livekit-client'
+import * as LivekitComponents from '@livekit/components-react'
+import { useRoomContext } from '@livekit/components-react'
+import i18next from 'i18next'
+import { Icon, Button, Text, Switch, Field } from '@/primitives'
+import { useConfig } from '@/api/useConfig'
+import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
+import { useUser } from '@/features/auth/api/useUser'
+import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
+import { useRoomMetadata } from '@/features/recording/hooks/useRoomMetadata'
+import { fetchApi } from '@/api/fetchApi'
+import { ApiError } from '@/api/ApiError'
+import { FeatureFlags } from '@/features/analytics/enums'
+import { usePluginConfig } from './config'
+import type { Plugin } from './types'
+import { registerPlugin } from './registry'
+import { useBroadcast } from './broadcast'
+import {
+  claim,
+  release,
+  push,
+  replace,
+  currentOwnerId,
+} from '@/features/subtitle/captionBus'
+import {
+  showBanner,
+  hideBanner,
+  type BannerTone,
+} from '@/features/banner/bannerStore'
+import {
+  setCaptionDecoration,
+  clearCaptionDecoration,
+  showCaptionPopover,
+  type CaptionDecorationOptions,
+  type CaptionPopoverOptions,
+} from '@/features/subtitle/captionButtonStore'
+import { notify } from '@/features/notifications/notify'
+import { NoAccessView } from '@/features/recording/components/NoAccessView'
+import { pluginContext } from './context'
+
+/** ABI version the host implements; the loader admits a bundle only when the host satisfies its `^apiVersion`. */
+export const HOST_API_VERSION = '1.0.0'
+
+/** Host major of every shared singleton; the loader refuses a bundle whose declared major diverges. */
+export const HOST_PEERS: Record<string, string> = {
+  react: '18',
+  'react-dom': '18',
+  'livekit-client': '2',
+  '@livekit/components-react': '2',
+  valtio: '2',
+}
+
+/**
+ * The ABI handed to a bundle's `activate(host)`. Shared singletons are passed BY
+ * REFERENCE so hook dispatchers and valtio proxies stay identity-stable across
+ * the host↔bundle boundary.
+ */
+export interface MeetPluginHost {
+  /** ABI version the host implements. */
+  readonly apiVersion: string
+  /** The one host React instance (also published on `window.React`). */
+  readonly react: typeof React
+  /** The one host valtio instance (proxy/useSnapshot/subscribe). */
+  readonly valtio: Pick<typeof Valtio, 'proxy' | 'useSnapshot' | 'subscribe'>
+  /** LiveKit React bindings the host exposes (room context only, for now). */
+  readonly livekit: Pick<typeof LivekitComponents, 'useRoomContext'>
+  /** Register a plugin manifest into the host registry. */
+  registerPlugin(plugin: Plugin): void
+  /** The priority-owned caption bus. */
+  readonly captionBus: {
+    claim: typeof claim
+    release: typeof release
+    push: typeof push
+    replace: typeof replace
+    current: typeof currentOwnerId
+  }
+  /** i18n seam — add a resource bundle to the host i18next singleton. */
+  readonly i18n: {
+    addResourceBundle: typeof i18next.addResourceBundle
+  }
+  /** Host-owned ambient-banner surface: show/hide an overlay pill keyed by `id`. */
+  readonly banner: {
+    show(
+      id: string,
+      opts: { text: string; icon?: string; tone?: BannerTone; testId?: string }
+    ): void
+    hide(id: string): void
+  }
+  /** Decoration surface for the CC button: badge/ring/label/popover keyed by `id`. */
+  readonly captionButton: {
+    setDecoration(id: string, opts: CaptionDecorationOptions): void
+    clearDecoration(id: string): void
+    popover(id: string, opts: CaptionPopoverOptions): void
+  }
+  /** Generic, product-agnostic toast: enqueue a plain message. */
+  readonly notify: typeof notify
+  /** Generic "no access" render/guard a surface shows when the user lacks rights. */
+  readonly accessGate: typeof NoAccessView
+  /** Frozen primitive set (Panda-styled) a bundle renders with. */
+  readonly primitives: {
+    Icon: typeof Icon
+    Button: typeof Button
+    Text: typeof Text
+    Switch: typeof Switch
+    Field: typeof Field
+  }
+  /** Read the deployment config (`GET config/`). */
+  useConfig: typeof useConfig
+  /** Read a plugin's typed config slice. */
+  usePluginConfig: typeof usePluginConfig
+  /** One host-owned valtio proxy per plugin id (cross-surface escape hatch). */
+  pluginContext: typeof pluginContext
+
+  // Data/service seams: room identity, user, admin rights, metadata, fetch.
+  /** Read the current room's API record (identity, `is_administrable`, …). */
+  useRoomData: typeof useRoomData
+  /** Read the currently logged-in user (auth state + profile). */
+  useUser: typeof useUser
+  /** Whether the current user is an admin/owner of the room. */
+  useIsAdminOrOwner: typeof useIsAdminOrOwner
+  /** Parsed LiveKit room metadata (broadcast to every participant). */
+  useRoomMetadata: typeof useRoomMetadata
+  /** Peer-to-peer broadcast over LiveKit participant data, with resync + TTL. */
+  useBroadcast: typeof useBroadcast
+  /** The host's authenticated fetch (credentials + CSRF + `apiUrl`). */
+  fetchApi: typeof fetchApi
+  /** Error thrown by `fetchApi` on a non-2xx response (`statusCode`/`body`). */
+  ApiError: typeof ApiError
+  /** Host analytics enums (feature-flag keys a surface gates itself on). */
+  readonly analytics: {
+    FeatureFlags: typeof FeatureFlags
+  }
+}
+
+/**
+ * Publish shared singletons on `window` before any bundle loads. Bundles are
+ * built with these globals as externals, so `react` inside a bundle resolves to
+ * `window.React` = the one host React. Idempotent.
+ */
+export const publishHostGlobals = (): void => {
+  window.React = React
+  window.ReactDOM = ReactDOM
+  window.ReactDOMClient = ReactDOMClient
+  window.ReactJSXRuntime = ReactJSXRuntime
+  window.__MEET_VALTIO__ = Valtio
+  window.__MEET_LIVEKIT_CLIENT__ = LivekitClient
+  window.__MEET_LIVEKIT_COMPONENTS__ = LivekitComponents
+  window.__MEET_PLUGINS__ ??= {}
+  window.__meetRegisterPlugin__ = (id, mod) => {
+    ;(window.__MEET_PLUGINS__ ??= {})[id] = mod
+  }
+}
+
+/** Build the single host object handed to every plugin's `activate(host)`. */
+export const buildHost = (): MeetPluginHost => ({
+  apiVersion: HOST_API_VERSION,
+  react: React,
+  valtio: { proxy, useSnapshot, subscribe },
+  livekit: { useRoomContext },
+  registerPlugin,
+  captionBus: { claim, release, push, replace, current: currentOwnerId },
+  i18n: { addResourceBundle: i18next.addResourceBundle.bind(i18next) },
+  banner: { show: showBanner, hide: hideBanner },
+  captionButton: {
+    setDecoration: setCaptionDecoration,
+    clearDecoration: clearCaptionDecoration,
+    popover: showCaptionPopover,
+  },
+  notify,
+  accessGate: NoAccessView,
+  primitives: { Icon, Button, Text, Switch, Field },
+  useConfig,
+  usePluginConfig,
+  pluginContext,
+  useRoomData,
+  useUser,
+  useIsAdminOrOwner,
+  useRoomMetadata,
+  useBroadcast,
+  fetchApi,
+  ApiError,
+  analytics: { FeatureFlags },
+})

--- a/src/frontend/src/features/plugins/index.ts
+++ b/src/frontend/src/features/plugins/index.ts
@@ -1,0 +1,8 @@
+// Plugin framework public API (registry). Built-in plugins are registered by
+// the app composition root (main.tsx), not here, so this barrel stays free of
+// concrete product features.
+export * from './types'
+export * from './config'
+export * from './registry'
+export * from './PanelErrorBoundary'
+export * from './useIsToolVisible'

--- a/src/frontend/src/features/plugins/index.ts
+++ b/src/frontend/src/features/plugins/index.ts
@@ -1,8 +1,10 @@
-// Plugin framework public API (registry). Built-in plugins are registered by
-// the app composition root (main.tsx), not here, so this barrel stays free of
-// concrete product features.
+// Plugin framework public API (registry, loader, host ABI). Built-in plugins are
+// registered by the app composition root (main.tsx), not here, so this barrel
+// stays free of concrete product features.
 export * from './types'
 export * from './config'
 export * from './registry'
+export * from './loader'
+export * from './host'
 export * from './PanelErrorBoundary'
 export * from './useIsToolVisible'

--- a/src/frontend/src/features/plugins/loader.test.ts
+++ b/src/frontend/src/features/plugins/loader.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Control the runtime env channel without the real getEnv/window plumbing.
+const env = vi.hoisted(() => ({ value: undefined as string | undefined }))
+vi.mock('@/utils/getEnv', () => ({ getEnv: () => env.value }))
+
+// Stub the host so importing the loader doesn't pull the whole host graph
+// (react-dom/primitives/livekit) into this pure unit test.
+vi.mock('./host', () => ({
+  HOST_API_VERSION: '1.0.0',
+  HOST_PEERS: {
+    react: '18',
+    'livekit-client': '2',
+    '@livekit/components-react': '2',
+    valtio: '2',
+  },
+  buildHost: vi.fn(),
+  publishHostGlobals: vi.fn(),
+}))
+
+import { parseRefs, isCompatible, type PluginBundleRef } from './loader'
+
+const ref = (over: Partial<PluginBundleRef> = {}): PluginBundleRef => ({
+  id: 'vendor.plugin',
+  url: 'https://cdn.example/plugin.umd.js',
+  apiVersion: '1.0.0',
+  ...over,
+})
+
+beforeEach(() => {
+  env.value = undefined
+})
+
+describe('parseRefs', () => {
+  it('returns [] when the env var is unset', () => {
+    expect(parseRefs()).toEqual([])
+  })
+
+  it('returns [] on malformed JSON', () => {
+    env.value = '{not json'
+    expect(parseRefs()).toEqual([])
+  })
+
+  it('returns [] when the JSON is not an array', () => {
+    env.value = '{"id":"x"}'
+    expect(parseRefs()).toEqual([])
+  })
+
+  it('parses a valid array of refs', () => {
+    const refs = [ref(), ref({ id: 'vendor.other' })]
+    env.value = JSON.stringify(refs)
+    expect(parseRefs()).toEqual(refs)
+  })
+})
+
+describe('isCompatible', () => {
+  it('accepts a ref whose apiVersion the host satisfies', () => {
+    expect(isCompatible(ref({ apiVersion: '1.0.0' }))).toBe(true)
+  })
+
+  it('rejects a ref requiring a newer host apiVersion', () => {
+    expect(isCompatible(ref({ apiVersion: '1.1.0' }))).toBe(false)
+    expect(isCompatible(ref({ apiVersion: '2.0.0' }))).toBe(false)
+  })
+
+  it('accepts matching peer majors', () => {
+    expect(isCompatible(ref({ peers: { react: '18', valtio: '2' } }))).toBe(true)
+  })
+
+  it('rejects a mismatched peer major', () => {
+    expect(isCompatible(ref({ peers: { react: '17' } }))).toBe(false)
+  })
+
+  it('ignores peers the host does not know about', () => {
+    expect(isCompatible(ref({ peers: { 'some-lib': '9' } }))).toBe(true)
+  })
+})

--- a/src/frontend/src/features/plugins/loader.ts
+++ b/src/frontend/src/features/plugins/loader.ts
@@ -1,0 +1,121 @@
+import { getEnv } from '@/utils/getEnv'
+import { satisfies } from './semver'
+import {
+  buildHost,
+  publishHostGlobals,
+  HOST_API_VERSION,
+  HOST_PEERS,
+  type MeetPluginHost,
+} from './host'
+
+/**
+ * A deploy-time bundle ref from `VITE_PLUGIN_BUNDLES`. `url` is a UMD/IIFE bundle
+ * that self-registers via `window.__meetRegisterPlugin__(id, module)` on eval.
+ */
+export interface PluginBundleRef {
+  id: string
+  url: string
+  /** ABI version the bundle targets — caret-gated against `HOST_API_VERSION`. */
+  apiVersion: string
+  /** Optional major-version pins for shared singletons (see `HOST_PEERS`). */
+  peers?: Record<string, string>
+}
+
+/** What a bundle self-registers: the entry point the host invokes post-load. */
+export interface PluginModule {
+  activate(host: MeetPluginHost): void | Promise<void>
+}
+
+/** Per-bundle load budget; a hung fetch/eval never blocks the others. */
+const LOAD_TIMEOUT_MS = 10_000
+
+/** Parse `VITE_PLUGIN_BUNDLES`; absent/empty/malformed → `[]` (never throws). */
+export const parseRefs = (): PluginBundleRef[] => {
+  const raw = getEnv('VITE_PLUGIN_BUNDLES')
+  if (!raw) return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as PluginBundleRef[]) : []
+  } catch {
+    return []
+  }
+}
+
+/** Compatibility gate: host must satisfy the bundle's `apiVersion` caret and every declared peer major. */
+export const isCompatible = (ref: PluginBundleRef): boolean => {
+  if (!satisfies(HOST_API_VERSION, `^${ref.apiVersion}`)) return false
+  for (const [lib, major] of Object.entries(ref.peers ?? {})) {
+    const hostMajor = HOST_PEERS[lib]
+    if (hostMajor && hostMajor !== major) return false
+  }
+  return true
+}
+
+/**
+ * Inject the bundle as a `<script>` and resolve once it self-registers under
+ * `ref.id`. Owns its load budget: on load, error OR timeout the script node is
+ * always removed. A bundle that registers after the timeout is never activated
+ * (bootPlugins only activates the resolved module), so it leaves no live surface.
+ */
+const loadBundle = (ref: PluginBundleRef): Promise<PluginModule> =>
+  new Promise<PluginModule>((resolve, reject) => {
+    const script = document.createElement('script')
+    let settled = false
+    const finish = (done: () => void) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      script.remove()
+      done()
+    }
+    const timer = setTimeout(
+      () =>
+        finish(() =>
+          reject(new Error(`bundle "${ref.id}" timed out after ${LOAD_TIMEOUT_MS}ms`))
+        ),
+      LOAD_TIMEOUT_MS
+    )
+    script.src = ref.url
+    script.async = true
+    script.onload = () =>
+      finish(() => {
+        const mod = window.__MEET_PLUGINS__?.[ref.id] as PluginModule | undefined
+        if (!mod) reject(new Error(`bundle "${ref.id}" loaded but did not register`))
+        else resolve(mod)
+      })
+    script.onerror = () =>
+      finish(() =>
+        reject(new Error(`bundle "${ref.id}" failed to load from ${ref.url}`))
+      )
+    document.head.appendChild(script)
+  })
+
+/**
+ * Boot every configured plugin bundle. Publishes host globals first, then loads
+ * and activates each ref independently: an incompatible, slow, or throwing
+ * bundle is skipped without affecting the others (a bad deploy config degrades
+ * gracefully instead of taking the app down).
+ */
+export const bootPlugins = async (): Promise<void> => {
+  publishHostGlobals()
+  const refs = parseRefs()
+  if (refs.length === 0) return
+
+  const host = buildHost()
+  await Promise.allSettled(
+    refs.map(async (ref) => {
+      if (!isCompatible(ref)) {
+        console.error(
+          `[plugins] skipping "${ref.id}": incompatible (apiVersion "${ref.apiVersion}", peers ${JSON.stringify(ref.peers ?? {})}, host "${HOST_API_VERSION}")`
+        )
+        return
+      }
+      try {
+        const mod = await loadBundle(ref)
+        await mod.activate(host)
+      } catch (error) {
+        console.error(`[plugins] failed to load/activate "${ref.id}"`, error)
+      }
+    })
+  )
+}

--- a/src/frontend/src/features/plugins/registry.test.ts
+++ b/src/frontend/src/features/plugins/registry.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  __clearRegistry,
+  getCaptionControllers,
+  registerPlugin,
+  resolveVisiblePlugins,
+  getVisibleToolPlugins,
+} from './registry'
+import type { Plugin } from './types'
+import type { ApiConfig } from '@/api/useConfig'
+
+/** Minimal ApiConfig carrying just the hidden_tools slice for resolver tests. */
+const cfg = (hidden_tools: string[]): ApiConfig =>
+  ({ hidden_tools }) as unknown as ApiConfig
+
+/** Build a minimal tool-plugin manifest for resolver tests (no rendering). */
+const mk = (
+  id: string,
+  opts: { order?: number; enabled?: boolean; replaces?: string[] } = {}
+): Plugin => ({
+  id,
+  apiVersion: '1.0.0',
+  i18nNamespace: id.replace(/\./g, '-'),
+  order: opts.order,
+  isEnabled: () => opts.enabled ?? true,
+  replaces: () => opts.replaces ?? [],
+  contributes: { tool: { icon: null, panel: { Component: () => null } } },
+})
+
+const ids = (plugins: Plugin[]): string[] => plugins.map((p) => p.id)
+
+/** Deterministic-output, non-deterministic-input Fisher–Yates shuffle. */
+const shuffle = <T>(arr: T[]): T[] => {
+  const out = [...arr]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+describe('resolveVisiblePlugins', () => {
+  it('(a) one plugin replaces two built-ins', () => {
+    const transcript = mk('recording.transcript')
+    const screenRecording = mk('recording.screen-recording')
+    const tool = mk('vendor.tool', {
+      replaces: ['recording.transcript', 'recording.screen-recording'],
+    })
+
+    const visible = resolveVisiblePlugins([transcript, screenRecording, tool])
+
+    expect(ids(visible)).toEqual(['vendor.tool'])
+  })
+
+  it('(b) two plugins hiding the same built-in — both survive', () => {
+    const builtin = mk('recording.transcript')
+    const p1 = mk('vendor.a', { replaces: ['recording.transcript'] })
+    const p2 = mk('vendor.b', { replaces: ['recording.transcript'] })
+
+    const visible = resolveVisiblePlugins([builtin, p1, p2])
+
+    expect(ids(visible)).toEqual(['vendor.a', 'vendor.b'])
+  })
+
+  it('(c) mutual A↔B — exactly one survivor, lowest order', () => {
+    const a = mk('vendor.a', { order: 0, replaces: ['vendor.b'] })
+    const b = mk('vendor.b', { order: 1, replaces: ['vendor.a'] })
+
+    const visible = resolveVisiblePlugins([a, b])
+
+    expect(ids(visible)).toEqual(['vendor.a'])
+  })
+
+  it('(d) cycle A→B→C→A — one survivor', () => {
+    const a = mk('vendor.a', { replaces: ['vendor.b'] })
+    const b = mk('vendor.b', { replaces: ['vendor.c'] })
+    const c = mk('vendor.c', { replaces: ['vendor.a'] })
+
+    const visible = resolveVisiblePlugins([a, b, c])
+
+    // Equal order → lexicographic tiebreak: a hides b, b is skipped,
+    // c hides a → only c survives.
+    expect(ids(visible)).toEqual(['vendor.c'])
+  })
+
+  it("(e) disabled plugin's replaces is ignored", () => {
+    const builtin = mk('recording.transcript')
+    const disabled = mk('vendor.tool', {
+      enabled: false,
+      replaces: ['recording.transcript'],
+    })
+
+    const visible = resolveVisiblePlugins([builtin, disabled])
+
+    expect(ids(visible)).toEqual(['recording.transcript'])
+  })
+
+  it('(f) hides plugins whose id is in config.hidden_tools', () => {
+    const transcript = mk('recording.transcript')
+    const screenRecording = mk('recording.screen-recording')
+    const acme = mk('acme.transcription')
+
+    const visible = resolveVisiblePlugins(
+      [transcript, screenRecording, acme],
+      cfg(['recording.transcript'])
+    )
+
+    // Equal order → lexicographic id tiebreak: acme.* before recording.*
+    expect(ids(visible)).toEqual([
+      'acme.transcription',
+      'recording.screen-recording',
+    ])
+  })
+
+  it('(g) hidden_tools applies on top of replaces', () => {
+    const transcript = mk('recording.transcript')
+    const acme = mk('acme.transcription', {
+      replaces: ['recording.transcript'],
+    })
+
+    // replaces already hides transcript; hidden_tools additionally hides nothing
+    // visible here, leaving only acme.
+    const visible = resolveVisiblePlugins(
+      [transcript, acme],
+      cfg(['recording.transcript'])
+    )
+
+    expect(ids(visible)).toEqual(['acme.transcription'])
+  })
+
+  it('(h) force-hiding every tool resolves to an empty menu', () => {
+    const only = mk('vendor.only')
+
+    const visible = resolveVisiblePlugins([only], cfg(['vendor.only']))
+
+    // No never-zero guard: an admin force-hiding the last tool gets an empty menu.
+    expect(ids(visible)).toEqual([])
+  })
+
+  it('is permutation-invariant (same set shuffled → identical output)', () => {
+    const all = [
+      mk('recording.transcript'),
+      mk('recording.screen-recording'),
+      mk('vendor.alpha', { order: 2, replaces: ['recording.transcript'] }),
+      mk('vendor.beta', { order: 1, replaces: ['vendor.alpha'] }),
+      mk('vendor.gamma', { order: 1, replaces: ['vendor.beta'] }),
+    ]
+
+    const expected = ids(resolveVisiblePlugins(all))
+
+    for (let i = 0; i < 50; i++) {
+      expect(ids(resolveVisiblePlugins(shuffle(all)))).toEqual(expected)
+    }
+  })
+})
+
+/** A headless caption controller stub for superset tests. */
+const CC = (): null => null
+
+/** Minimal native `Plugin` manifest (contributes a captionController). */
+const mkCC = (
+  id: string,
+  opts: { enabled?: boolean; priority?: number; ccEnabled?: boolean } = {}
+): Plugin => ({
+  id,
+  apiVersion: '1.0.0',
+  i18nNamespace: id.replace(/\./g, '-'),
+  isEnabled: () => opts.enabled ?? true,
+  contributes: {
+    captionController: {
+      priority: opts.priority,
+      Controller: CC,
+      isEnabled:
+        opts.ccEnabled === undefined ? undefined : () => opts.ccEnabled!,
+    },
+  },
+})
+
+describe('getCaptionControllers', () => {
+  beforeEach(() => __clearRegistry())
+
+  it('returns only enabled captionController contributions', () => {
+    registerPlugin(mk('vendor.tool-only')) // no controller
+    registerPlugin(mkCC('vendor.cc-on', { priority: 0 }))
+    registerPlugin(mkCC('vendor.cc-off', { enabled: false, priority: 5 }))
+
+    const ccs = getCaptionControllers()
+
+    expect(ccs.map((c) => c.priority)).toEqual([0])
+    expect(ccs[0].Controller).toBe(CC)
+  })
+
+  it('respects the contribution-level isEnabled gate', () => {
+    registerPlugin(mkCC('vendor.cc-on', { priority: 0 }))
+    registerPlugin(mkCC('vendor.cc-gated', { priority: 5, ccEnabled: false }))
+
+    const ccs = getCaptionControllers()
+
+    // Plugin is enabled, but the contribution gated itself off → excluded.
+    expect(ccs.map((c) => c.priority)).toEqual([0])
+  })
+
+  it('excludes a hidden_tools kill-listed plugin', () => {
+    registerPlugin(mkCC('vendor.cc-on', { priority: 0 }))
+    registerPlugin(mkCC('vendor.cc-killed', { priority: 5 }))
+
+    const ccs = getCaptionControllers(cfg(['vendor.cc-killed']))
+
+    expect(ccs.map((c) => c.pluginId)).toEqual(['vendor.cc-on'])
+  })
+})
+
+describe('getVisibleToolPlugins', () => {
+  beforeEach(() => __clearRegistry())
+
+  it('resolves visible tool plugins as their stored Plugin manifests', () => {
+    registerPlugin(mk('recording.transcript'))
+    registerPlugin(mk('vendor.tool', { replaces: ['recording.transcript'] }))
+    registerPlugin(mkCC('vendor.cc-only')) // non-tool → never visible here
+
+    const visible = getVisibleToolPlugins()
+
+    expect(visible.map((p) => p.id)).toEqual(['vendor.tool'])
+    expect(visible[0].apiVersion).toBe('1.0.0')
+    expect(visible[0].contributes.tool).toBeDefined()
+  })
+
+  it('a late registerPlugin() is observable to a re-reading consumer', () => {
+    // Selectors read the live registry, so a plugin registered AFTER an initial
+    // read (a late external bundle) appears on the next read. In React this
+    // re-read is triggered by the useRegistryVersion() bump on registration.
+    registerPlugin(mk('vendor.early'))
+    expect(getVisibleToolPlugins().map((p) => p.id)).toEqual(['vendor.early'])
+
+    registerPlugin(mk('vendor.late'))
+    expect(getVisibleToolPlugins().map((p) => p.id)).toEqual([
+      'vendor.early',
+      'vendor.late',
+    ])
+  })
+})

--- a/src/frontend/src/features/plugins/registry.ts
+++ b/src/frontend/src/features/plugins/registry.ts
@@ -1,0 +1,125 @@
+import { proxy, useSnapshot } from 'valtio'
+import type { ApiConfig } from '@/api/useConfig'
+import type { CaptionControllerContribution, Plugin } from './types'
+
+/** Reverse-DNS `vendor.feature` id format: lowercase, kebab segments allowed. */
+const ID_PATTERN =
+  /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$/
+
+const registry = new Map<string, Plugin>()
+
+// Bumped on every mutation so render-time selector callers re-render; only this
+// integer is proxied — Plugin objects never enter the reactive graph.
+const registryVersion = proxy({ n: 0 })
+
+/** Subscribe a component to registry mutations (re-render trigger only). */
+export const useRegistryVersion = (): number => useSnapshot(registryVersion).n
+
+/** DEV-only guard: reject a malformed or duplicate id before registering. */
+const assertRegistrable = (id: string): void => {
+  if (!ID_PATTERN.test(id)) {
+    throw new Error(
+      `[plugins] invalid id "${id}" — expected reverse-DNS vendor.feature (lowercase)`
+    )
+  }
+  if (registry.has(id)) throw new Error(`[plugins] duplicate id "${id}"`)
+}
+
+/** Register a plugin. DEV throws on a malformed/duplicate id; prod warns then overwrites. */
+export const registerPlugin = (p: Plugin): void => {
+  if (import.meta.env.DEV) {
+    assertRegistrable(p.id)
+  } else if (registry.has(p.id)) {
+    console.warn(
+      `[plugins] duplicate id "${p.id}" — overwriting the previous registration`
+    )
+  }
+  registry.set(p.id, p)
+  registryVersion.n++
+}
+
+/** Test-only: clears the module-level registry between cases. */
+export const __clearRegistry = (): void => {
+  registry.clear()
+  registryVersion.n++
+}
+
+/** All registered plugins, in insertion order. */
+export const getToolPlugins = (): Plugin[] => [...registry.values()]
+
+/** O(1) lookup of a registered plugin by id. */
+export const getPlugin = (id: string): Plugin | undefined => registry.get(id)
+
+/** The identity/gating subset the conflict resolver reads. */
+interface Precedence {
+  id: string
+  order?: number
+  isEnabled: (config?: ApiConfig) => boolean
+  replaces?: (config?: ApiConfig) => string[]
+}
+
+/** Precedence: lower `order` wins, lexicographic `id` as tiebreak. */
+const byPrecedence = (a: Precedence, b: Precedence): number =>
+  (a.order ?? 0) - (b.order ?? 0) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+
+/**
+ * Pure conflict resolver: filter by `isEnabled`, sort by precedence, then resolve
+ * `replaces` in a single pass (an already-hidden plugin does NOT contribute its
+ * own `replaces()`). Deterministic, independent of registration order.
+ */
+export const resolveVisiblePlugins = <T extends Precedence>(
+  all: T[],
+  config?: ApiConfig
+): T[] => {
+  const enabled = all.filter((p) => p.isEnabled(config)).sort(byPrecedence)
+  const hidden = new Set<string>()
+  for (const p of enabled) {
+    if (hidden.has(p.id)) {
+      // Hidden by a higher-precedence plugin, so its replaces() is ignored.
+      if (import.meta.env.DEV && (p.replaces?.(config) ?? []).length > 0) {
+        console.warn(
+          `[plugins] "${p.id}" is hidden by a higher-precedence plugin; its replaces() is ignored.`
+        )
+      }
+      continue
+    }
+    for (const v of p.replaces?.(config) ?? []) hidden.add(v)
+  }
+  const visible = enabled.filter((p) => !hidden.has(p.id))
+
+  // Deployment force-hide (config.hidden_tools). An admin who force-hides every
+  // tool gets an empty menu — their explicit choice, no un-hide guard.
+  const forceHidden = new Set(config?.hidden_tools ?? [])
+  if (forceHidden.size === 0) return visible
+  return visible.filter((p) => !forceHidden.has(p.id))
+}
+
+/**
+ * Resolve the visible tool plugins over the live registry. Plain selector, not a
+ * hook — render-time callers pair it with useRegistryVersion() for reactivity.
+ */
+export const getVisibleToolPlugins = (config?: ApiConfig): Plugin[] =>
+  resolveVisiblePlugins(
+    getToolPlugins().filter((p) => p.contributes.tool),
+    config
+  )
+
+/** A resolved caption controller tagged with its owning plugin id (stable key). */
+export interface ResolvedCaptionController extends CaptionControllerContribution {
+  pluginId: string
+}
+
+/**
+ * Enabled caption-controller contributions, subject to the same visibility rules
+ * as tools (`isEnabled`, `replaces`, `hidden_tools`) plus the contribution-level
+ * `isEnabled` gate — a kill-listed plugin must not mount its controller either.
+ */
+export const getCaptionControllers = (
+  config?: ApiConfig
+): ResolvedCaptionController[] =>
+  resolveVisiblePlugins(
+    getToolPlugins().filter((p) => p.contributes.captionController),
+    config
+  )
+    .map((p) => ({ ...p.contributes.captionController!, pluginId: p.id }))
+    .filter((cc) => cc.isEnabled?.(config) ?? true)

--- a/src/frontend/src/features/plugins/semver.test.ts
+++ b/src/frontend/src/features/plugins/semver.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { satisfies } from './semver'
+
+describe('satisfies (caret-only)', () => {
+  it('matches the exact floor', () => {
+    expect(satisfies('1.0.0', '^1.0.0')).toBe(true)
+  })
+
+  it('matches a higher patch/minor within the same major', () => {
+    expect(satisfies('1.0.5', '^1.0.0')).toBe(true)
+    expect(satisfies('1.4.0', '^1.2.0')).toBe(true)
+    expect(satisfies('1.2.9', '^1.2.3')).toBe(true)
+  })
+
+  it('rejects a version below the floor within the same major', () => {
+    expect(satisfies('1.1.0', '^1.2.0')).toBe(false)
+    expect(satisfies('1.2.2', '^1.2.3')).toBe(false)
+  })
+
+  it('rejects a different major (both directions)', () => {
+    expect(satisfies('2.0.0', '^1.0.0')).toBe(false)
+    expect(satisfies('1.9.9', '^2.0.0')).toBe(false)
+  })
+
+  it('rejects a non-caret range or an unparseable version', () => {
+    expect(satisfies('1.0.0', '1.0.0')).toBe(false)
+    expect(satisfies('1.0.0', '~1.0.0')).toBe(false)
+    expect(satisfies('1.0.0', '>=1.0.0')).toBe(false)
+    expect(satisfies('not-a-version', '^1.0.0')).toBe(false)
+  })
+
+  it('tolerates a version with a prerelease/build suffix on the numeric core', () => {
+    expect(satisfies('1.2.3-beta.1', '^1.0.0')).toBe(true)
+  })
+})

--- a/src/frontend/src/features/plugins/semver.ts
+++ b/src/frontend/src/features/plugins/semver.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal semver check (no dependency): supports only the caret form `^x.y.z`.
+ * True iff `version` has the same major and is >= the floor; anything else false.
+ */
+
+const CARET_RANGE = /^\^(\d+)\.(\d+)\.(\d+)$/
+const VERSION = /^(\d+)\.(\d+)\.(\d+)/
+
+export const satisfies = (version: string, range: string): boolean => {
+  const r = CARET_RANGE.exec(range)
+  if (!r) return false
+  const v = VERSION.exec(version)
+  if (!v) return false
+
+  const [rMajor, rMinor, rPatch] = [Number(r[1]), Number(r[2]), Number(r[3])]
+  const [vMajor, vMinor, vPatch] = [Number(v[1]), Number(v[2]), Number(v[3])]
+
+  if (vMajor !== rMajor) return false
+  if (vMinor !== rMinor) return vMinor > rMinor
+  return vPatch >= rPatch
+}

--- a/src/frontend/src/features/plugins/types.ts
+++ b/src/frontend/src/features/plugins/types.ts
@@ -1,0 +1,60 @@
+import type { ComponentType, LazyExoticComponent, ReactNode } from 'react'
+import type { ApiConfig } from '@/api/useConfig'
+
+/** A plugin sub-panel component, plain or `React.lazy(...)`. */
+export type PluginPanelComponent =
+  | ComponentType
+  | LazyExoticComponent<ComponentType>
+
+/** A plugin sub-panel: its lazy/plain component + i18n options. */
+export interface PluginPanel {
+  /** `React.lazy(...)` => first code-split of the tree. */
+  Component: PluginPanelComponent
+  /** Defaults to `'panel.heading'` in the plugin's `i18nNamespace`. */
+  headingKey?: string
+  /** Defaults to `'panel.content'` (close-button aria) in the ns. */
+  contentKey?: string
+}
+
+/** A Tools sub-panel "app" contribution. */
+export interface ToolContribution {
+  icon: ReactNode
+  /** Defaults to `'tool.title'` in the plugin's `i18nNamespace`. */
+  titleKey?: string
+  /** Defaults to `'tool.body'` in the plugin's `i18nNamespace`. */
+  descriptionKey?: string
+  panel: PluginPanel
+}
+
+/** A headless caption-controller contribution that claims the caption bus. */
+export interface CaptionControllerContribution {
+  /** Bus-ownership priority (lower wins/native, higher overrides). */
+  priority?: number
+  /** Headless component (returns null) that owns the bus while mounted. */
+  Controller: PluginPanelComponent
+  /** Runtime gate read from `GET config/`; defaults to always-on. */
+  isEnabled?: (config?: ApiConfig) => boolean
+}
+
+/** A plugin manifest: identity/gating fields plus what it `contributes`. */
+export interface Plugin {
+  /** Stable reverse-DNS `vendor.feature` id; also `layoutStore.activeSubPanelId`. */
+  id: string
+  /** Plugin ABI version the manifest targets (caret-matched by the host). */
+  apiVersion: string
+  /** i18n namespace loaded on demand; kebab-case, never the id. */
+  i18nNamespace: string
+  /** Deterministic order in the menu (lower wins, default 0). */
+  order?: number
+  /** Runtime gate read from `GET config/` — no rebuild to (de)activate. */
+  isEnabled: (config?: ApiConfig) => boolean
+  /** Ids of OTHER tools hidden when this one is active. */
+  replaces?: (config?: ApiConfig) => string[]
+  contributes: {
+    tool?: ToolContribution
+    captionController?: CaptionControllerContribution
+  }
+}
+
+/** Identity helper that types a plugin manifest at its definition site. */
+export const definePlugin = (p: Plugin): Plugin => p

--- a/src/frontend/src/features/plugins/useIsToolVisible.ts
+++ b/src/frontend/src/features/plugins/useIsToolVisible.ts
@@ -1,0 +1,13 @@
+import { useConfig } from '@/api/useConfig'
+import { getVisibleToolPlugins, useRegistryVersion } from './registry'
+
+/**
+ * Reactive: whether the tool plugin `id` survives visibility resolution
+ * (isEnabled, replaces, hidden_tools). Entry points that openSubPanel(id) must
+ * gate on this — Tools only renders panels of visible plugins.
+ */
+export const useIsToolVisible = (id: string): boolean => {
+  const { data } = useConfig()
+  useRegistryVersion()
+  return getVisibleToolPlugins(data).some((p) => p.id === id)
+}

--- a/src/frontend/src/features/recording/components/ControlsButton.tsx
+++ b/src/frontend/src/features/recording/components/ControlsButton.tsx
@@ -27,7 +27,8 @@ interface ControlsButtonProps {
   handle: () => void
   isPendingToStart: boolean
   isPendingToStop: boolean
-  openSidePanel: () => void
+  /** Shortcut to the other mode's panel; omit when that tool is not visible. */
+  openSidePanel?: () => void
 }
 
 const MIN_SPINNER_DISPLAY_TIME = 2000
@@ -119,7 +120,7 @@ export const ControlsButton = ({
   // Inactive state (Start button)
   return (
     <Layout>
-      {statuses.isAnotherModeStarted && (
+      {statuses.isAnotherModeStarted && openSidePanel && (
         <RACButton
           className={css({
             backgroundColor: 'primary.50',

--- a/src/frontend/src/features/recording/components/RecordingStateToast.tsx
+++ b/src/frontend/src/features/recording/components/RecordingStateToast.tsx
@@ -10,17 +10,20 @@ import {
 import { FeatureFlags } from '@/features/analytics/enums'
 import { Button as RACButton } from 'react-aria-components'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
+import { TRANSCRIPT_PLUGIN_ID } from '../transcript.plugin'
+import { SCREEN_RECORDING_PLUGIN_ID } from '../screenRecording.plugin'
 import { useRoomMetadata } from '../hooks/useRoomMetadata'
 import { RecordingStatusIcon } from './RecordingStatusIcon'
 import { useIsRecording } from '@livekit/components-react'
 import { useScreenReaderAnnounce } from '@/hooks/useScreenReaderAnnounce'
+import { useIsToolVisible } from '@/features/plugins'
 
 export const RecordingStateToast = () => {
   const { t } = useTranslation('rooms', {
     keyPrefix: 'recordingStateToast',
   })
 
-  const { openTranscript, openScreenRecording } = useSidePanel()
+  const { openSubPanel } = useSidePanel()
 
   const lastKeyRef = useRef('')
   const announce = useScreenReaderAnnounce()
@@ -53,6 +56,9 @@ export const RecordingStateToast = () => {
   const metadata = useRoomMetadata()
   const isRecording = useIsRecording()
 
+  const isTranscriptToolVisible = useIsToolVisible(TRANSCRIPT_PLUGIN_ID)
+  const isScreenToolVisible = useIsToolVisible(SCREEN_RECORDING_PLUGIN_ID)
+
   const key = useMemo(() => {
     if (!metadata?.recording_status || !metadata?.recording_mode) {
       return undefined
@@ -83,9 +89,11 @@ export const RecordingStateToast = () => {
 
   if (!key) return null
 
+  // Without a visible target panel the label degrades to plain text.
   const hasScreenRecordingAccessAndActive =
-    isScreenRecordingActive && hasScreenRecordingAccess
-  const hasTranscriptAccessAndActive = isTranscriptActive && hasTranscriptAccess
+    isScreenRecordingActive && hasScreenRecordingAccess && isScreenToolVisible
+  const hasTranscriptAccessAndActive =
+    isTranscriptActive && hasTranscriptAccess && isTranscriptToolVisible
 
   return (
     <>
@@ -124,7 +132,7 @@ export const RecordingStateToast = () => {
           )}
         {hasScreenRecordingAccessAndActive && (
           <RACButton
-            onPress={openScreenRecording}
+            onPress={() => openSubPanel(SCREEN_RECORDING_PLUGIN_ID)}
             className={css({
               textStyle: 'sm !important',
               fontWeight: '500 !important',
@@ -136,7 +144,7 @@ export const RecordingStateToast = () => {
         )}
         {hasTranscriptAccessAndActive && (
           <RACButton
-            onPress={openTranscript}
+            onPress={() => openSubPanel(TRANSCRIPT_PLUGIN_ID)}
             className={css({
               textStyle: 'sm !important',
               fontWeight: '500 !important',

--- a/src/frontend/src/features/recording/components/ScreenRecordingSidePanel.tsx
+++ b/src/frontend/src/features/recording/components/ScreenRecordingSidePanel.tsx
@@ -27,6 +27,8 @@ import { useTranscriptionLanguage } from '@/features/settings'
 import { useMutateRecording } from '../hooks/useMutateRecording'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
 import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
+import { TRANSCRIPT_PLUGIN_ID } from '../transcript.plugin'
+import { useIsToolVisible } from '@/features/plugins'
 import { FeatureFlags } from '@/features/analytics/enums'
 import { LimitDescription } from './LimitDescription'
 
@@ -57,7 +59,8 @@ export const ScreenRecordingSidePanel = () => {
   const statuses = useRecordingStatuses(RecordingMode.ScreenRecording)
 
   const room = useRoomContext()
-  const { openTranscript } = useSidePanel()
+  const { openSubPanel } = useSidePanel()
+  const isTranscriptToolVisible = useIsToolVisible(TRANSCRIPT_PLUGIN_ID)
 
   const handleRequestScreenRecording = async () => {
     await notifyParticipants({
@@ -205,7 +208,11 @@ export const ScreenRecordingSidePanel = () => {
         statuses={statuses}
         isPendingToStart={isPendingToStart}
         isPendingToStop={isPendingToStop}
-        openSidePanel={openTranscript}
+        openSidePanel={
+          isTranscriptToolVisible
+            ? () => openSubPanel(TRANSCRIPT_PLUGIN_ID)
+            : undefined
+        }
       />
     </Div>
   )

--- a/src/frontend/src/features/recording/components/TranscriptSidePanel.tsx
+++ b/src/frontend/src/features/recording/components/TranscriptSidePanel.tsx
@@ -35,6 +35,8 @@ import { useIsMetadataCollectorEnabled } from '../hooks/useMetadataCollectorEnab
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
 import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
 import { LimitDescription } from './LimitDescription'
+import { SCREEN_RECORDING_PLUGIN_ID } from '../screenRecording.plugin'
+import { useIsToolVisible } from '@/features/plugins'
 
 export const TranscriptSidePanel = () => {
   const { data } = useConfig()
@@ -72,7 +74,8 @@ export const TranscriptSidePanel = () => {
   const statuses = useRecordingStatuses(RecordingMode.Transcript)
 
   const room = useRoomContext()
-  const { openScreenRecording } = useSidePanel()
+  const { openSubPanel } = useSidePanel()
+  const isScreenToolVisible = useIsToolVisible(SCREEN_RECORDING_PLUGIN_ID)
 
   const handleRequestTranscription = async () => {
     await notifyParticipants({
@@ -257,7 +260,11 @@ export const TranscriptSidePanel = () => {
         statuses={statuses}
         isPendingToStart={isPendingToStart}
         isPendingToStop={isPendingToStop}
-        openSidePanel={openScreenRecording}
+        openSidePanel={
+          isScreenToolVisible
+            ? () => openSubPanel(SCREEN_RECORDING_PLUGIN_ID)
+            : undefined
+        }
       />
     </Div>
   )

--- a/src/frontend/src/features/recording/hooks/useIsRecordingModeEnabled.ts
+++ b/src/frontend/src/features/recording/hooks/useIsRecordingModeEnabled.ts
@@ -1,11 +1,17 @@
 import type { RecordingMode } from '../types'
-import { useConfig } from '@/api/useConfig'
+import { useConfig, type ApiConfig } from '@/api/useConfig'
 
-export const useIsRecordingModeEnabled = (mode: RecordingMode) => {
-  const { data } = useConfig()
-
-  return (
-    data?.recording?.is_enabled &&
-    data?.recording?.available_modes?.includes(mode)
+/** Pure predicate: is `mode` available in the deployment recording config? */
+export const isRecordingModeEnabled = (
+  config: ApiConfig | undefined,
+  mode: RecordingMode
+): boolean =>
+  !!(
+    config?.recording?.is_enabled &&
+    config?.recording?.available_modes?.includes(mode)
   )
+
+export const useIsRecordingModeEnabled = (mode: RecordingMode): boolean => {
+  const { data } = useConfig()
+  return isRecordingModeEnabled(data, mode)
 }

--- a/src/frontend/src/features/recording/screenRecording.plugin.tsx
+++ b/src/frontend/src/features/recording/screenRecording.plugin.tsx
@@ -1,0 +1,35 @@
+import { lazy } from 'react'
+import { Icon } from '@/primitives'
+import { definePlugin } from '@/features/plugins/types'
+import type { ApiConfig } from '@/api/useConfig'
+import { RecordingMode } from './types'
+import { isRecordingModeEnabled } from './hooks/useIsRecordingModeEnabled'
+
+/** Stable id — also the persisted `activeSubPanelId` and `tool-${id}` data-attr. */
+export const SCREEN_RECORDING_PLUGIN_ID = 'recording.screen-recording'
+
+/** Built-in "Record" sub-panel, expressed as a plugin. */
+export const plugin = definePlugin({
+  id: SCREEN_RECORDING_PLUGIN_ID,
+  apiVersion: '1.0.0',
+  i18nNamespace: 'rooms',
+  order: 20,
+  isEnabled: (config?: ApiConfig): boolean =>
+    isRecordingModeEnabled(config, RecordingMode.ScreenRecording),
+  contributes: {
+    tool: {
+      icon: <Icon type="symbols" name="mode_standby" />,
+      titleKey: 'moreTools.tools.screenRecording.title',
+      descriptionKey: 'moreTools.tools.screenRecording.body',
+      panel: {
+        Component: lazy(() =>
+          import('./components/ScreenRecordingSidePanel').then((m) => ({
+            default: m.ScreenRecordingSidePanel,
+          }))
+        ),
+        headingKey: 'sidePanel.heading.screenRecording',
+        contentKey: 'sidePanel.content.screenRecording',
+      },
+    },
+  },
+})

--- a/src/frontend/src/features/recording/transcript.plugin.tsx
+++ b/src/frontend/src/features/recording/transcript.plugin.tsx
@@ -1,0 +1,35 @@
+import { lazy } from 'react'
+import { Icon } from '@/primitives'
+import { definePlugin } from '@/features/plugins/types'
+import type { ApiConfig } from '@/api/useConfig'
+import { RecordingMode } from './types'
+import { isRecordingModeEnabled } from './hooks/useIsRecordingModeEnabled'
+
+/** Stable id — also the persisted `activeSubPanelId` and `tool-${id}` data-attr. */
+export const TRANSCRIPT_PLUGIN_ID = 'recording.transcript'
+
+/** Built-in "Transcribe" sub-panel, expressed as a plugin. */
+export const plugin = definePlugin({
+  id: TRANSCRIPT_PLUGIN_ID,
+  apiVersion: '1.0.0',
+  i18nNamespace: 'rooms',
+  order: 10,
+  isEnabled: (config?: ApiConfig): boolean =>
+    isRecordingModeEnabled(config, RecordingMode.Transcript),
+  contributes: {
+    tool: {
+      icon: <Icon type="symbols" name="speech_to_text" />,
+      titleKey: 'moreTools.tools.transcript.title',
+      descriptionKey: 'moreTools.tools.transcript.body',
+      panel: {
+        Component: lazy(() =>
+          import('./components/TranscriptSidePanel').then((m) => ({
+            default: m.TranscriptSidePanel,
+          }))
+        ),
+        headingKey: 'sidePanel.heading.transcript',
+        contentKey: 'sidePanel.content.transcript',
+      },
+    },
+  },
+})

--- a/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
@@ -7,6 +7,8 @@ import { RiArrowLeftLine, RiCloseLine } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 import { ParticipantsList } from './controls/Participants/ParticipantsList'
 import { useSidePanel } from '../hooks/useSidePanel'
+import { getVisibleToolPlugins, useRegistryVersion } from '@/features/plugins'
+import { useConfig } from '@/api/useConfig'
 import { ReactNode } from 'react'
 import { Chat } from '../prefabs/Chat'
 import { Effects } from './effects/Effects'
@@ -154,11 +156,28 @@ export const SidePanel = () => {
     isToolsOpen,
     isAdminOpen,
     isInfoOpen,
-    isSubPanelOpen,
     activeSubPanelId,
   } = useSidePanel()
   const { t } = useTranslation('rooms', { keyPrefix: 'sidePanel' })
-  const title = t(`heading.${activeSubPanelId || activePanelId}`)
+  // Sub-panel headings/aria resolve through the registry in the PLUGIN's own
+  // i18n namespace; top-level panels keep their 'rooms' sidePanel.* keys.
+  const { t: tPlugin } = useTranslation()
+  const { data: config } = useConfig()
+  useRegistryVersion()
+  const visibleTools = getVisibleToolPlugins(config)
+  const activePlugin = activeSubPanelId
+    ? visibleTools.find((p) => p.id === activeSubPanelId)
+    : undefined
+  const title = activePlugin
+    ? tPlugin(activePlugin.contributes.tool?.panel.headingKey ?? 'panel.heading', {
+        ns: activePlugin.i18nNamespace,
+      })
+    : t(`heading.${activePanelId}`)
+  const closeContent = activePlugin
+    ? tPlugin(activePlugin.contributes.tool?.panel.contentKey ?? 'panel.content', {
+        ns: activePlugin.i18nNamespace,
+      })
+    : t(`content.${activePanelId}`)
 
   const { isOpen: isReactionToolbarOpen } = useReactionsToolbar()
 
@@ -171,10 +190,10 @@ export const SidePanel = () => {
         layoutStore.activeSubPanelId = null
       }}
       closeButtonTooltip={t('closeButton', {
-        content: t(`content.${activeSubPanelId || activePanelId}`),
+        content: closeContent,
       })}
       isClosed={!isSidePanelOpen}
-      isSubmenu={isSubPanelOpen}
+      isSubmenu={!!activeSubPanelId}
       isReactionToolbarOpen={isReactionToolbarOpen}
       backButtonLabel={t('backToTools')}
       onBack={() => (layoutStore.activeSubPanelId = null)}

--- a/src/frontend/src/features/rooms/livekit/components/Tools.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/Tools.tsx
@@ -1,23 +1,26 @@
 import { A, Div, Icon, Text } from '@/primitives'
+import { Spinner } from '@/primitives/Spinner'
 import { css } from '@/styled-system/css'
+import { Center } from '@/styled-system/jsx'
 import { Button as RACButton } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
-import { ReactNode } from 'react'
-import { SubPanelId, useSidePanel } from '../hooks/useSidePanel'
+import { ReactNode, Suspense } from 'react'
+import { useSidePanel } from '../hooks/useSidePanel'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
-import {
-  useIsRecordingModeEnabled,
-  RecordingMode,
-  TranscriptSidePanel,
-  ScreenRecordingSidePanel,
-} from '@/features/recording'
 import { useConfig } from '@/api/useConfig'
+import {
+  PanelErrorBoundary,
+  getVisibleToolPlugins,
+  useRegistryVersion,
+  type Plugin,
+} from '@/features/plugins'
 
 export interface ToolsButtonProps {
   icon: ReactNode
   title: string
   description: string
   onPress: () => void
+  dataAttr?: string
 }
 
 const ToolButton = ({
@@ -25,9 +28,11 @@ const ToolButton = ({
   title,
   description,
   onPress,
+  dataAttr,
 }: ToolsButtonProps) => {
   return (
     <RACButton
+      data-attr={dataAttr}
       className={css({
         display: 'flex',
         flexDirection: 'row',
@@ -93,10 +98,38 @@ const ToolButton = ({
   )
 }
 
+/** Renders one registry plugin as a Tools menu entry, translated in its ns. */
+const PluginToolButton = ({
+  plugin,
+  onPress,
+}: {
+  plugin: Plugin
+  onPress: () => void
+}) => {
+  const { t } = useTranslation(plugin.i18nNamespace)
+  return (
+    <ToolButton
+      icon={plugin.contributes.tool?.icon}
+      title={t(plugin.contributes.tool?.titleKey ?? 'tool.title')}
+      description={t(plugin.contributes.tool?.descriptionKey ?? 'tool.body')}
+      onPress={onPress}
+      dataAttr={`tool-${plugin.id.replace(/\./g, '-')}`}
+    />
+  )
+}
+
+/** Suspense fallback while a lazy plugin panel is loading. */
+const PanelFallback = () => (
+  <Center flexGrow={1} padding="2rem">
+    <Spinner />
+  </Center>
+)
+
 export const Tools = () => {
   const { data } = useConfig()
-  const { openTranscript, openScreenRecording, activeSubPanelId, isToolsOpen } =
-    useSidePanel()
+  useRegistryVersion() // re-render when a late bundle registers a tool
+  const plugins = getVisibleToolPlugins(data)
+  const { activeSubPanelId, openSubPanel, isToolsOpen } = useSidePanel()
   const { t } = useTranslation('rooms', { keyPrefix: 'moreTools' })
 
   // Restore focus to the element that opened the Tools panel
@@ -115,21 +148,24 @@ export const Tools = () => {
     preventScroll: true,
   })
 
-  const isTranscriptEnabled = useIsRecordingModeEnabled(
-    RecordingMode.Transcript
-  )
-
-  const isScreenRecordingEnabled = useIsRecordingModeEnabled(
-    RecordingMode.ScreenRecording
-  )
-
-  switch (activeSubPanelId) {
-    case SubPanelId.TRANSCRIPT:
-      return <TranscriptSidePanel />
-    case SubPanelId.SCREEN_RECORDING:
-      return <ScreenRecordingSidePanel />
-    default:
-      break
+  const activePlugin = plugins.find((p) => p.id === activeSubPanelId)
+  if (activePlugin) {
+    const { Component } = activePlugin.contributes.tool!.panel
+    return (
+      // Keyed by plugin so a failure in one panel resets when switching.
+      <PanelErrorBoundary
+        key={activePlugin.id}
+        fallback={
+          <Center flexGrow={1} padding="2rem">
+            <Text variant="note">{t('panelError')}</Text>
+          </Center>
+        }
+      >
+        <Suspense fallback={<PanelFallback />}>
+          <Component />
+        </Suspense>
+      </PanelErrorBoundary>
+    )
   }
 
   return (
@@ -166,22 +202,13 @@ export const Tools = () => {
           </A>
         )}
       </Text>
-      {isTranscriptEnabled && (
-        <ToolButton
-          icon={<Icon name="speech_to_text" />}
-          title={t('tools.transcript.title')}
-          description={t('tools.transcript.body')}
-          onPress={() => openTranscript()}
+      {plugins.map((plugin) => (
+        <PluginToolButton
+          key={plugin.id}
+          plugin={plugin}
+          onPress={() => openSubPanel(plugin.id)}
         />
-      )}
-      {isScreenRecordingEnabled && (
-        <ToolButton
-          icon={<Icon name="mode_standby" />}
-          title={t('tools.screenRecording.title')}
-          description={t('tools.screenRecording.body')}
-          onPress={() => openScreenRecording()}
-        />
-      )}
+      ))}
     </Div>
   )
 }

--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/ScreenRecordingMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/ScreenRecordingMenuItem.tsx
@@ -4,25 +4,29 @@ import { useTranslation } from 'react-i18next'
 import { menuRecipe } from '@/primitives/menuRecipe'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
 import { RecordingMode, useHasRecordingAccess } from '@/features/recording'
+import { SCREEN_RECORDING_PLUGIN_ID } from '@/features/recording/screenRecording.plugin'
 import { FeatureFlags } from '@/features/analytics/enums'
+import { useIsToolVisible } from '@/features/plugins'
 
 export const ScreenRecordingMenuItem = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'options.items' })
-  const { isScreenRecordingOpen, openScreenRecording, toggleTools } =
-    useSidePanel()
+  const { isSubPanelOpen, openSubPanel, toggleTools } = useSidePanel()
 
   const hasScreenRecordingAccess = useHasRecordingAccess(
     RecordingMode.ScreenRecording,
     FeatureFlags.ScreenRecording
   )
+  const isToolVisible = useIsToolVisible(SCREEN_RECORDING_PLUGIN_ID)
 
-  if (!hasScreenRecordingAccess) return null
+  if (!hasScreenRecordingAccess || !isToolVisible) return null
 
   return (
     <MenuItem
       className={menuRecipe({ icon: true, variant: 'dark' }).item}
       onAction={() =>
-        !isScreenRecordingOpen ? openScreenRecording() : toggleTools()
+        !isSubPanelOpen(SCREEN_RECORDING_PLUGIN_ID)
+          ? openSubPanel(SCREEN_RECORDING_PLUGIN_ID)
+          : toggleTools()
       }
     >
       <RiRecordCircleLine size={20} />

--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
@@ -4,23 +4,30 @@ import { useTranslation } from 'react-i18next'
 import { menuRecipe } from '@/primitives/menuRecipe'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
 import { RecordingMode, useHasRecordingAccess } from '@/features/recording'
+import { TRANSCRIPT_PLUGIN_ID } from '@/features/recording/transcript.plugin'
 import { FeatureFlags } from '@/features/analytics/enums'
+import { useIsToolVisible } from '@/features/plugins'
 
 export const TranscriptMenuItem = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'options.items' })
-  const { isTranscriptOpen, openTranscript, toggleTools } = useSidePanel()
+  const { isSubPanelOpen, openSubPanel, toggleTools } = useSidePanel()
 
   const hasTranscriptAccess = useHasRecordingAccess(
     RecordingMode.Transcript,
     FeatureFlags.Transcript
   )
+  const isToolVisible = useIsToolVisible(TRANSCRIPT_PLUGIN_ID)
 
-  if (!hasTranscriptAccess) return null
+  if (!hasTranscriptAccess || !isToolVisible) return null
 
   return (
     <MenuItem
       className={menuRecipe({ icon: true, variant: 'dark' }).item}
-      onAction={() => (!isTranscriptOpen ? openTranscript() : toggleTools())}
+      onAction={() =>
+        !isSubPanelOpen(TRANSCRIPT_PLUGIN_ID)
+          ? openSubPanel(TRANSCRIPT_PLUGIN_ID)
+          : toggleTools()
+      }
     >
       <RiFileTextLine size={20} />
       {t('transcript')}

--- a/src/frontend/src/features/rooms/livekit/components/controls/SubtitlesToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/SubtitlesToggle.tsx
@@ -1,9 +1,17 @@
 import { useTranslation } from 'react-i18next'
+import { useSnapshot } from 'valtio'
 import { RiClosedCaptioningLine } from '@remixicon/react'
-import { ToggleButton } from '@/primitives'
+import { Popover, Text, ToggleButton } from '@/primitives'
 import { css } from '@/styled-system/css'
 import { useSubtitles } from '@/features/subtitle/hooks/useSubtitles'
 import { useAreSubtitlesAvailable } from '@/features/subtitle/hooks/useAreSubtitlesAvailable'
+import { useCaptionTakeover } from '@/features/subtitle/captionBus'
+import {
+  captionButtonStore,
+  dismissCaptionPopover,
+} from '@/features/subtitle/captionButtonStore'
+import { toneColor } from '@/primitives/tone'
+import { layoutStore } from '@/stores/layout'
 
 export const SubtitlesToggle = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'controls.subtitles' })
@@ -12,7 +20,37 @@ export const SubtitlesToggle = () => {
   const tooltipLabel = areSubtitlesOpen ? 'open' : 'closed'
   const areSubtitlesAvailable = useAreSubtitlesAvailable()
 
+  // Decoration surface; with none set, the render collapses to the original.
+  const { decoration: deco, popover } = useSnapshot(captionButtonStore)
+  // While a plugin owns the caption bus, CC toggles ONLY the overlay (no
+  // start-subtitle POST that would re-dispatch the native agent).
+  const overridden = useCaptionTakeover()
+
   if (!areSubtitlesAvailable) return null
+
+  const tone = deco?.tone ?? 'info'
+  const buttonLabel = deco?.label ?? t(tooltipLabel)
+  const onPress = overridden
+    ? () => {
+        layoutStore.showSubtitles = !layoutStore.showSubtitles
+      }
+    : toggleSubtitles
+  const popoverActive = !!popover
+
+  const button = (
+    <ToggleButton
+      square
+      variant="primaryDark"
+      aria-label={buttonLabel}
+      tooltip={buttonLabel}
+      isSelected={areSubtitlesOpen}
+      isDisabled={areSubtitlesPending}
+      onPress={onPress}
+      data-attr={`controls-subtitles-${tooltipLabel}`}
+    >
+      <RiClosedCaptioningLine />
+    </ToggleButton>
+  )
 
   return (
     <div
@@ -21,18 +59,64 @@ export const SubtitlesToggle = () => {
         display: 'inline-block',
       })}
     >
-      <ToggleButton
-        square
-        variant="primaryDark"
-        aria-label={t(tooltipLabel)}
-        tooltip={t(tooltipLabel)}
-        isSelected={areSubtitlesOpen}
-        isDisabled={areSubtitlesPending}
-        onPress={toggleSubtitles}
-        data-attr={`controls-subtitles-${tooltipLabel}`}
-      >
-        <RiClosedCaptioningLine />
-      </ToggleButton>
+      {popoverActive ? (
+        <Popover
+          isOpen
+          onOpenChange={(open) => {
+            if (!open) dismissCaptionPopover()
+          }}
+        >
+          {button}
+          <Text
+            variant="sm"
+            data-attr={popover?.testId ?? `caption-popover-${deco?.id}`}
+            className={css({ display: 'block', maxWidth: '14rem' })}
+          >
+            {popover?.text}
+          </Text>
+        </Popover>
+      ) : (
+        button
+      )}
+      {deco?.live && (
+        <span
+          aria-hidden="true"
+          className={css({
+            position: 'absolute',
+            inset: 0,
+            borderRadius: '4px',
+            border: '2px solid',
+            color: toneColor[tone],
+            animation: 'caption_live_ring 1.8s ease-out infinite',
+            pointerEvents: 'none',
+          })}
+        />
+      )}
+      {deco?.badge && (
+        <span
+          data-attr={deco.testId ?? `caption-badge-${deco.id}`}
+          className={css({
+            position: 'absolute',
+            top: '-4px',
+            right: '-4px',
+            paddingX: '0.25rem',
+            minWidth: '1rem',
+            height: '1rem',
+            lineHeight: '1rem',
+            fontSize: '0.625rem',
+            fontWeight: 700,
+            textAlign: 'center',
+            color: 'white',
+            backgroundColor: toneColor[tone],
+            border: '1px solid white',
+            borderRadius: '999px',
+            pointerEvents: 'none',
+            zIndex: 1,
+          })}
+        >
+          {deco.badge}
+        </span>
+      )}
     </div>
   )
 }

--- a/src/frontend/src/features/rooms/livekit/hooks/useSidePanel.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useSidePanel.ts
@@ -10,11 +10,6 @@ export enum PanelId {
   INFO = 'info',
 }
 
-export enum SubPanelId {
-  TRANSCRIPT = 'transcript',
-  SCREEN_RECORDING = 'screenRecording',
-}
-
 export const useSidePanel = () => {
   const layoutSnap = useSnapshot(layoutStore)
   const activePanelId = layoutSnap.activePanelId
@@ -26,10 +21,7 @@ export const useSidePanel = () => {
   const isToolsOpen = activePanelId == PanelId.TOOLS
   const isAdminOpen = activePanelId == PanelId.ADMIN
   const isInfoOpen = activePanelId == PanelId.INFO
-  const isTranscriptOpen = activeSubPanelId == SubPanelId.TRANSCRIPT
-  const isScreenRecordingOpen = activeSubPanelId == SubPanelId.SCREEN_RECORDING
   const isSidePanelOpen = !!activePanelId
-  const isSubPanelOpen = !!activeSubPanelId
 
   const toggleAdmin = () => {
     layoutStore.activePanelId = isAdminOpen ? null : PanelId.ADMIN
@@ -61,15 +53,14 @@ export const useSidePanel = () => {
     if (layoutSnap.activeSubPanelId) layoutStore.activeSubPanelId = null
   }
 
-  const openTranscript = () => {
-    layoutStore.activeSubPanelId = SubPanelId.TRANSCRIPT
+  /** Open a Tools sub-panel by its registered plugin id. */
+  const openSubPanel = (id: string) => {
+    layoutStore.activeSubPanelId = id
     layoutStore.activePanelId = PanelId.TOOLS
   }
 
-  const openScreenRecording = () => {
-    layoutStore.activeSubPanelId = SubPanelId.SCREEN_RECORDING
-    layoutStore.activePanelId = PanelId.TOOLS
-  }
+  /** Whether the given plugin's sub-panel is the active one. */
+  const isSubPanelOpen = (id: string) => activeSubPanelId === id
 
   return {
     activePanelId,
@@ -80,8 +71,7 @@ export const useSidePanel = () => {
     toggleTools,
     toggleAdmin,
     toggleInfo,
-    openTranscript,
-    openScreenRecording,
+    openSubPanel,
     isSubPanelOpen,
     isChatOpen,
     isParticipantsOpen,
@@ -90,7 +80,5 @@ export const useSidePanel = () => {
     isToolsOpen,
     isAdminOpen,
     isInfoOpen,
-    isTranscriptOpen,
-    isScreenRecordingOpen,
   }
 }

--- a/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
+++ b/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
@@ -24,6 +24,7 @@ import { FocusLayout } from '../components/FocusLayout'
 import { ParticipantTile } from '../components/ParticipantTile'
 import { SidePanel } from '../components/SidePanel'
 import { RecordingProvider } from '@/features/recording'
+import { Banners } from '@/features/banner/Banners'
 import { ScreenShareErrorModal } from '../components/ScreenShareErrorModal'
 import { useConnectionObserver } from '../hooks/useConnectionObserver'
 import { useRoomPageTitle } from '../hooks/useRoomPageTitle'
@@ -306,6 +307,7 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
       <RoomAudioRenderer />
       <ConnectionStateToast />
       <RecordingProvider />
+      <Banners />
       <SettingsDialogProvider />
       <ReactionPortals />
     </div>

--- a/src/frontend/src/features/subtitle/CaptionSources.tsx
+++ b/src/frontend/src/features/subtitle/CaptionSources.tsx
@@ -1,0 +1,23 @@
+import { useConfig } from '@/api/useConfig'
+import { getCaptionControllers, useRegistryVersion } from '@/features/plugins'
+import { NativeCaptionSource } from './nativeCaptionSource'
+
+/**
+ * Headless mount point for caption producers: the native source plus every
+ * enabled plugin caption controller. Must live inside RoomContext.
+ */
+export const CaptionSources = () => {
+  const { data: config } = useConfig()
+  useRegistryVersion() // mount a late bundle's caption controller
+  const controllers = getCaptionControllers(config)
+
+  return (
+    <>
+      <NativeCaptionSource />
+      {controllers.map((controller) => {
+        const Controller = controller.Controller
+        return <Controller key={controller.pluginId} />
+      })}
+    </>
+  )
+}

--- a/src/frontend/src/features/subtitle/api/stopSubtitle.ts
+++ b/src/frontend/src/features/subtitle/api/stopSubtitle.ts
@@ -1,0 +1,18 @@
+import { fetchApi } from '@/api/fetchApi'
+
+export interface StopSubtitleParams {
+  id: string
+  token: string
+}
+
+export const stopSubtitle = ({
+  id,
+  token,
+}: StopSubtitleParams): Promise<{ status: string }> => {
+  return fetchApi(`rooms/${id}/stop-subtitle/`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+}

--- a/src/frontend/src/features/subtitle/captionBus.test.ts
+++ b/src/frontend/src/features/subtitle/captionBus.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  captionBus,
+  claim,
+  currentOwnerId,
+  push,
+  release,
+  type NormalizedCaption,
+} from './captionBus'
+
+/** Build a minimal caption; overrides let a test tweak id/text/final. */
+const cap = (
+  id: string,
+  opts: { text?: string; final?: boolean; key?: string } = {}
+): NormalizedCaption => ({
+  id,
+  text: opts.text ?? id,
+  final: opts.final ?? false,
+  firstReceivedTime: 0,
+  lastReceivedTime: 0,
+  speaker: { key: opts.key ?? 'alice', name: opts.key ?? 'alice' },
+})
+
+const ids = (): string[] => captionBus.stream.map((c) => c.id)
+const texts = (): string[] => captionBus.stream.map((c) => c.text)
+
+beforeEach(() => {
+  captionBus.owners.splice(0)
+  captionBus.stream.splice(0)
+})
+
+describe('captionBus claim / currentOwnerId', () => {
+  it('claims an idle bus and reports the current owner', () => {
+    expect(currentOwnerId()).toBeNull()
+    const token = claim('native', { priority: 0 })
+    expect(token).not.toBeNull()
+    expect(currentOwnerId()).toBe('native')
+  })
+
+  it('defaults priority to 10 when omitted', () => {
+    claim('a') // priority 10
+    // native (0) cannot override a strictly-higher (10) top owner.
+    expect(claim('native', { priority: 0 })).toBeNull()
+    expect(currentOwnerId()).toBe('a')
+  })
+})
+
+describe('captionBus priority', () => {
+  it('an equal-or-higher priority claim overrides the top owner', () => {
+    claim('native', { priority: 0 })
+    const token = claim('plugin', { priority: 5 })
+    expect(token).not.toBeNull()
+    expect(currentOwnerId()).toBe('plugin')
+  })
+
+  it('refuses a strictly-lower priority claim (returns null)', () => {
+    claim('plugin', { priority: 5 })
+    expect(claim('native', { priority: 0 })).toBeNull()
+    expect(currentOwnerId()).toBe('plugin')
+  })
+})
+
+describe('captionBus push gate', () => {
+  it('accepts writes from the top owner only', () => {
+    const native = claim('native', { priority: 0 })!
+    const plugin = claim('plugin', { priority: 5 })!
+
+    // native is no longer the top owner -> ignored
+    push(native, [cap('n1')])
+    expect(ids()).toEqual([])
+
+    push(plugin, [cap('p1')])
+    expect(ids()).toEqual(['p1'])
+  })
+
+  it('ignores writes from a stale token after release', () => {
+    const token = claim('native', { priority: 0 })!
+    release(token)
+    push(token, [cap('x')])
+    expect(ids()).toEqual([])
+  })
+})
+
+describe('captionBus dedup / partial→final', () => {
+  it('replaces a caption pushed again under the same id', () => {
+    const token = claim('native', { priority: 0 })!
+    push(token, [cap('s1', { text: 'hel' })])
+    push(token, [cap('s1', { text: 'hello' })])
+    expect(ids()).toEqual(['s1'])
+    expect(texts()).toEqual(['hello'])
+  })
+
+  it('upgrades a seen partial to its final version in place', () => {
+    const token = claim('native', { priority: 0 })!
+    push(token, [cap('s1', { text: 'partial', final: false })])
+    push(token, [cap('s2', { text: 'next', final: false })])
+    push(token, [cap('s1', { text: 'final', final: true })])
+    expect(ids()).toEqual(['s1', 's2'])
+    expect(captionBus.stream[0]).toMatchObject({ text: 'final', final: true })
+  })
+})
+
+describe('captionBus stream reset', () => {
+  it('resets the stream when a new owner claims', () => {
+    const native = claim('native', { priority: 0 })!
+    push(native, [cap('n1')])
+    expect(ids()).toEqual(['n1'])
+
+    claim('plugin', { priority: 5 })
+    expect(ids()).toEqual([])
+  })
+
+  it('keeps the stream when a non-top owner releases', () => {
+    const native = claim('native', { priority: 0 })!
+    const plugin = claim('plugin', { priority: 5 })!
+    push(plugin, [cap('p1')])
+
+    release(native)
+    expect(ids()).toEqual(['p1'])
+    expect(currentOwnerId()).toBe('plugin')
+  })
+
+  it('resets the stream on release so the owner below resumes clean', () => {
+    const native = claim('native', { priority: 0 })!
+    const plugin = claim('plugin', { priority: 5 })!
+    push(plugin, [cap('p1')])
+    expect(ids()).toEqual(['p1'])
+
+    release(plugin)
+    expect(ids()).toEqual([])
+    expect(currentOwnerId()).toBe('native')
+
+    // native resumes as the top owner and can push again
+    push(native, [cap('n1')])
+    expect(ids()).toEqual(['n1'])
+  })
+})

--- a/src/frontend/src/features/subtitle/captionBus.ts
+++ b/src/frontend/src/features/subtitle/captionBus.ts
@@ -1,0 +1,114 @@
+import { proxy, useSnapshot } from 'valtio'
+
+/** Reserved bus-owner id for the built-in native caption source (priority 0). */
+export const NATIVE_SOURCE_ID = 'native'
+
+/** Who a caption belongs to (name/color pre-resolved by the source). */
+export interface CaptionSpeaker {
+  key: string
+  name: string
+  color?: string
+}
+
+/** A source-agnostic caption pushed onto the bus and rendered by the overlay. */
+export interface NormalizedCaption {
+  id: string
+  speaker: CaptionSpeaker
+  text: string
+  final: boolean
+  firstReceivedTime: number
+  lastReceivedTime: number
+  language?: string
+}
+
+/** A bus owner. `token` is an opaque capability from `claim`, required by `release`/`push`. */
+export interface Owner {
+  id: string
+  priority: number
+  token: symbol
+}
+
+export interface BusState {
+  owners: Owner[]
+  stream: NormalizedCaption[]
+}
+
+/** Cap the retained stream so snapshots stay cheap under frequent partials. */
+const STREAM_TAIL = 200
+
+/** Module-level caption bus (single instance, host-owned). */
+export const captionBus = proxy<BusState>({
+  owners: [],
+  stream: [],
+})
+
+const topOwner = (): Owner | undefined =>
+  captionBus.owners[captionBus.owners.length - 1]
+
+/** Id of the current (top-of-stack) owner, or `null` when the bus is idle. */
+export const currentOwnerId = (): string | null => topOwner()?.id ?? null
+
+/** Reactive: true while a plugin (any non-native owner) is on top of the bus. */
+export const useCaptionTakeover = (): boolean => {
+  const { owners } = useSnapshot(captionBus)
+  const topId = owners.length ? owners[owners.length - 1].id : null
+  return topId !== null && topId !== NATIVE_SOURCE_ID
+}
+
+/**
+ * Claim ownership of the bus. Refused only when the current top owner has a
+ * strictly-higher priority (equal-or-lower is overridden). On success the new
+ * owner is pushed on top and the stream reset.
+ */
+export const claim = (
+  id: string,
+  { priority = 10 }: { priority?: number } = {}
+): symbol | null => {
+  const top = topOwner()
+  if (top && top.priority > priority) return null
+  const token = Symbol(id)
+  captionBus.owners.push({ id, priority, token })
+  captionBus.stream = []
+  return token
+}
+
+/**
+ * Release a claimed ownership; no-op for a stale token. The stream is reset only
+ * when the TOP owner leaves — a lower owner leaving must not blank the captions
+ * currently rendered by the active producer.
+ */
+export const release = (token: symbol): void => {
+  const idx = captionBus.owners.findIndex((o) => o.token === token)
+  if (idx === -1) return
+  const wasTop = idx === captionBus.owners.length - 1
+  captionBus.owners.splice(idx, 1)
+  if (wasTop) captionBus.stream = []
+}
+
+/**
+ * Append captions (top-owner gated). Dedup by `id`: an existing id is replaced in
+ * place, so a partial is upgraded by its final version.
+ */
+export const push = (token: symbol, caps: NormalizedCaption[]): void => {
+  const top = topOwner()
+  if (!top || top.token !== token) return
+  for (const cap of caps) {
+    const idx = captionBus.stream.findIndex((c) => c.id === cap.id)
+    if (idx === -1) {
+      captionBus.stream.push(cap)
+    } else {
+      captionBus.stream[idx] = cap
+    }
+  }
+  if (captionBus.stream.length > STREAM_TAIL) {
+    captionBus.stream.splice(0, captionBus.stream.length - STREAM_TAIL)
+  }
+}
+
+/** Replace the whole stream (top-owner gated), for producers that re-derive the full list each update. */
+export const replace = (token: symbol, caps: NormalizedCaption[]): void => {
+  const top = topOwner()
+  if (!top || top.token !== token) return
+  captionBus.stream =
+    caps.length > STREAM_TAIL ? caps.slice(-STREAM_TAIL) : [...caps]
+}

--- a/src/frontend/src/features/subtitle/captionButtonStore.test.ts
+++ b/src/frontend/src/features/subtitle/captionButtonStore.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  captionButtonStore,
+  setCaptionDecoration,
+  clearCaptionDecoration,
+  showCaptionPopover,
+  dismissCaptionPopover,
+} from './captionButtonStore'
+
+/** Minimal in-memory Storage mock (the test runs in the node environment). */
+const makeSessionStorage = (): Storage => {
+  const m = new Map<string, string>()
+  return {
+    getItem: (k) => (m.has(k) ? (m.get(k) as string) : null),
+    setItem: (k, v) => {
+      m.set(k, String(v))
+    },
+    removeItem: (k) => {
+      m.delete(k)
+    },
+    clear: () => {
+      m.clear()
+    },
+    key: (i) => Array.from(m.keys())[i] ?? null,
+    get length() {
+      return m.size
+    },
+  }
+}
+
+beforeEach(() => {
+  captionButtonStore.decoration = undefined
+  captionButtonStore.popover = undefined
+  vi.stubGlobal('sessionStorage', makeSessionStorage())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('captionButtonStore set / clear', () => {
+  it('sets the decoration', () => {
+    expect(captionButtonStore.decoration).toBeUndefined()
+    setCaptionDecoration('acme', { badge: 'Acme' })
+    expect(captionButtonStore.decoration).toMatchObject({
+      id: 'acme',
+      badge: 'Acme',
+    })
+  })
+
+  it('carries live / tone / label / testId through', () => {
+    setCaptionDecoration('acme', {
+      live: true,
+      badge: 'Acme',
+      tone: 'success',
+      label: 'Sous-titres Acme',
+      testId: 'cc-acme-live',
+    })
+    expect(captionButtonStore.decoration).toMatchObject({
+      live: true,
+      tone: 'success',
+      label: 'Sous-titres Acme',
+      testId: 'cc-acme-live',
+    })
+  })
+
+  it('leaves optional fields undefined when omitted', () => {
+    setCaptionDecoration('acme', { badge: 'Acme' })
+    const deco = captionButtonStore.decoration
+    expect(deco?.tone).toBeUndefined()
+    expect(deco?.label).toBeUndefined()
+    expect(deco?.testId).toBeUndefined()
+  })
+
+  it('replaces the decoration in place when re-set (last writer wins)', () => {
+    setCaptionDecoration('acme', { badge: 'A', tone: 'info' })
+    setCaptionDecoration('acme', { badge: 'B', tone: 'success' })
+    expect(captionButtonStore.decoration).toMatchObject({
+      id: 'acme',
+      badge: 'B',
+      tone: 'success',
+    })
+  })
+
+  it('a different id overwrites the single slot', () => {
+    setCaptionDecoration('a', { badge: 'A' })
+    setCaptionDecoration('b', { badge: 'B' })
+    expect(captionButtonStore.decoration?.id).toBe('b')
+  })
+
+  it('clears the decoration by its id', () => {
+    setCaptionDecoration('acme', { badge: 'Acme' })
+    clearCaptionDecoration('acme')
+    expect(captionButtonStore.decoration).toBeUndefined()
+  })
+
+  it('clear is a no-op for a non-matching id', () => {
+    setCaptionDecoration('acme', { badge: 'Acme' })
+    clearCaptionDecoration('nope')
+    expect(captionButtonStore.decoration?.id).toBe('acme')
+  })
+})
+
+describe('captionButtonStore popover', () => {
+  it('shows a popover and stores its content', () => {
+    showCaptionPopover('acme', { text: 'here' })
+    expect(captionButtonStore.popover).toMatchObject({ text: 'here' })
+  })
+
+  it('carries an optional testId through', () => {
+    showCaptionPopover('acme', { text: 'here', testId: 'cc-pop' })
+    expect(captionButtonStore.popover?.testId).toBe('cc-pop')
+  })
+
+  it('dismiss clears the popover', () => {
+    showCaptionPopover('acme', { text: 'here' })
+    dismissCaptionPopover()
+    expect(captionButtonStore.popover).toBeUndefined()
+  })
+
+  it('once=per-meeting shows only once per room+id and sets a marker', () => {
+    showCaptionPopover('acme', {
+      text: 'here',
+      once: 'per-meeting',
+      roomId: 'room-1',
+    })
+    expect(captionButtonStore.popover?.text).toBe('here')
+    expect(sessionStorage.getItem('meet.captionPopover.room-1.acme')).toBe('1')
+
+    // Second call for the same room+id is a no-op even after dismissal.
+    dismissCaptionPopover()
+    showCaptionPopover('acme', {
+      text: 'again',
+      once: 'per-meeting',
+      roomId: 'room-1',
+    })
+    expect(captionButtonStore.popover).toBeUndefined()
+  })
+
+  it('once=per-meeting is keyed per room (a new room shows again)', () => {
+    showCaptionPopover('acme', {
+      text: 'here',
+      once: 'per-meeting',
+      roomId: 'room-1',
+    })
+    dismissCaptionPopover()
+    showCaptionPopover('acme', {
+      text: 'here',
+      once: 'per-meeting',
+      roomId: 'room-2',
+    })
+    expect(captionButtonStore.popover?.text).toBe('here')
+    expect(sessionStorage.getItem('meet.captionPopover.room-2.acme')).toBe('1')
+  })
+
+  it('without once, always (re)shows and sets no marker', () => {
+    showCaptionPopover('acme', { text: 'first' })
+    dismissCaptionPopover()
+    showCaptionPopover('acme', { text: 'second' })
+    expect(captionButtonStore.popover?.text).toBe('second')
+    expect(sessionStorage.length).toBe(0)
+  })
+
+  it('once without a roomId falls through and shows (no key to gate on)', () => {
+    showCaptionPopover('acme', { text: 'here', once: 'per-meeting' })
+    expect(captionButtonStore.popover?.text).toBe('here')
+    expect(sessionStorage.length).toBe(0)
+  })
+})

--- a/src/frontend/src/features/subtitle/captionButtonStore.ts
+++ b/src/frontend/src/features/subtitle/captionButtonStore.ts
@@ -1,0 +1,87 @@
+import { proxy } from 'valtio'
+import type { Tone } from '@/primitives/tone'
+
+/** Decoration severity the host maps to a themed color in `<SubtitlesToggle/>`. */
+export type CaptionButtonTone = Tone
+
+/** A decoration layered onto the CC button, keyed by producer-owned `id`. */
+export interface CaptionButtonDecoration {
+  id: string
+  /** Draw a pulsing "live" ring around the button. */
+  live?: boolean
+  /** Short text shown in a corner badge (e.g. a source name). */
+  badge?: string
+  /** Severity used to color the badge + ring via the host tone→token map. */
+  tone?: CaptionButtonTone
+  /** Overrides the button's aria-label/tooltip while set. */
+  label?: string
+  /** Optional DOM hook for automation; falls back to `caption-badge-<id>`. */
+  testId?: string
+}
+
+/** Options accepted by {@link setCaptionDecoration} (everything but the id). */
+export type CaptionDecorationOptions = Omit<CaptionButtonDecoration, 'id'>
+
+/** A one-time popover anchored to the CC button. */
+export interface CaptionPopover {
+  text: string
+  testId?: string
+}
+
+/** Options accepted by {@link showCaptionPopover}. */
+export interface CaptionPopoverOptions {
+  text: string
+  /** `'per-meeting'` shows it at most once per person per meeting (keyed below). */
+  once?: 'per-meeting'
+  /** Meeting identity used for the once-per-meeting sessionStorage key. */
+  roomId?: string
+  testId?: string
+}
+
+interface CaptionButtonState {
+  decoration?: CaptionButtonDecoration
+  popover?: CaptionPopover
+}
+
+/** Host-owned valtio store backing the CC-button decoration surface (one button = one slot). */
+export const captionButtonStore = proxy<CaptionButtonState>({})
+
+/** Set (or replace) the CC-button decoration; last writer wins. */
+export const setCaptionDecoration = (
+  id: string,
+  opts: CaptionDecorationOptions
+): void => {
+  captionButtonStore.decoration = { id, ...opts }
+}
+
+/** Clear the decoration when it is the one registered under `id`. */
+export const clearCaptionDecoration = (id: string): void => {
+  if (captionButtonStore.decoration?.id === id) {
+    captionButtonStore.decoration = undefined
+  }
+}
+
+/**
+ * Show a popover anchored to the CC button. `once: 'per-meeting'` + `roomId`
+ * fires at most once per meeting via a sessionStorage marker; else always shows.
+ */
+export const showCaptionPopover = (
+  id: string,
+  opts: CaptionPopoverOptions
+): void => {
+  if (opts.once === 'per-meeting' && opts.roomId) {
+    const key = `meet.captionPopover.${opts.roomId}.${id}`
+    try {
+      if (sessionStorage.getItem(key)) return
+      sessionStorage.setItem(key, '1')
+    } catch {
+      // sessionStorage unavailable (private mode / SSR): fall through and show.
+    }
+  }
+  captionButtonStore.popover = { text: opts.text, testId: opts.testId }
+}
+
+/** Dismiss the active popover (called by the host on interaction). */
+export const dismissCaptionPopover = (): void => {
+  captionButtonStore.popover = undefined
+}

--- a/src/frontend/src/features/subtitle/component/Subtitles.tsx
+++ b/src/frontend/src/features/subtitle/component/Subtitles.tsx
@@ -1,14 +1,11 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useSubtitles } from '../hooks/useSubtitles'
 import { css, cva } from '@/styled-system/css'
 import { styled } from '@/styled-system/jsx'
 import { Avatar } from '@/components/Avatar'
 import { Text } from '@/primitives'
-import { useRoomContext } from '@livekit/components-react'
-import { getParticipantColor } from '@/features/rooms/utils/getParticipantColor'
-import { getParticipantName } from '@/features/rooms/utils/getParticipantName'
-import { type Participant, RoomEvent } from 'livekit-client'
-import { useSnapshot } from 'valtio'
+import { useSnapshot, type Snapshot } from 'valtio'
+import { captionBus, type NormalizedCaption } from '../captionBus'
 import {
   accessibilityStore,
   CAPTION_TEXT_SIZE_OPTIONS,
@@ -30,87 +27,31 @@ const CAPTION_FONT_SIZES = Object.fromEntries(
   CAPTION_TEXT_SIZE_OPTIONS.map((size) => [size, FONT_SIZE_CONFIG[size]])
 ) as Record<CaptionTextSize, { fontSize: string; lineHeight: string }>
 
-export interface TranscriptionSegment {
+/** Read-only caption as seen through the bus snapshot. */
+type SnapshotCaption = Snapshot<NormalizedCaption>
+
+/** A contiguous run of captions from the same speaker, ready to render. */
+interface CaptionRow {
   id: string
-  text: string
-  language: string
-  startTime?: number
-  endTime: number
-  final: boolean
-  firstReceivedTime: number
-  lastReceivedTime: number
+  speaker: SnapshotCaption['speaker']
+  captions: SnapshotCaption[]
 }
 
-export interface TranscriptionSegmentWithParticipant extends TranscriptionSegment {
-  participant: Participant
-}
-
-export interface TranscriptionRow {
-  id: string
-  participant: Participant
-  segments: TranscriptionSegment[]
-  startTime?: number
-  lastUpdateTime: number
-  lastReceivedTime: number
-}
-
-const useTranscriptionState = () => {
-  const [transcriptionSegments, setTranscriptionSegments] = useState<
-    TranscriptionSegmentWithParticipant[]
-  >([])
-
-  const updateTranscriptionSegments = (
-    segments: TranscriptionSegment[],
-    participant?: Participant
-  ) => {
-    console.log(participant, segments)
-
-    if (!participant || segments.length === 0) return
-
-    if (segments.length > 1) {
-      console.warn('Unexpected error more segments')
-      return
-    }
-
-    const segment = segments[0]
-
-    setTranscriptionSegments((prevSegments) => {
-      const existingSegmentIds = new Set(prevSegments.map((s) => s.id))
-      if (existingSegmentIds.has(segment.id)) return prevSegments
-      return [
-        ...prevSegments,
-        {
-          participant: participant,
-          ...segment,
-        },
-      ]
-    })
-  }
-
-  return {
-    updateTranscriptionSegments,
-    transcriptionSegments,
-  }
-}
-
-const Transcription = ({ row }: { row: TranscriptionRow }) => {
+const Transcription = ({ row }: { row: CaptionRow }) => {
   const { captionTextSize, captionFontColor, captionBackgroundColor } =
     useSnapshot(accessibilityStore)
-  const participantColor = getParticipantColor(row.participant)
-  const participantName = getParticipantName(row.participant)
+  const { speaker } = row
+  const participantName = speaker.name
+  const participantColor = speaker.color
   const { fontSize, lineHeight } = CAPTION_FONT_SIZES[captionTextSize]
   const fontColor = CAPTION_FONT_COLOR_VALUES[captionFontColor]
   const backgroundColor =
     CAPTION_BACKGROUND_COLOR_VALUES[captionBackgroundColor]
 
-  const getDisplayText = (row: TranscriptionRow): string => {
-    return row.segments
-      .filter((segment) => segment.text.trim())
-      .map((segment) => segment.text.trim())
-      .join(' ')
-  }
-
-  const displayText = getDisplayText(row)
+  const displayText = row.captions
+    .map((caption) => caption.text.trim())
+    .filter((text) => text)
+    .join(' ')
 
   if (!displayText) return null
 
@@ -142,6 +83,7 @@ const Transcription = ({ row }: { row: TranscriptionRow }) => {
             {participantName}
           </Text>
           <p
+            data-attr="caption-overlay-line"
             className={css({
               fontWeight: '400',
               borderRadius: '4px',
@@ -180,54 +122,31 @@ const SubtitlesWrapper = styled(
 
 export const Subtitles = () => {
   const { areSubtitlesOpen } = useSubtitles()
-  const room = useRoomContext()
+  const { stream } = useSnapshot(captionBus)
 
-  const { transcriptionSegments, updateTranscriptionSegments } =
-    useTranscriptionState()
+  const captionRows = useMemo(() => {
+    if (stream.length === 0) return []
 
-  useEffect(() => {
-    if (!room) return
-    room.on(RoomEvent.TranscriptionReceived, updateTranscriptionSegments)
-    return () => {
-      room.off(RoomEvent.TranscriptionReceived, updateTranscriptionSegments)
-    }
-  }, [room, updateTranscriptionSegments])
+    const rows: CaptionRow[] = []
+    let currentRow: CaptionRow | null = null
 
-  const transcriptionRows = useMemo(() => {
-    if (transcriptionSegments.length === 0) return []
-
-    const rows: TranscriptionRow[] = []
-    let currentRow: TranscriptionRow | null = null
-
-    for (const segment of transcriptionSegments) {
+    for (const caption of stream) {
       const shouldStartNewRow =
-        !currentRow ||
-        currentRow.participant.identity !== segment.participant.identity
+        !currentRow || currentRow.speaker.key !== caption.speaker.key
 
       if (shouldStartNewRow) {
         currentRow = {
-          id: `${segment.participant.identity}-${segment.firstReceivedTime}`,
-          participant: segment.participant,
-          segments: [segment],
-          startTime: segment.startTime,
-          lastUpdateTime: segment.lastReceivedTime,
-          lastReceivedTime: segment.lastReceivedTime,
+          id: `${caption.speaker.key}-${caption.firstReceivedTime}`,
+          speaker: caption.speaker,
+          captions: [caption],
         }
         rows.push(currentRow)
       } else if (currentRow) {
-        currentRow.segments.push(segment)
-        currentRow.lastUpdateTime = Math.max(
-          currentRow.lastUpdateTime,
-          segment.lastReceivedTime
-        )
-        currentRow.lastReceivedTime = Math.max(
-          currentRow.lastReceivedTime,
-          segment.lastReceivedTime
-        )
+        currentRow.captions.push(caption)
       }
     }
     return rows
-  }, [transcriptionSegments])
+  }, [stream])
 
   return (
     <SubtitlesWrapper areOpen={areSubtitlesOpen}>
@@ -244,7 +163,7 @@ export const Subtitles = () => {
           alignItems: 'center',
         })}
       >
-        {transcriptionRows
+        {captionRows
           .slice()
           .reverse()
           .map((row) => (

--- a/src/frontend/src/features/subtitle/hooks/useSubtitles.tsx
+++ b/src/frontend/src/features/subtitle/hooks/useSubtitles.tsx
@@ -2,9 +2,14 @@ import { useSnapshot } from 'valtio'
 import { layoutStore } from '@/stores/layout'
 import { useStartSubtitle } from '../api/startSubtitle'
 import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
-import { useRoomContext } from '@livekit/components-react'
+import { useConnectionState, useRoomContext } from '@livekit/components-react'
 import { useEffect } from 'react'
-import { RoomEvent } from 'livekit-client'
+import { ConnectionState, RoomEvent } from 'livekit-client'
+import { useCaptionTakeover } from '../captionBus'
+
+// Module-level: the takeover-open edge is consumed once per takeover, not once
+// per hook instance — a consumer mounting later must not override a manual close.
+let openedForTakeover = false
 
 export const useSubtitles = () => {
   const layoutSnap = useSnapshot(layoutStore)
@@ -13,6 +18,7 @@ export const useSubtitles = () => {
   const apiRoomData = useRoomData()
   const { mutateAsync: startSubtitleRoom, isPending } = useStartSubtitle()
 
+  // User action: POST start-subtitle (dispatches the native agent), then reveal.
   const toggleSubtitles = async () => {
     if (!layoutSnap.showSubtitles && apiRoomData?.livekit) {
       await startSubtitleRoom({
@@ -23,6 +29,22 @@ export const useSubtitles = () => {
 
     layoutStore.showSubtitles = !layoutSnap.showSubtitles
   }
+
+  const connected = useConnectionState(room) === ConnectionState.Connected
+
+  // Claim-driven auto-open: reveal the overlay once when a plugin takes over the
+  // bus. The edge is consumed only once connected (a takeover during connect still
+  // opens on connect); reset on release; a manual close is respected.
+  const overridden = useCaptionTakeover()
+  useEffect(() => {
+    if (!overridden) {
+      openedForTakeover = false
+      return
+    }
+    if (openedForTakeover || !connected) return
+    openedForTakeover = true
+    layoutStore.showSubtitles = true
+  }, [overridden, connected])
 
   useEffect(() => {
     if (!room) return

--- a/src/frontend/src/features/subtitle/nativeCaptionSource.tsx
+++ b/src/frontend/src/features/subtitle/nativeCaptionSource.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react'
+import { useRoomContext } from '@livekit/components-react'
+import {
+  type Participant,
+  type TranscriptionSegment,
+  RoomEvent,
+} from 'livekit-client'
+import { getParticipantColor } from '@/features/rooms/utils/getParticipantColor'
+import { getParticipantName } from '@/features/rooms/utils/getParticipantName'
+import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
+import {
+  NATIVE_SOURCE_ID,
+  claim,
+  push,
+  release,
+  useCaptionTakeover,
+} from './captionBus'
+import { stopSubtitle } from './api/stopSubtitle'
+
+/**
+ * Headless native caption source (priority 0): subscribes to
+ * `RoomEvent.TranscriptionReceived`, normalizes each segment, and pushes it while
+ * top owner. While a plugin controller owns the bus it releases its claim and
+ * unsubscribes; it re-claims when the takeover ends. It never (re)starts the
+ * native agent itself — that stays a user action (CC button).
+ */
+export const NativeCaptionSource = (): null => {
+  const room = useRoomContext()
+  const apiRoomData = useRoomData()
+  const overridden = useCaptionTakeover()
+  const stoppedRef = useRef(false)
+
+  // When overridden, stop the native subtitle producer (redundant while a plugin
+  // owns captions). Best-effort, idempotent; needs the room's LiveKit token.
+  // Re-armed when the takeover ends: the user may restart the native agent via
+  // CC, and a later takeover must stop it again.
+  useEffect(() => {
+    if (!overridden) {
+      stoppedRef.current = false
+      return
+    }
+    if (stoppedRef.current) return
+    const id = apiRoomData?.livekit?.room
+    const token = apiRoomData?.livekit?.token
+    if (!id || !token) return
+    stoppedRef.current = true
+    stopSubtitle({ id, token }).catch(() => {})
+  }, [overridden, apiRoomData])
+
+  useEffect(() => {
+    if (!room || overridden) return
+    const token = claim(NATIVE_SOURCE_ID, { priority: 0 })
+    if (!token) return
+
+    const onTranscription = (
+      segments: TranscriptionSegment[],
+      participant?: Participant
+    ) => {
+      if (!participant || segments.length === 0) return
+      // LiveKit delivers one segment per event here; ignore the unexpected batch case.
+      if (segments.length > 1) return
+      const segment = segments[0]
+      push(token, [
+        {
+          id: segment.id,
+          text: segment.text,
+          final: segment.final,
+          firstReceivedTime: segment.firstReceivedTime,
+          lastReceivedTime: segment.lastReceivedTime,
+          language: segment.language,
+          speaker: {
+            key: participant.identity,
+            name: getParticipantName(participant),
+            color: getParticipantColor(participant),
+          },
+        },
+      ])
+    }
+
+    room.on(RoomEvent.TranscriptionReceived, onTranscription)
+    return () => {
+      room.off(RoomEvent.TranscriptionReceived, onTranscription)
+      release(token)
+    }
+  }, [room, overridden])
+
+  return null
+}

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -369,6 +369,7 @@
   },
   "moreTools": {
     "body": "Nutze weitere Tools, um deine Meetings zu verbessern.",
+    "panelError": "Dieses Tool konnte nicht geladen werden. Bitte lade die Seite neu.",
     "linkAriaLabel": "Dokumentation zu den Tools öffnen – öffnet in neuem Tab",
     "moreLink": "Dokumentation öffnen",
     "tools": {

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -368,6 +368,7 @@
   },
   "moreTools": {
     "body": "Access more tools to enhance your meetings.",
+    "panelError": "This tool failed to load. Try reloading the page.",
     "linkAriaLabel": "Open documentation about tools - opens in new window",
     "moreLink": "Open documentation",
     "tools": {

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -368,6 +368,7 @@
   },
   "moreTools": {
     "body": "Accéder à davantage d'outils pour améliorer vos réunions.",
+    "panelError": "Cet outil n'a pas pu être chargé. Essayez de recharger la page.",
     "linkAriaLabel": "Ouvrir la documentation sur les outils - ouvre dans une nouvelle fenêtre",
     "moreLink": "Ouvrir la documentation",
     "tools": {

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -368,6 +368,7 @@
   },
   "moreTools": {
     "body": "Je krijgt toegang tot meer tools om je vergaderingen te verbeteren.",
+    "panelError": "Deze tool kon niet worden geladen. Probeer de pagina opnieuw te laden.",
     "linkAriaLabel": "Documentatie over tools openen - opent in nieuw venster",
     "moreLink": "Documentatie openen",
     "tools": {

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import { registerPlugin } from '@/features/plugins'
+import { bootPlugins } from '@/features/plugins/loader'
 import { plugin as transcriptPlugin } from '@/features/recording/transcript.plugin'
 import { plugin as screenRecordingPlugin } from '@/features/recording/screenRecording.plugin'
 
-// Composition root: register built-ins (sync) before first render.
+// Composition root: register built-ins (sync) before first render, then boot
+// external deploy-time bundles in the background — contributions appear reactively.
 registerPlugin(transcriptPlugin)
 registerPlugin(screenRecordingPlugin)
 
@@ -14,3 +16,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <App />
   </React.StrictMode>
 )
+
+void bootPlugins().catch((error) => {
+  console.error('[plugins] boot failed', error)
+})

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
+import { registerPlugin } from '@/features/plugins'
+import { plugin as transcriptPlugin } from '@/features/recording/transcript.plugin'
+import { plugin as screenRecordingPlugin } from '@/features/recording/screenRecording.plugin'
+
+// Composition root: register built-ins (sync) before first render.
+registerPlugin(transcriptPlugin)
+registerPlugin(screenRecordingPlugin)
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/frontend/src/primitives/Popover.tsx
+++ b/src/frontend/src/primitives/Popover.tsx
@@ -43,6 +43,9 @@ export const Popover = ({
   children,
   variant = 'light',
   withArrow = true,
+  isOpen,
+  defaultOpen,
+  onOpenChange,
   ...dialogProps
 }: {
   children: [
@@ -53,10 +56,20 @@ export const Popover = ({
   ]
   variant?: 'dark' | 'light'
   withArrow?: boolean
+  /** Controlled open state, forwarded to the underlying `DialogTrigger`. */
+  isOpen?: boolean
+  /** Uncontrolled initial open state, forwarded to `DialogTrigger`. */
+  defaultOpen?: boolean
+  /** Notified when the popover opens/closes (press, escape, outside click). */
+  onOpenChange?: (isOpen: boolean) => void
 } & Omit<DialogProps, 'children'>) => {
   const [trigger, popoverContent] = children
   return (
-    <DialogTrigger>
+    <DialogTrigger
+      isOpen={isOpen}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
+    >
       {trigger}
       <StyledPopover>
         {withArrow && (

--- a/src/frontend/src/primitives/tone.ts
+++ b/src/frontend/src/primitives/tone.ts
@@ -1,0 +1,10 @@
+/** Severity vocabulary shared by host UI surfaces (banner, CC-button decoration). */
+export type Tone = 'info' | 'success' | 'warning' | 'danger'
+
+/** Themed color per tone, using the host's semantic Panda tokens. */
+export const toneColor: Record<Tone, string> = {
+  info: 'primary.700',
+  success: 'success.700',
+  warning: 'warning',
+  danger: 'danger.700',
+}

--- a/src/frontend/src/stores/layout.ts
+++ b/src/frontend/src/stores/layout.ts
@@ -1,15 +1,12 @@
 import { proxy } from 'valtio'
-import type {
-  PanelId,
-  SubPanelId,
-} from '@/features/rooms/livekit/hooks/useSidePanel'
+import { PanelId } from '@/features/rooms/livekit/hooks/useSidePanel'
 
 type State = {
   showHeader: boolean
   showFooter: boolean
   showSubtitles: boolean
   activePanelId: PanelId | null
-  activeSubPanelId: SubPanelId | null
+  activeSubPanelId: string | null
   showReactionsToolbar: boolean
 }
 

--- a/src/frontend/src/utils/getEnv.ts
+++ b/src/frontend/src/utils/getEnv.ts
@@ -1,0 +1,13 @@
+/**
+ * Resolve a frontend env var: window.VITE_CONFIG (injected at container startup)
+ * first, else import.meta.env (build-time). Lets one image be reconfigured at
+ * deploy time via VITE_* env vars.
+ */
+export const getEnv = <K extends keyof ImportMetaEnv>(
+  key: K
+): ImportMetaEnv[K] | undefined => {
+  if (typeof window !== 'undefined' && window.VITE_CONFIG?.[key]) {
+    return window.VITE_CONFIG[key] as ImportMetaEnv[K]
+  }
+  return import.meta.env[key]
+}

--- a/src/frontend/src/vite-env.d.ts
+++ b/src/frontend/src/vite-env.d.ts
@@ -2,8 +2,31 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string
   readonly VITE_APP_TITLE: string
+  /** JSON array of deploy-time plugin bundle refs (see `plugins/loader.ts`). */
+  readonly VITE_PLUGIN_BUNDLES?: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
+}
+
+/** What a deploy-time plugin bundle self-registers with the host. */
+interface MeetRegisteredPlugin {
+  activate(host: unknown): void | Promise<void>
+}
+
+interface Window {
+  VITE_CONFIG?: Partial<Record<keyof ImportMetaEnv, string>>
+  // Host singletons published before any bundle loads; bundles bind these as
+  // externals so their bare imports resolve to the one host instance.
+  React?: typeof import('react')
+  ReactDOM?: typeof import('react-dom')
+  ReactDOMClient?: typeof import('react-dom/client')
+  ReactJSXRuntime?: typeof import('react/jsx-runtime')
+  __MEET_VALTIO__?: typeof import('valtio')
+  __MEET_LIVEKIT_CLIENT__?: typeof import('livekit-client')
+  __MEET_LIVEKIT_COMPONENTS__?: typeof import('@livekit/components-react')
+  // Bundle self-registration channel (set by the host, called by each bundle).
+  __MEET_PLUGINS__?: Record<string, MeetRegisteredPlugin>
+  __meetRegisterPlugin__?: (id: string, mod: MeetRegisteredPlugin) => void
 }

--- a/src/frontend/tsconfig.app.json
+++ b/src/frontend/tsconfig.app.json
@@ -27,5 +27,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "@types"]
+  "include": ["src", "@types", "plugin-examples"]
 }

--- a/src/frontend/tsconfig.node.json
+++ b/src/frontend/tsconfig.node.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vite.plugin.config.ts"]
 }

--- a/src/frontend/vite.plugin.config.ts
+++ b/src/frontend/vite.plugin.config.ts
@@ -1,0 +1,62 @@
+import { resolve } from 'path'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+// External-bundle build preset for deploy-time plugins: a single self-registering
+// UMD/IIFE whose shared singletons are `external`, bound via `output.globals` to
+// the host globals from `plugins/host.ts#publishHostGlobals`. `output.globals` is
+// honored only for umd/iife (not ESM), which is why bundles load as `<script>`s.
+// Every key here MUST match a `window.*` the host publishes before boot.
+const HOST_GLOBALS: Record<string, string> = {
+  react: 'React',
+  'react-dom': 'ReactDOM',
+  'react-dom/client': 'ReactDOMClient',
+  'react/jsx-runtime': 'ReactJSXRuntime',
+  valtio: '__MEET_VALTIO__',
+  'livekit-client': '__MEET_LIVEKIT_CLIENT__',
+  '@livekit/components-react': '__MEET_LIVEKIT_COMPONENTS__',
+}
+
+// Overridable via env so the same preset builds any plugin (smoke is the default).
+const entry = process.env.PLUGIN_ENTRY ?? 'plugin-examples/smoke/index.tsx'
+const name = process.env.PLUGIN_NAME ?? 'smoke'
+const globalName = process.env.PLUGIN_GLOBAL ?? 'MeetPluginBundle'
+const outDir = process.env.PLUGIN_OUTDIR ?? 'dist-plugins'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  // Bundled deps read `process.env.NODE_ENV` at init; a browser IIFE has no
+  // `process`, so an unreplaced reference throws before the bundle self-registers.
+  // Replace it at build time.
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  },
+  build: {
+    outDir,
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(process.cwd(), entry),
+      name: globalName,
+      formats: ['umd'],
+      fileName: () => `${name}.umd.js`,
+    },
+    rollupOptions: {
+      external: Object.keys(HOST_GLOBALS),
+      output: {
+        globals: HOST_GLOBALS,
+        // A bundled CJS dep can emit a runtime `require("react")` for an external
+        // module; in a browser IIFE `require` is undefined and throws before
+        // self-register. Provide an IIFE-scoped `require` (via `intro`) that maps
+        // the externalized specifiers to the same host globals.
+        intro:
+          'var require=function(m){var g={' +
+          Object.entries(HOST_GLOBALS)
+            .map(([k, v]) => `"${k}":window.${v}`)
+            .join(',') +
+          '};if(Object.prototype.hasOwnProperty.call(g,m))return g[m];' +
+          'throw new Error("[meet-plugin] cannot require external module: "+m);};',
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Introduces a generic, first-class **tool-plugin framework** for the in-room UI.
Meeting tools are no longer hard-coded: they are contributed through a plugin
registry, external bundles can be loaded at **deploy time** (a single built
image, reconfigured via env), and plugins drive the core UI through a published
**host ABI** rather than any plugin-specific concept baked into the app.

The built-in Transcript and Screen-recording tools are re-expressed as
first-class registry plugins, so they flow through the exact same machinery as
external plugins and can be hidden or replaced.

## What's new

### Plugin registry framework (`26938161`)
- `Plugin` descriptor: reverse-DNS id, semver `apiVersion`, `isEnabled(config)`,
  `replaces()`, tool + side-panel contributions.
- `registerPlugin` / priority-ordered `resolveVisiblePlugins`
  (`isEnabled` + `replaces` + `hidden_tools` kill-list, lexicographic tiebreak)
  and a per-plugin valtio `pluginContext`.
- Tools menu and side panel render registry entries generically; recording
  toasts / menu items / side panels route through `openSubPanel(pluginId)` and
  a generic imperative `notify` seam.

### Host-owned UI surfaces
- **Caption bus** (`ca56716a`) — the single on-screen caption overlay is claimed
  by the highest-priority registered source; the native LiveKit transcription is
  extracted into `nativeCaptionSource` and a plugin can take captions over and
  yield them back.
- **Banner surface** (`3c8522bd`) — a generic, dismissible in-room banner stack
  any plugin can drive.
- **Caption button** (`869f1b25`) — badge/tone/label decorations + one-time
  popover on the CC toggle; the toggle becomes owner-aware (reflects the current
  caption-bus owner).

### Deploy-time loader + host ABI (`8af11c37`)
- `VITE_PLUGIN_BUNDLES` (resolved via `getEnv`) lists self-registering external
  IIFE bundles the host loads and version-checks (`satisfies`) at boot.
- Host ABI (`host.ts`): React/valtio/livekit singletons on `window`, room-data +
  authenticated-fetch seams, `host.notify`, `host.banner`, `host.captionButton`,
  `host.captionBus`, and a peer-to-peer `host.broadcast` over LiveKit data
  channels.
- `vite.plugin.config.ts`: a standalone external-bundle build preset.

### Backend (`0677d378`)
- Generic `stop-subtitle` room action that stops the native realtime-
  transcription agent when a higher-priority caption owner takes over
  (idempotent, best-effort, LiveKit-token gated like `start-subtitle`).
- Frontend plugins config surface: `PluginsValue` envelope validator, the
  `plugins` FRONTEND namespace, and a `hidden_tools` kill-list at the
  runtime-config root.

### Showcase example plugin (`99150187`)
- A single reference plugin under `src/frontend/plugin-examples/showcase/` that
  touches every seam of the host ABI, so the framework ships no frozen contract
  without an in-tree consumer and plugin authors have a working call to copy.
- Loaded in dev/CI only through `VITE_PLUGIN_BUNDLES`, never registered in
  production `main.tsx`. Ships an authoring `README.md`.

## Testing
- Vitest unit tests for the registry, caption bus, caption-button store and the
  showcase plugin (`captionBus.test.ts`, `captionButtonStore.test.ts`,
  `showcase/index.test.ts`).
- Backend tests for the `stop-subtitle` action and `SubtitleService.stop_subtitle`.

## Notes
- CHANGELOG updated under `[Unreleased] → Added`.