### PR TITLE
♿️(frontend) close side panel with Escape key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - ♻️(frontend) inline model weights to avoid loading them from remote
 - ♻️(frontend) inline MediaPipe WASM modules to avoid loading from remote
 - ⬆️(frontend) upgrade posthog-js from 1.387.0 to 1.391.2
+- ♿️(frontend) close side panel with Escape key #1507
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♿️(frontend) close side panel with Escape key #1507
+
 ### Added
 
 - ✨(agent) support Voxtral realtime as inference engine

--- a/src/frontend/src/features/chat/components/ChatTextArea.tsx
+++ b/src/frontend/src/features/chat/components/ChatTextArea.tsx
@@ -51,7 +51,7 @@ export const ChatTextArea = () => {
   const isDisabled = !textAreaValue.trim() || isSending
 
   const onKeyDown = async (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    e.stopPropagation()
+    if (e.key !== 'Escape') e.stopPropagation()
     if (e.key !== 'Enter' || (e.key === 'Enter' && e.shiftKey) || isDisabled)
       return
     e.preventDefault()

--- a/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
@@ -17,6 +17,7 @@ import { HStack } from '@/styled-system/jsx'
 import { useReactionsToolbar } from '@/features/reactions/hooks/useReactionsToolbar'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 import { useEscapeToClose } from '@/hooks/useEscapeToClose'
+import { srOnly } from '@/styles/a11y'
 
 type StyledSidePanelProps = {
   title: string
@@ -25,6 +26,7 @@ type StyledSidePanelProps = {
   onClose: () => void
   isClosed: boolean
   closeButtonTooltip: string
+  escapeHint: string
   isSubmenu: boolean
   onBack: () => void
   backButtonLabel: string
@@ -41,6 +43,7 @@ const StyledSidePanel = React.forwardRef<HTMLElement, StyledSidePanelProps>(
       isClosed,
       isReactionToolbarOpen,
       closeButtonTooltip,
+      escapeHint,
       isSubmenu = false,
       onBack,
       backButtonLabel,
@@ -85,7 +88,11 @@ const StyledSidePanel = React.forwardRef<HTMLElement, StyledSidePanelProps>(
       }}
       aria-hidden={isClosed}
       aria-label={ariaLabel}
+      aria-describedby="side-panel-escape-hint"
     >
+      <span id="side-panel-escape-hint" className={srOnly}>
+        {escapeHint}
+      </span>
       <HStack alignItems="center">
         {isSubmenu && (
           <Button
@@ -211,6 +218,7 @@ export const SidePanel = () => {
       closeButtonTooltip={t('closeButton', {
         content: t(`content.${activeSubPanelId || activePanelId}`),
       })}
+      escapeHint={t('escapeHint')}
       isClosed={!isSidePanelOpen}
       isSubmenu={isSubPanelOpen}
       isReactionToolbarOpen={isReactionToolbarOpen}

--- a/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
@@ -16,6 +16,7 @@ import { Info } from './Info'
 import { HStack } from '@/styled-system/jsx'
 import { useReactionsToolbar } from '@/features/reactions/hooks/useReactionsToolbar'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import { useEscapeToClose } from '@/hooks/useEscapeToClose'
 
 type StyledSidePanelProps = {
   title: string
@@ -188,21 +189,25 @@ export const SidePanel = () => {
     focusAside()
   }, [activePanelId, focusAside])
 
+  const closePanel = useCallback(() => {
+    layoutStore.activePanelId = null
+    layoutStore.activeSubPanelId = null
+  }, [])
+
   useRestoreFocus(isSidePanelOpen, {
     onOpened: handlePanelOpened,
     preventScroll: true,
     activeKey: activePanelId,
   })
 
+  useEscapeToClose(isSidePanelOpen, asideRef, closePanel)
+
   return (
     <StyledSidePanel
       ref={asideRef}
       title={title}
       ariaLabel={t('ariaLabel', { title })}
-      onClose={() => {
-        layoutStore.activePanelId = null
-        layoutStore.activeSubPanelId = null
-      }}
+      onClose={closePanel}
       closeButtonTooltip={t('closeButton', {
         content: t(`content.${activeSubPanelId || activePanelId}`),
       })}

--- a/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
@@ -17,6 +17,7 @@ import { HStack } from '@/styled-system/jsx'
 import { useReactionsToolbar } from '@/features/reactions/hooks/useReactionsToolbar'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 import { useEscapeToClose } from '@/hooks/useEscapeToClose'
+import { srOnly } from '@/styles/a11y'
 
 type StyledSidePanelProps = {
   title: string
@@ -25,6 +26,7 @@ type StyledSidePanelProps = {
   onClose: () => void
   isClosed: boolean
   closeButtonTooltip: string
+  escapeHint: string
   isSubmenu: boolean
   onBack: () => void
   backButtonLabel: string
@@ -41,6 +43,7 @@ const StyledSidePanel = React.forwardRef<HTMLElement, StyledSidePanelProps>(
       isClosed,
       isReactionToolbarOpen,
       closeButtonTooltip,
+      escapeHint,
       isSubmenu = false,
       onBack,
       backButtonLabel,
@@ -85,7 +88,11 @@ const StyledSidePanel = React.forwardRef<HTMLElement, StyledSidePanelProps>(
       }}
       aria-hidden={isClosed}
       aria-label={ariaLabel}
+      aria-describedby="side-panel-escape-hint"
     >
+      <span id="side-panel-escape-hint" className={srOnly}>
+        {escapeHint}
+      </span>
       <HStack alignItems="center">
         {isSubmenu && (
           <Button
@@ -206,6 +213,7 @@ export const SidePanel = () => {
       closeButtonTooltip={t('closeButton', {
         content: t(`content.${activeSubPanelId || activePanelId}`),
       })}
+      escapeHint={t('escapeHint')}
       isClosed={!isSidePanelOpen}
       isSubmenu={isSubPanelOpen}
       isReactionToolbarOpen={isReactionToolbarOpen}

--- a/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
@@ -16,6 +16,7 @@ import { Info } from './Info'
 import { HStack } from '@/styled-system/jsx'
 import { useReactionsToolbar } from '@/features/reactions/hooks/useReactionsToolbar'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import { useEscapeToClose } from '@/hooks/useEscapeToClose'
 
 type StyledSidePanelProps = {
   title: string
@@ -193,6 +194,8 @@ export const SidePanel = () => {
     preventScroll: true,
     activeKey: activePanelId,
   })
+
+  useEscapeToClose(isSidePanelOpen, asideRef, closeSidePanel)
 
   return (
     <StyledSidePanel

--- a/src/frontend/src/features/rooms/livekit/components/chat/Input.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/chat/Input.tsx
@@ -35,6 +35,11 @@ export const ChatInput = ({
     if (!isDisabled) handleSubmit()
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== 'Escape') e.stopPropagation()
+    submitOnEnter(e)
+  }
+
   useEffect(() => {
     const resize = () => {
       if (!inputRef.current) return
@@ -79,10 +84,7 @@ export const ChatInput = ({
     >
       <TextArea
         ref={inputRef}
-        onKeyDown={(e) => {
-          e.stopPropagation()
-          submitOnEnter(e)
-        }}
+        onKeyDown={handleKeyDown}
         onKeyUp={(e) => e.stopPropagation()}
         placeholder={t('textArea.placeholder')}
         value={text}

--- a/src/frontend/src/hooks/useEscapeToClose.ts
+++ b/src/frontend/src/hooks/useEscapeToClose.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, type RefObject } from 'react'
+
+export const useEscapeToClose = (
+  isActive: boolean,
+  containerRef: RefObject<HTMLElement | null>,
+  onClose: () => void
+) => {
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+
+  useEffect(() => {
+    if (!isActive) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      if (!containerRef.current?.contains(document.activeElement)) return
+      e.stopPropagation()
+      onCloseRef.current()
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isActive, containerRef])
+}

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -361,7 +361,8 @@
       "tools": "Weitere Tools",
       "info": "Meeting-Informationen"
     },
-    "closeButton": "{{content}} ausblenden"
+    "closeButton": "{{content}} ausblenden (Escape)",
+    "escapeHint": "Escape drücken zum Schließen"
   },
   "chat": {
     "disclaimer": "Die Nachrichten sind nur für Teilnehmende zum Zeitpunkt des Sendens sichtbar. Alle Nachrichten werden am Ende des Meetings gelöscht.",

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -435,7 +435,8 @@
       "tools": "Weitere Tools",
       "info": "Meeting-Informationen"
     },
-    "closeButton": "{{content}} ausblenden"
+    "closeButton": "{{content}} ausblenden (Escape)",
+    "escapeHint": "Escape drücken zum Schließen"
   },
   "chat": {
     "disclaimer": "Die Nachrichten sind nur für Teilnehmende zum Zeitpunkt des Sendens sichtbar. Alle Nachrichten werden am Ende des Meetings gelöscht.",

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -360,7 +360,8 @@
       "tools": "more tools",
       "info": "meeting information"
     },
-    "closeButton": "Hide {{content}}"
+    "closeButton": "Hide {{content}} (Escape)",
+    "escapeHint": "Press Escape to close"
   },
   "chat": {
     "disclaimer": "The messages are visible to participants only at the time they are sent. All messages are deleted at the end of the call.",

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -435,7 +435,8 @@
       "tools": "more tools",
       "info": "meeting information"
     },
-    "closeButton": "Hide {{content}}"
+    "closeButton": "Hide {{content}} (Escape)",
+    "escapeHint": "Press Escape to close"
   },
   "chat": {
     "disclaimer": "The messages are visible to participants only at the time they are sent. All messages are deleted at the end of the call.",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -360,7 +360,8 @@
       "tools": "outils de réunion",
       "info": "informations sur la réunion"
     },
-    "closeButton": "Masquer {{content}}"
+    "closeButton": "Masquer {{content}} (Échap)",
+    "escapeHint": "Appuyez sur Échap pour fermer"
   },
   "chat": {
     "disclaimer": "Les messages sont visibles par les participants uniquement au moment de\nleur envoi. Tous les messages sont supprimés à la fin de l'appel.",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -435,7 +435,8 @@
       "tools": "outils de réunion",
       "info": "informations sur la réunion"
     },
-    "closeButton": "Masquer {{content}}"
+    "closeButton": "Masquer {{content}} (Échap)",
+    "escapeHint": "Appuyez sur Échap pour fermer"
   },
   "chat": {
     "disclaimer": "Les messages sont visibles par les participants uniquement au moment de\nleur envoi. Tous les messages sont supprimés à la fin de l'appel.",

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -360,7 +360,8 @@
       "tools": "meer tools",
       "info": "vergaderinformatie"
     },
-    "closeButton": "Verberg {{content}}"
+    "closeButton": "Verberg {{content}} (Escape)",
+    "escapeHint": "Druk op Escape om te sluiten"
   },
   "chat": {
     "disclaimer": "De berichten zijn alleen voor de deelnemers zichtbaar op het moment dat ze worden verzonden. Alle berichten worden verwijderd aan het einde van het gesprek.",

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -435,7 +435,8 @@
       "tools": "meer tools",
       "info": "vergaderinformatie"
     },
-    "closeButton": "Verberg {{content}}"
+    "closeButton": "Verberg {{content}} (Escape)",
+    "escapeHint": "Druk op Escape om te sluiten"
   },
   "chat": {
     "disclaimer": "De berichten zijn alleen voor de deelnemers zichtbaar op het moment dat ze worden verzonden. Alle berichten worden verwijderd aan het einde van het gesprek.",


### PR DESCRIPTION
## Purpose

Side panels can be closed with the ✕ button, but keyboard users have no equivalent shortcut. Escape should close the panel and return focus to the trigger button.

## Proposal

- [x] Close side panel with Escape when focus is inside the panel
- [x] Restore focus on the trigger button that opened the panel
- [x] If a second panel is opened without closing the first, restore focus on the last opened panel trigger (not the first one)
- [x] Allow Escape from the chat textarea to close the panel
