### PR TITLE
[frontend] fix(subtitles): update existing segments in-place instead of deduplicating by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to
 - 🩹(backend) identify externally provisioned users to PostHog
 - 🐛(backend) fix info panel crash for unregistered rooms
 - ♿️(frontend) focus side panel container on open #1452
+- 🐛(frontend) fix subtitles: update transcription segments in-place to display full sentences
 
 ## [1.23.0] - 2026-07-08
 

--- a/src/frontend/src/features/subtitle/component/Subtitles.tsx
+++ b/src/frontend/src/features/subtitle/component/Subtitles.tsx
@@ -74,16 +74,16 @@ const useTranscriptionState = () => {
 
     const segment = segments[0]
 
-    setTranscriptionSegments((prevSegments) => {
-      const existingSegmentIds = new Set(prevSegments.map((s) => s.id))
-      if (existingSegmentIds.has(segment.id)) return prevSegments
-      return [
-        ...prevSegments,
-        {
-          participant: participant,
-          ...segment,
-        },
-      ]
+    setTranscriptionSegments((prevSegments: TranscriptionSegmentWithParticipant[]) => {
+      const existingIndex = prevSegments.findIndex(
+        (s: TranscriptionSegmentWithParticipant) => s.id === segment.id
+      )
+      if (existingIndex === -1) {
+        return [...prevSegments, { participant, ...segment }]
+      }
+      const next = prevSegments.slice()
+      next[existingIndex] = { ...next[existingIndex], ...segment }
+      return next
     })
   }
 


### PR DESCRIPTION
## Purpose

Fix an accessibility issue, by fixing the subtitle bug. This fix was identified by @cameledev in PR #1277. However, the latter PR has a bigger scope, a different purpose, and has merge conflicts: it may take some time to merge. This PR extracts just the Subtitles.tsx change to unblock the bug fix independently of the larger voxtral feature.

To give a little more context: when using subtitle feature with a livekit agent with STT system (vosk-fr), every word is sent back to frontend (visible in Console tab) but UI does not update accordingly. Messages are deduplicated by ID, meaning only the first subtitle word is displayed in the UI. This is an accessibility problem.

## Proposal

Isolate the Subtitles.tsx fix in a separate PR to push an accessibility improvement. It is better than wait for a feature that has a different scope. As stated in PR 1277 : "Incompatible wire protocol (most important issue)"

- [x] Fix `setTranscriptionSegments`
