### PR TITLE
✨(all) share images in the meeting chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(all) share images in the meeting chat #1547
 - ✨(summary) report exception type in failure analytics
 - ✨(frontend) add configurable documentation menu item
 - ✨(frontend) allow promoting authenticated participants

--- a/src/backend/core/api/__init__.py
+++ b/src/backend/core/api/__init__.py
@@ -60,6 +60,12 @@ def get_frontend_configuration(request):
                 "allowed_mimetypes"
             ],
         },
+        "chat_media": {
+            "enabled": settings.CHAT_MEDIA_ENABLED,
+            "max_size": settings.CHAT_MEDIA_MAX_SIZE,
+            "allowed_mimetypes": settings.CHAT_MEDIA_ALLOWED_MIMETYPES,
+            "allowed_extensions": settings.CHAT_MEDIA_ALLOWED_EXTENSIONS,
+        },
         "telephony": build_telephony_config(),
         "resource": {
             "default_access_level": settings.RESOURCE_DEFAULT_ACCESS_LEVEL,

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -1,0 +1,65 @@
+"""
+Test the frontend configuration endpoint.
+"""
+
+from rest_framework.test import APIClient
+
+
+def test_api_config_is_public():
+    """The configuration is readable without authentication."""
+    response = APIClient().get("/api/v1.0/config/")
+
+    assert response.status_code == 200
+
+
+def test_api_config_chat_media_defaults():
+    """Chat media is advertised with its default limits and enabled by default."""
+    response = APIClient().get("/api/v1.0/config/")
+
+    assert response.status_code == 200
+    assert response.json()["chat_media"] == {
+        "enabled": True,
+        "max_size": 5 * 1024 * 1024,
+        "allowed_mimetypes": [
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+            "image/gif",
+        ],
+        "allowed_extensions": [".jpg", ".jpeg", ".png", ".webp", ".gif"],
+    }
+
+
+def test_api_config_chat_media_excludes_svg():
+    """SVG is never advertised, it can execute script once rendered."""
+    response = APIClient().get("/api/v1.0/config/")
+
+    chat_media = response.json()["chat_media"]
+
+    assert "image/svg+xml" not in chat_media["allowed_mimetypes"]
+    assert ".svg" not in chat_media["allowed_extensions"]
+
+
+def test_api_config_chat_media_disabled(settings):
+    """An operator can turn chat media off."""
+    settings.CHAT_MEDIA_ENABLED = False
+
+    response = APIClient().get("/api/v1.0/config/")
+
+    assert response.json()["chat_media"]["enabled"] is False
+
+
+def test_api_config_chat_media_overrides(settings):
+    """Limits and allowlists are reported from settings, not hardcoded."""
+    settings.CHAT_MEDIA_MAX_SIZE = 1024
+    settings.CHAT_MEDIA_ALLOWED_MIMETYPES = ["image/png"]
+    settings.CHAT_MEDIA_ALLOWED_EXTENSIONS = [".png"]
+
+    response = APIClient().get("/api/v1.0/config/")
+
+    assert response.json()["chat_media"] == {
+        "enabled": True,
+        "max_size": 1024,
+        "allowed_mimetypes": ["image/png"],
+        "allowed_extensions": [".png"],
+    }

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -940,6 +940,27 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # Chat media settings
+    # Images are relayed between participants over LiveKit byte streams and are
+    # never stored, so there is nothing for an operator to provision.
+    CHAT_MEDIA_ENABLED = values.BooleanValue(
+        True, environ_name="CHAT_MEDIA_ENABLED", environ_prefix=None
+    )
+    CHAT_MEDIA_MAX_SIZE = values.PositiveIntegerValue(
+        5 * MB, environ_name="CHAT_MEDIA_MAX_SIZE", environ_prefix=None
+    )
+    CHAT_MEDIA_ALLOWED_MIMETYPES = values.ListValue(
+        # SVG is deliberately excluded, it can execute script.
+        ["image/jpeg", "image/png", "image/webp", "image/gif"],
+        environ_name="CHAT_MEDIA_ALLOWED_MIMETYPES",
+        environ_prefix=None,
+    )
+    CHAT_MEDIA_ALLOWED_EXTENSIONS = values.ListValue(
+        [".jpg", ".jpeg", ".png", ".webp", ".gif"],
+        environ_name="CHAT_MEDIA_ALLOWED_EXTENSIONS",
+        environ_prefix=None,
+    )
+
     # Metadata collector settings
     METADATA_COLLECTOR_ENABLED = values.BooleanValue(
         False, environ_name="METADATA_COLLECTOR_ENABLED", environ_prefix=None

--- a/src/frontend/src/api/useConfig.ts
+++ b/src/frontend/src/api/useConfig.ts
@@ -42,6 +42,12 @@ export interface ApiConfig {
     allowed_extensions: string[]
     allowed_mimetypes: string[]
   }
+  chat_media?: {
+    enabled: boolean
+    max_size: number
+    allowed_mimetypes: string[]
+    allowed_extensions: string[]
+  }
   subtitle: {
     enabled: boolean
   }

--- a/src/frontend/src/features/chat/components/Chat.tsx
+++ b/src/frontend/src/features/chat/components/Chat.tsx
@@ -2,6 +2,9 @@ import { useTranslation } from 'react-i18next'
 import { Text } from '@/primitives'
 import { ChatMessages } from './ChatMessages'
 import { ChatTextArea } from './ChatTextArea'
+import { ChatDropZone } from './ChatDropZone'
+import { ChatPendingAttachment } from './ChatPendingAttachment'
+import { useSendChatMedia } from '../media/useSendChatMedia'
 import { styled } from '@/styled-system/jsx'
 
 const ChatContainer = styled('div', {
@@ -35,16 +38,29 @@ const TextContainer = styled('div', {
 
 export const Chat = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'chat' })
+  const { stage, send, clear, limits } = useSendChatMedia()
 
   return (
     <ChatContainer>
       <TextContainer>
         <Text variant="sm">{t('disclaimer')}</Text>
       </TextContainer>
-      <ChatMessagesContainer>
-        <ChatMessages />
-      </ChatMessagesContainer>
-      <ChatTextArea />
+      <ChatDropZone
+        onDrop={stage}
+        isDisabled={!limits.enabled}
+        acceptedMimetypes={limits.allowedMimetypes}
+      >
+        <ChatMessagesContainer>
+          <ChatMessages />
+        </ChatMessagesContainer>
+        {limits.enabled && <ChatPendingAttachment onRemove={clear} />}
+        <ChatTextArea
+          onAttach={stage}
+          onSendMedia={send}
+          isMediaEnabled={limits.enabled}
+          acceptedMimetypes={limits.allowedMimetypes}
+        />
+      </ChatDropZone>
     </ChatContainer>
   )
 }

--- a/src/frontend/src/features/chat/components/ChatAttachButton.tsx
+++ b/src/frontend/src/features/chat/components/ChatAttachButton.tsx
@@ -1,0 +1,44 @@
+import { FileTrigger } from 'react-aria-components'
+import { RiImageAddLine } from '@remixicon/react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/primitives'
+
+type ChatAttachButtonProps = {
+  onSelect: (file: File) => void
+  isDisabled?: boolean
+  acceptedMimetypes: string[]
+}
+
+/**
+ * The keyboard route in, and the only practical one on a touch screen where
+ * there is nothing to drag from. Dragging is never the sole entry point.
+ */
+export const ChatAttachButton = ({
+  onSelect,
+  isDisabled,
+  acceptedMimetypes,
+}: ChatAttachButtonProps) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'chat.media' })
+
+  return (
+    <FileTrigger
+      acceptedFileTypes={acceptedMimetypes}
+      onSelect={(files) => {
+        const file = files?.[0]
+        if (file) onSelect(file)
+      }}
+    >
+      <Button
+        square
+        invisible
+        variant="tertiaryText"
+        size="sm"
+        isDisabled={isDisabled}
+        aria-label={t('attach')}
+        data-attr="chat-attach-image"
+      >
+        <RiImageAddLine size={20} />
+      </Button>
+    </FileTrigger>
+  )
+}

--- a/src/frontend/src/features/chat/components/ChatDropZone.tsx
+++ b/src/frontend/src/features/chat/components/ChatDropZone.tsx
@@ -1,0 +1,75 @@
+import { ReactNode } from 'react'
+import { DropZone } from 'react-aria-components'
+import { useTranslation } from 'react-i18next'
+import { css } from '@/styled-system/css'
+import { Text } from '@/primitives'
+
+type ChatDropZoneProps = {
+  onDrop: (file: File) => void
+  isDisabled?: boolean
+  acceptedMimetypes: string[]
+  children: ReactNode
+}
+
+/**
+ * Wraps the whole chat panel so a file can be dropped anywhere in it rather
+ * than onto a small target. Convenience only: the picker button and pasting
+ * both do the same thing without a pointer.
+ */
+export const ChatDropZone = ({
+  onDrop,
+  isDisabled,
+  acceptedMimetypes,
+  children,
+}: ChatDropZoneProps) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'chat.media' })
+
+  return (
+    <DropZone
+      isDisabled={isDisabled}
+      aria-label={t('dropZone')}
+      getDropOperation={(types) =>
+        acceptedMimetypes.some((type) => types.has(type)) ? 'copy' : 'cancel'
+      }
+      onDrop={async (event) => {
+        const item = event.items.find(
+          (candidate) =>
+            candidate.kind === 'file' &&
+            acceptedMimetypes.includes(candidate.type)
+        )
+        if (item?.kind === 'file') onDrop(await item.getFile())
+      }}
+      className={css({
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        minHeight: 0,
+        position: 'relative',
+        '&[data-drop-target]': {
+          outline: '2px dashed token(colors.primary.500)',
+          outlineOffset: '-4px',
+          borderRadius: 4,
+        },
+      })}
+    >
+      {children}
+      <Text
+        variant="sm"
+        margin={false}
+        className={css({
+          display: 'none',
+          position: 'absolute',
+          inset: 0,
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+          backgroundColor: 'greyscale.50',
+          borderRadius: 4,
+          '[data-drop-target] > &': { display: 'flex' },
+        })}
+      >
+        {t('dropHint')}
+      </Text>
+    </DropZone>
+  )
+}

--- a/src/frontend/src/features/chat/components/ChatImageLightbox.tsx
+++ b/src/frontend/src/features/chat/components/ChatImageLightbox.tsx
@@ -1,0 +1,85 @@
+import { useTranslation } from 'react-i18next'
+import { RiDownloadLine } from '@remixicon/react'
+import { css } from '@/styled-system/css'
+import { Dialog, Text } from '@/primitives'
+import type { ChatMediaRow } from '@/stores/chat'
+
+type ChatImageLightboxProps = {
+  item: ChatMediaRow
+  isOpen: boolean
+  onOpenChange: (isOpen: boolean) => void
+}
+
+/**
+ * The enlarged view, and the only place an image can be saved from.
+ *
+ * The blob URL is never navigated to, only used as an `img` source or an
+ * anchor's download target. A `blob:` URL is same-origin, so opening one in a
+ * tab would run whatever the bytes turn out to be under this application's
+ * origin.
+ */
+export const ChatImageLightbox = ({
+  item,
+  isOpen,
+  onOpenChange,
+}: ChatImageLightboxProps) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'chat.media' })
+
+  if (!item.objectUrl) return null
+
+  const extension = item.mimeType.split('/')[1] || 'bin'
+
+  return (
+    <Dialog
+      size="large"
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      // Named rather than titled: a `title` renders a heading above the image,
+      // which would repeat the caption shown beneath it.
+      aria-label={item.caption || t('alt')}
+    >
+      <div
+        className={css({
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.75rem',
+          alignItems: 'flex-start',
+        })}
+      >
+        <img
+          src={item.objectUrl}
+          alt={item.caption || t('alt')}
+          className={css({
+            maxWidth: '100%',
+            maxHeight: '70vh',
+            objectFit: 'contain',
+            borderRadius: 4,
+          })}
+        />
+        {!!item.caption && (
+          <Text
+            variant="body"
+            margin={false}
+            className={css({ whiteSpace: 'pre-wrap' })}
+          >
+            {item.caption}
+          </Text>
+        )}
+        <a
+          href={item.objectUrl}
+          download={`image-${item.id.slice(0, 8)}.${extension}`}
+          className={css({
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.375rem',
+            textDecoration: 'underline',
+          })}
+          data-attr="chat-download-image"
+        >
+          <RiDownloadLine size={16} />
+          {t('download')}
+        </a>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/frontend/src/features/chat/components/ChatMessage.tsx
+++ b/src/frontend/src/features/chat/components/ChatMessage.tsx
@@ -28,7 +28,7 @@ export const ChatMessage = ({ item }: ChatMessageProps) => {
           identity={item.identity}
         />
       )}
-      <ChatMessageBody message={item.message} />
+      {item.kind === 'text' && <ChatMessageBody message={item.message} />}
     </StyledContainer>
   )
 }

--- a/src/frontend/src/features/chat/components/ChatMessage.tsx
+++ b/src/frontend/src/features/chat/components/ChatMessage.tsx
@@ -2,6 +2,7 @@ import type { ChatRow } from '@/stores/chat'
 import { styled } from '@/styled-system/jsx'
 import { ChatMessageMetadata } from './ChatMessageMedata'
 import { ChatMessageBody } from './ChatMessageBody'
+import { ChatMessageImage } from './ChatMessageImage'
 
 const StyledContainer = styled('li', {
   base: {
@@ -28,7 +29,11 @@ export const ChatMessage = ({ item }: ChatMessageProps) => {
           identity={item.identity}
         />
       )}
-      {item.kind === 'text' && <ChatMessageBody message={item.message} />}
+      {item.kind === 'text' ? (
+        <ChatMessageBody message={item.message} />
+      ) : (
+        <ChatMessageImage item={item} />
+      )}
     </StyledContainer>
   )
 }

--- a/src/frontend/src/features/chat/components/ChatMessageBody.tsx
+++ b/src/frontend/src/features/chat/components/ChatMessageBody.tsx
@@ -1,10 +1,10 @@
-import { ChatRow } from '@/stores/chat'
+import { ChatTextRow } from '@/stores/chat'
 import React, { useMemo } from 'react'
 import { formatChatMessageLinks } from '@livekit/components-react'
 import { css } from '@/styled-system/css'
 import { Text } from '@/primitives'
 
-type ChatMessageBodyProps = Pick<ChatRow, 'message'>
+type ChatMessageBodyProps = Pick<ChatTextRow, 'message'>
 
 export const ChatMessageBody = React.memo(
   ({ message }: ChatMessageBodyProps) => {

--- a/src/frontend/src/features/chat/components/ChatMessageImage.tsx
+++ b/src/frontend/src/features/chat/components/ChatMessageImage.tsx
@@ -116,7 +116,11 @@ export const ChatMessageImage = ({ item }: ChatMessageImageProps) => {
         />
       </StyledFrame>
       {!!item.caption && (
-        <Text variant="sm" margin={false} className={css({ whiteSpace: 'pre-wrap' })}>
+        <Text
+          variant="sm"
+          margin={false}
+          className={css({ whiteSpace: 'pre-wrap' })}
+        >
           {item.caption}
         </Text>
       )}

--- a/src/frontend/src/features/chat/components/ChatMessageImage.tsx
+++ b/src/frontend/src/features/chat/components/ChatMessageImage.tsx
@@ -1,0 +1,125 @@
+import { useTranslation } from 'react-i18next'
+import { css } from '@/styled-system/css'
+import { styled } from '@/styled-system/jsx'
+import { Text } from '@/primitives'
+import type { ChatMediaRow } from '@/stores/chat'
+
+const StyledFigure = styled('figure', {
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.25rem',
+    margin: 0,
+    maxWidth: '100%',
+  },
+})
+
+const StyledFrame = styled('div', {
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    borderRadius: 4,
+    backgroundColor: 'greyscale.50',
+    maxWidth: '100%',
+  },
+})
+
+/**
+ * Reserves the final height while the bytes are still arriving, so the list
+ * does not jump when the image lands. The sender measured these; a receiver
+ * that was not told falls back to a fixed box.
+ */
+const aspectRatio = (row: ChatMediaRow) =>
+  row.width && row.height ? `${row.width} / ${row.height}` : undefined
+
+type ChatMessageImageProps = {
+  item: ChatMediaRow
+}
+
+/**
+ * Progress lives in its own component so that updating it re-renders nothing
+ * else. The row sits inside a virtualized list, and a transfer writes a new
+ * percentage twenty times.
+ */
+const TransferProgress = ({ item }: { item: ChatMediaRow }) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'chat.media' })
+  const percent =
+    item.progress == null ? undefined : Math.round(item.progress * 100)
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={t('receiving')}
+      aria-valuenow={percent}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className={css({
+        width: '100%',
+        height: '4px',
+        borderRadius: 'full',
+        backgroundColor: 'greyscale.200',
+        overflow: 'hidden',
+      })}
+    >
+      <div
+        className={css({
+          height: '100%',
+          backgroundColor: 'primary.500',
+          transition: 'width 150ms linear',
+        })}
+        style={{ width: percent == null ? '100%' : `${percent}%` }}
+      />
+    </div>
+  )
+}
+
+export const ChatMessageImage = ({ item }: ChatMessageImageProps) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'chat.media' })
+
+  if (item.status === 'failed') {
+    return (
+      <Text variant="smNote" margin={false}>
+        {t(`error.${item.error ?? 'transfer_failed'}`)}
+      </Text>
+    )
+  }
+
+  if (item.status === 'receiving' || !item.objectUrl) {
+    return (
+      <StyledFigure aria-busy>
+        <StyledFrame
+          style={{ aspectRatio: aspectRatio(item), width: '12rem' }}
+        />
+        <TransferProgress item={item} />
+        <Text variant="smNote" margin={false}>
+          {t('receiving')}
+        </Text>
+      </StyledFigure>
+    )
+  }
+
+  return (
+    <StyledFigure>
+      <StyledFrame style={{ maxWidth: '16rem' }}>
+        <img
+          src={item.objectUrl}
+          alt={item.caption || t('alt')}
+          style={{ aspectRatio: aspectRatio(item) }}
+          className={css({
+            display: 'block',
+            width: '100%',
+            height: 'auto',
+            objectFit: 'contain',
+          })}
+        />
+      </StyledFrame>
+      {!!item.caption && (
+        <Text variant="sm" margin={false} className={css({ whiteSpace: 'pre-wrap' })}>
+          {item.caption}
+        </Text>
+      )}
+    </StyledFigure>
+  )
+}

--- a/src/frontend/src/features/chat/components/ChatMessageImage.tsx
+++ b/src/frontend/src/features/chat/components/ChatMessageImage.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from '@/styled-system/css'
 import { styled } from '@/styled-system/jsx'
 import { Text } from '@/primitives'
 import type { ChatMediaRow } from '@/stores/chat'
+import { ChatImageLightbox } from './ChatImageLightbox'
 
 const StyledFigure = styled('figure', {
   base: {
@@ -77,6 +79,7 @@ const TransferProgress = ({ item }: { item: ChatMediaRow }) => {
 
 export const ChatMessageImage = ({ item }: ChatMessageImageProps) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'chat.media' })
+  const [isOpen, setIsOpen] = useState(false)
 
   if (item.status === 'failed') {
     return (
@@ -103,18 +106,37 @@ export const ChatMessageImage = ({ item }: ChatMessageImageProps) => {
   return (
     <StyledFigure>
       <StyledFrame style={{ maxWidth: '16rem' }}>
-        <img
-          src={item.objectUrl}
-          alt={item.caption || t('alt')}
-          style={{ aspectRatio: aspectRatio(item) }}
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          aria-label={t('enlarge')}
           className={css({
             display: 'block',
             width: '100%',
-            height: 'auto',
-            objectFit: 'contain',
+            padding: 0,
+            border: 'none',
+            background: 'none',
+            cursor: 'pointer',
+            '&:focus-visible': {
+              outline: '2px solid token(colors.primary.500)',
+            },
           })}
-        />
+          data-attr="chat-open-image"
+        >
+          <img
+            src={item.objectUrl}
+            alt={item.caption || t('alt')}
+            style={{ aspectRatio: aspectRatio(item) }}
+            className={css({
+              display: 'block',
+              width: '100%',
+              height: 'auto',
+              objectFit: 'contain',
+            })}
+          />
+        </button>
       </StyledFrame>
+      <ChatImageLightbox item={item} isOpen={isOpen} onOpenChange={setIsOpen} />
       {!!item.caption && (
         <Text
           variant="sm"

--- a/src/frontend/src/features/chat/components/ChatPendingAttachment.tsx
+++ b/src/frontend/src/features/chat/components/ChatPendingAttachment.tsx
@@ -1,0 +1,90 @@
+import { useTranslation } from 'react-i18next'
+import { useSnapshot } from 'valtio'
+import { RiCloseLine } from '@remixicon/react'
+import { css } from '@/styled-system/css'
+import { styled } from '@/styled-system/jsx'
+import { Button, Text } from '@/primitives'
+import { chatStore } from '@/stores/chat'
+
+const StyledRow = styled('div', {
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: '0.5rem',
+    backgroundColor: 'greyscale.50',
+    borderRadius: 4,
+    marginTop: '0.75rem',
+  },
+})
+
+type ChatPendingAttachmentProps = {
+  onRemove: () => void
+}
+
+/**
+ * The staged image, above the text box, before anything is sent. Its presence
+ * is what makes a drop reversible: nothing leaves the browser until send.
+ */
+export const ChatPendingAttachment = ({
+  onRemove,
+}: ChatPendingAttachmentProps) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'chat.media' })
+  const { pendingAttachment, isPreparing, mediaFailure } =
+    useSnapshot(chatStore)
+
+  // A failed send keeps the staged image, so the error is shown beside it
+  // rather than in place of it: a participant whose send failed still needs
+  // the thumbnail and the remove button to retry or give up.
+  const failure = mediaFailure && (
+    <StyledRow role="alert">
+      <Text variant="smNote" margin={false}>
+        {t(`error.${mediaFailure}`)}
+      </Text>
+    </StyledRow>
+  )
+
+  if (isPreparing) {
+    return (
+      <StyledRow>
+        <Text variant="smNote" margin={false}>
+          {t('preparing')}
+        </Text>
+      </StyledRow>
+    )
+  }
+
+  if (!pendingAttachment) return failure || null
+
+  return (
+    <>
+      {failure}
+      <StyledRow>
+        <img
+          src={pendingAttachment.previewUrl}
+          alt={t('stagedAlt')}
+          className={css({
+            width: '2.5rem',
+            height: '2.5rem',
+            objectFit: 'cover',
+            borderRadius: 4,
+          })}
+        />
+        <Text variant="smNote" margin={false} className={css({ flexGrow: 1 })}>
+          {t('staged')}
+        </Text>
+        <Button
+          square
+          invisible
+          variant="tertiaryText"
+          size="sm"
+          aria-label={t('remove')}
+          onPress={onRemove}
+          data-attr="chat-remove-image"
+        >
+          <RiCloseLine size={18} />
+        </Button>
+      </StyledRow>
+    </>
+  )
+}

--- a/src/frontend/src/features/chat/components/ChatProvider.tsx
+++ b/src/frontend/src/features/chat/components/ChatProvider.tsx
@@ -1,10 +1,14 @@
 // features/rooms/chat/ChatProvider.tsx — renders no DOM, mounted once at room level
 import { ref } from 'valtio'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import { useChat, useRoomContext } from '@livekit/components-react'
-import { appendRow, chatStore, resetChatStore } from '@/stores/chat'
-import type { ChatMessage } from '@livekit/components-core'
+import {
+  appendRow,
+  chatStore,
+  resetChatStore,
+  setChatVisibility,
+} from '@/stores/chat'
 import {
   LocalParticipant,
   Participant,
@@ -13,7 +17,6 @@ import {
 } from 'livekit-client'
 
 export const ChatProvider = () => {
-  const lastReadMsgAt = React.useRef<ChatMessage['timestamp']>(0)
   const { send, chatMessages, isSending } = useChat()
   const { isChatOpen } = useSidePanel()
 
@@ -53,19 +56,11 @@ export const ChatProvider = () => {
     chatStore.isSending = isSending
   }, [isSending])
 
-  // Set the unread messages count
+  // Unread is counted over chat rows, which see both text messages and the
+  // images arriving on byte streams. `chatMessages` only ever holds the former.
   useEffect(() => {
-    if (chatMessages.length === 0) return
-    const last = chatMessages[chatMessages.length - 1]
-    if (isChatOpen) {
-      lastReadMsgAt.current = last.timestamp
-      chatStore.unreadMessages = 0
-      return
-    }
-    chatStore.unreadMessages = chatMessages.filter(
-      (m) => !lastReadMsgAt.current || m.timestamp > lastReadMsgAt.current
-    ).length
-  }, [chatMessages, isChatOpen])
+    setChatVisibility(isChatOpen)
+  }, [isChatOpen])
 
   // Listen to participant name changes
   useEffect(() => {

--- a/src/frontend/src/features/chat/components/ChatProvider.tsx
+++ b/src/frontend/src/features/chat/components/ChatProvider.tsx
@@ -9,6 +9,7 @@ import {
   resetChatStore,
   setChatVisibility,
 } from '@/stores/chat'
+import { useReceiveChatMedia } from '../media/useReceiveChatMedia'
 import {
   LocalParticipant,
   Participant,
@@ -21,6 +22,8 @@ export const ChatProvider = () => {
   const { isChatOpen } = useSidePanel()
 
   const room = useRoomContext()
+
+  useReceiveChatMedia()
 
   useEffect(() => {
     resetChatStore()

--- a/src/frontend/src/features/chat/components/ChatTextArea.tsx
+++ b/src/frontend/src/features/chat/components/ChatTextArea.tsx
@@ -9,10 +9,12 @@ import {
   persistTextAreaValue,
 } from '@/stores/chat'
 import { ChatSubmitButton } from './ChatSubmitButton'
+import { ChatAttachButton } from './ChatAttachButton'
 
 const StyledContainer = styled('div', {
   base: {
     display: 'flex',
+    alignItems: 'flex-end',
     margin: '0.75rem 0 1.5rem',
     padding: '0.5rem',
     backgroundColor: 'gray.100',
@@ -20,8 +22,21 @@ const StyledContainer = styled('div', {
   },
 })
 
-export const ChatTextArea = () => {
-  const { isSending, send, textAreaValue } = useSnapshot(chatStore)
+type ChatTextAreaProps = {
+  onAttach: (file: File) => void
+  onSendMedia: () => void
+  isMediaEnabled: boolean
+  acceptedMimetypes: string[]
+}
+
+export const ChatTextArea = ({
+  onAttach,
+  onSendMedia,
+  isMediaEnabled,
+  acceptedMimetypes,
+}: ChatTextAreaProps) => {
+  const { isSending, isPreparing, send, textAreaValue, pendingAttachment } =
+    useSnapshot(chatStore)
 
   const { t } = useTranslation('rooms', { keyPrefix: 'controls.chat.input' })
 
@@ -39,14 +54,22 @@ export const ChatTextArea = () => {
   }, [])
 
   const handleSubmit = useCallback(async () => {
+    // A staged image takes precedence: the text box then holds its caption,
+    // and the two go out as one stream rather than as two messages.
+    if (chatStore.pendingAttachment) {
+      await onSendMedia()
+      inputRef?.current?.focus({ preventScroll: true })
+      return
+    }
     const text = chatStore.textAreaValue
     if (!send || !text) return
     await send(text)
     inputRef?.current?.focus({ preventScroll: true })
     clearTextAreaValue()
-  }, [send, inputRef])
+  }, [send, inputRef, onSendMedia])
 
-  const isDisabled = !textAreaValue.trim() || isSending
+  const isDisabled =
+    (!textAreaValue.trim() && !pendingAttachment) || isSending || isPreparing
 
   const onKeyDown = async (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     e.stopPropagation()
@@ -60,13 +83,35 @@ export const ChatTextArea = () => {
     e.stopPropagation()
   }
 
+  /**
+   * Pasting is what a screenshot actually wants: the operating system puts it
+   * on the clipboard, and there is no file on disk to pick or drag.
+   */
+  const onPaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!isMediaEnabled) return
+    const file = Array.from(e.clipboardData.files).find((candidate) =>
+      candidate.type.startsWith('image/')
+    )
+    if (!file) return
+    e.preventDefault()
+    onAttach(file)
+  }
+
   return (
     <StyledContainer>
+      {isMediaEnabled && (
+        <ChatAttachButton
+          onSelect={onAttach}
+          isDisabled={isSending || isPreparing}
+          acceptedMimetypes={acceptedMimetypes}
+        />
+      )}
       <TextArea
         ref={inputRef}
         value={textAreaValue}
         onKeyDown={onKeyDown}
         onKeyUp={onKeyUp}
+        onPaste={onPaste}
         onChange={(e) => {
           persistTextAreaValue(e.target.value)
         }}
@@ -83,7 +128,11 @@ export const ChatTextArea = () => {
         placeholderStyle="strong"
         spellCheck={false}
         maxLength={2000}
-        placeholder={t('textArea.placeholder')}
+        placeholder={t(
+          pendingAttachment
+            ? 'textArea.captionPlaceholder'
+            : 'textArea.placeholder'
+        )}
         aria-label={t('textArea.label')}
       />
       <ChatSubmitButton handleSubmit={handleSubmit} isDisabled={isDisabled} />

--- a/src/frontend/src/features/chat/media/constants.ts
+++ b/src/frontend/src/features/chat/media/constants.ts
@@ -1,0 +1,42 @@
+/**
+ * LiveKit byte stream topic carrying chat images. Distinct from `lk.chat`,
+ * the text stream topic `useChat` drives, so an attachment cannot be forged
+ * by typing a marker into the message box.
+ */
+export const CHAT_MEDIA_TOPIC = 'chat-media'
+
+/**
+ * Used until `/config/` answers, and when it cannot be reached. The backend is
+ * authoritative: these mirror the defaults in `CHAT_MEDIA_*` settings.
+ */
+export const FALLBACK_MAX_SIZE = 5 * 1024 * 1024
+
+export const FALLBACK_ALLOWED_MIMETYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+]
+
+/** Long edge of a downscaled image, in pixels. */
+export const DOWNSCALE_LONG_EDGE = 2048
+
+/** Quality passed to `toBlob` when re-encoding an over-cap image. */
+export const DOWNSCALE_QUALITY = 0.85
+
+/** A caption longer than this is truncated before it is sent or rendered. */
+export const MAX_CAPTION_LENGTH = 2000
+
+/**
+ * Inbound streams read at once from a single participant. Further streams from
+ * that participant are dropped rather than queued, so one sender cannot fill
+ * another participant's memory.
+ */
+export const MAX_CONCURRENT_STREAMS_PER_SENDER = 3
+
+/**
+ * Progress is written to the store in steps of this many percent. A 5 MB image
+ * arrives in roughly 350 chunks, and writing each one would re-render the
+ * virtualized list about 44 times a second.
+ */
+export const PROGRESS_STEP_PERCENT = 5

--- a/src/frontend/src/features/chat/media/constants.ts
+++ b/src/frontend/src/features/chat/media/constants.ts
@@ -24,6 +24,12 @@ export const DOWNSCALE_LONG_EDGE = 2048
 /** Quality passed to `toBlob` when re-encoding an over-cap image. */
 export const DOWNSCALE_QUALITY = 0.85
 
+/**
+ * Bytes written per chunk. LiveKit splits its own writes near this size, so
+ * matching it avoids a second split.
+ */
+export const CHUNK_SIZE = 15_000
+
 /** A caption longer than this is truncated before it is sent or rendered. */
 export const MAX_CAPTION_LENGTH = 2000
 

--- a/src/frontend/src/features/chat/media/downscaleImage.ts
+++ b/src/frontend/src/features/chat/media/downscaleImage.ts
@@ -1,0 +1,43 @@
+import { DOWNSCALE_LONG_EDGE, DOWNSCALE_QUALITY } from './constants'
+
+/**
+ * Reduces an over-cap image by drawing it smaller and re-encoding as WebP.
+ *
+ * Only reached when the image exceeds the size cap. Under it the bytes are sent
+ * untouched, because re-encoding a screenshot that was already lossless costs
+ * exactly the legibility the feature exists for.
+ *
+ * A side effect worth knowing: canvas copies pixels and nothing else, so the
+ * result carries no metadata. That is not this function's job, and stripping
+ * metadata generally is a separate change.
+ */
+export async function downscaleImage(file: File): Promise<Blob> {
+  const bitmap = await createImageBitmap(file)
+  try {
+    const scale = Math.min(
+      1,
+      DOWNSCALE_LONG_EDGE / Math.max(bitmap.width, bitmap.height)
+    )
+    const width = Math.max(1, Math.round(bitmap.width * scale))
+    const height = Math.max(1, Math.round(bitmap.height * scale))
+
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+
+    const context = canvas.getContext('2d')
+    if (!context) throw new Error('2d canvas context unavailable')
+    context.drawImage(bitmap, 0, 0, width, height)
+
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (blob) =>
+          blob ? resolve(blob) : reject(new Error('canvas encoding failed')),
+        'image/webp',
+        DOWNSCALE_QUALITY
+      )
+    })
+  } finally {
+    bitmap.close()
+  }
+}

--- a/src/frontend/src/features/chat/media/probeImage.ts
+++ b/src/frontend/src/features/chat/media/probeImage.ts
@@ -1,0 +1,98 @@
+/**
+ * Identifies an image from its leading bytes rather than from what the sender
+ * says it is. A declared MIME type is attacker-controlled on the receive path
+ * and merely wrong on the send path, since browsers guess it from the file
+ * extension.
+ *
+ * Pure functions over a `Uint8Array`, so a test runner covers them the day this
+ * repository has one.
+ */
+
+const startsWith = (bytes: Uint8Array, signature: number[], offset = 0) =>
+  bytes.length >= offset + signature.length &&
+  signature.every((byte, i) => bytes[offset + i] === byte)
+
+/**
+ * Returns the MIME type the bytes actually are, or null when they are not an
+ * image this application handles. Never returns `image/svg+xml`: SVG is text,
+ * has no magic number, and executes script once rendered.
+ */
+export function sniffImageType(bytes: Uint8Array): string | null {
+  // FF D8 FF, the JPEG start-of-image marker followed by any APP marker.
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) return 'image/jpeg'
+
+  // The 8-byte PNG signature, whose 0x0d0a...0a catches newline mangling.
+  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+    return 'image/png'
+
+  // "GIF87a" or "GIF89a".
+  if (startsWith(bytes, [0x47, 0x49, 0x46, 0x38])) return 'image/gif'
+
+  // "RIFF" .... "WEBP": a container tag and a form type four bytes apart.
+  if (
+    startsWith(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+    startsWith(bytes, [0x57, 0x45, 0x42, 0x50], 8)
+  )
+    return 'image/webp'
+
+  return null
+}
+
+/**
+ * Whether a GIF carries more than one frame.
+ *
+ * Counts Graphic Control Extension blocks, `21 F9`, which precede each rendered
+ * frame. A heuristic rather than a parse: it can misread that byte pair inside
+ * compressed image data. Both failure directions are mild. A false positive
+ * refuses an over-cap GIF that could have been flattened, and a false negative
+ * flattens an animation the sender expected to keep, which only reaches a user
+ * for a GIF above the size cap.
+ */
+export function isAnimatedGif(bytes: Uint8Array): boolean {
+  let seen = 0
+  for (let i = 0; i < bytes.length - 1; i++) {
+    if (bytes[i] === 0x21 && bytes[i + 1] === 0xf9) {
+      seen += 1
+      if (seen > 1) return true
+    }
+  }
+  return false
+}
+
+export type ImageProbe = {
+  mimeType: string
+  isAnimated: boolean
+}
+
+/**
+ * Reads only the head of the blob. `slice` hands back a view without pulling
+ * the whole file into the JavaScript heap, which matters for the animation scan
+ * on a large GIF.
+ */
+export async function probeImage(blob: Blob): Promise<ImageProbe | null> {
+  const head = new Uint8Array(await blob.slice(0, 4096).arrayBuffer())
+  const mimeType = sniffImageType(head)
+  if (!mimeType) return null
+
+  if (mimeType !== 'image/gif') return { mimeType, isAnimated: false }
+
+  const whole = new Uint8Array(await blob.arrayBuffer())
+  return { mimeType, isAnimated: isAnimatedGif(whole) }
+}
+
+/**
+ * Natural dimensions, via the browser's own decoder. Doubles as the check that
+ * the bytes are a renderable image and not merely something wearing an image's
+ * first four bytes.
+ */
+export function measureImage(
+  objectUrl: string
+): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () =>
+      resolve({ width: image.naturalWidth, height: image.naturalHeight })
+    image.onerror = () => reject(new Error('image failed to decode'))
+    image.src = objectUrl
+  })
+}

--- a/src/frontend/src/features/chat/media/useChatMediaLimits.ts
+++ b/src/frontend/src/features/chat/media/useChatMediaLimits.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+import { useConfig } from '@/api/useConfig'
+import { FALLBACK_ALLOWED_MIMETYPES, FALLBACK_MAX_SIZE } from './constants'
+
+export type ChatMediaLimits = {
+  enabled: boolean
+  maxSize: number
+  allowedMimetypes: string[]
+}
+
+/**
+ * The backend is authoritative, so an operator can change the cap or narrow the
+ * allowlist without a rebuild. The fallbacks apply only before `/config/`
+ * answers and when it cannot be reached; they mirror the setting defaults.
+ */
+export const useChatMediaLimits = (): ChatMediaLimits => {
+  const { data: config } = useConfig()
+  return useMemo(
+    () => ({
+      enabled: config?.chat_media?.enabled ?? false,
+      maxSize: config?.chat_media?.max_size ?? FALLBACK_MAX_SIZE,
+      allowedMimetypes:
+        config?.chat_media?.allowed_mimetypes ?? FALLBACK_ALLOWED_MIMETYPES,
+    }),
+    [config]
+  )
+}

--- a/src/frontend/src/features/chat/media/useReceiveChatMedia.ts
+++ b/src/frontend/src/features/chat/media/useReceiveChatMedia.ts
@@ -1,0 +1,142 @@
+import { useEffect } from 'react'
+import { useRoomContext } from '@livekit/components-react'
+import {
+  appendReceivingMediaRow,
+  failMediaRow,
+  resolveMediaRow,
+  updateMediaProgress,
+} from '@/stores/chat'
+import {
+  CHAT_MEDIA_TOPIC,
+  MAX_CAPTION_LENGTH,
+  MAX_CONCURRENT_STREAMS_PER_SENDER,
+  PROGRESS_STEP_PERCENT,
+} from './constants'
+import { sniffImageType } from './probeImage'
+import { useChatMediaLimits } from './useChatMediaLimits'
+
+/**
+ * Control characters would let a sender break the row's layout. Matching them
+ * is the point here, so the rule that normally catches them by accident is
+ * suppressed deliberately.
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/g
+
+const sanitizeCaption = (value: unknown) =>
+  typeof value === 'string'
+    ? value.replace(CONTROL_CHARACTERS, '').slice(0, MAX_CAPTION_LENGTH)
+    : ''
+
+const sanitizeDimension = (value: unknown) => {
+  const parsed = Number.parseInt(String(value ?? ''), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}
+
+const decodes = (objectUrl: string) =>
+  new Promise<boolean>((resolve) => {
+    const image = new Image()
+    image.onload = () => resolve(true)
+    image.onerror = () => resolve(false)
+    image.src = objectUrl
+  })
+
+/**
+ * Receives images sent on the chat media topic.
+ *
+ * Everything the sender declares is treated as hostile, because a room admits
+ * unauthenticated participants: the declared size is checked before the stream
+ * is read and the assembled length again after it, the declared MIME type is
+ * ignored in favour of the payload's own leading bytes, and the result must
+ * decode as an image before it is shown.
+ */
+export const useReceiveChatMedia = () => {
+  const room = useRoomContext()
+  const limits = useChatMediaLimits()
+
+  useEffect(() => {
+    if (!limits.enabled) return
+
+    const inFlight = new Map<string, number>()
+
+    room.registerByteStreamHandler(CHAT_MEDIA_TOPIC, async (reader, from) => {
+      const identity = from?.identity
+      const key = identity ?? 'unknown'
+      const running = inFlight.get(key) ?? 0
+      if (running >= MAX_CONCURRENT_STREAMS_PER_SENDER) return
+      inFlight.set(key, running + 1)
+
+      const { id, size, attributes } = reader.info
+      try {
+        if (typeof size === 'number' && size > limits.maxSize) return
+
+        appendReceivingMediaRow({
+          id,
+          identity,
+          // The handler is only told the identity, so the display name is
+          // looked up on the room.
+          name: identity
+            ? room.getParticipantByIdentity(identity)?.name
+            : undefined,
+          caption: sanitizeCaption(attributes?.caption),
+          mimeType: '',
+          size: size ?? 0,
+          width: sanitizeDimension(attributes?.width),
+          height: sanitizeDimension(attributes?.height),
+        })
+
+        // A 5 MB image arrives in roughly 350 chunks. Writing each one would
+        // re-render the virtualized list about 44 times a second, so the store
+        // only sees a change when the displayed percentage does.
+        let lastShown = -1
+        reader.onProgress = (progress) => {
+          if (progress == null) return updateMediaProgress(id, undefined)
+          const shown =
+            Math.floor((progress * 100) / PROGRESS_STEP_PERCENT) *
+            PROGRESS_STEP_PERCENT
+          if (shown === lastShown) return
+          lastShown = shown
+          updateMediaProgress(id, shown / 100)
+        }
+
+        const chunks = await reader.readAll()
+        const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0)
+        if (total > limits.maxSize) {
+          failMediaRow(id, 'transfer_failed')
+          return
+        }
+
+        const payload = new Uint8Array(total)
+        let offset = 0
+        for (const chunk of chunks) {
+          payload.set(chunk, offset)
+          offset += chunk.byteLength
+        }
+
+        const mimeType = sniffImageType(payload)
+        if (!mimeType || !limits.allowedMimetypes.includes(mimeType)) {
+          failMediaRow(id, 'decode_failed')
+          return
+        }
+
+        const objectUrl = URL.createObjectURL(
+          new Blob([payload as BlobPart], { type: mimeType })
+        )
+        if (!(await decodes(objectUrl))) {
+          URL.revokeObjectURL(objectUrl)
+          failMediaRow(id, 'decode_failed')
+          return
+        }
+
+        resolveMediaRow(id, objectUrl, mimeType)
+      } catch {
+        failMediaRow(id, 'transfer_failed')
+      } finally {
+        inFlight.set(key, (inFlight.get(key) ?? 1) - 1)
+      }
+    })
+
+    // Registering twice on one topic throws, and StrictMode runs this twice.
+    return () => room.unregisterByteStreamHandler(CHAT_MEDIA_TOPIC)
+  }, [room, limits])
+}

--- a/src/frontend/src/features/chat/media/useSendChatMedia.ts
+++ b/src/frontend/src/features/chat/media/useSendChatMedia.ts
@@ -1,0 +1,142 @@
+import { useCallback } from 'react'
+import { ref } from 'valtio'
+import { useRoomContext } from '@livekit/components-react'
+import {
+  appendLocalMediaRow,
+  chatStore,
+  clearPendingAttachment,
+  clearTextAreaValue,
+  stageAttachment,
+} from '@/stores/chat'
+import {
+  CHAT_MEDIA_TOPIC,
+  CHUNK_SIZE,
+  MAX_CAPTION_LENGTH,
+} from './constants'
+import { downscaleImage } from './downscaleImage'
+import { measureImage, probeImage } from './probeImage'
+import { useChatMediaLimits } from './useChatMediaLimits'
+
+/**
+ * An image and its caption are one byte stream. The caption travels in the
+ * stream's attributes rather than as a second chat message, so the two arrive
+ * together, nothing has to pair them afterwards, and an attachment cannot be
+ * forged by typing a marker into the message box.
+ *
+ * Written with `streamBytes` rather than `sendFile`. The convenience wrapper
+ * accepts only a topic, a MIME type and destinations, dropping the three fields
+ * this needs: the attributes carrying the caption, the name that replaces the
+ * real filename, and the total size that lets a receiver show a percentage.
+ */
+export const useSendChatMedia = () => {
+  const room = useRoomContext()
+  const limits = useChatMediaLimits()
+
+  /**
+   * Validates, reduces if needed, and holds the result for the participant to
+   * caption. Nothing is sent until they press send, so a mistaken drop can be
+   * taken back.
+   */
+  const stage = useCallback(
+    async (file: File) => {
+      chatStore.isPreparing = true
+      chatStore.mediaFailure = undefined
+      let previewUrl: string | undefined
+
+      try {
+        const probe = await probeImage(file)
+        if (!probe || !limits.allowedMimetypes.includes(probe.mimeType)) {
+          chatStore.mediaFailure = 'type_not_allowed'
+          return
+        }
+
+        let payload: Blob = file
+        if (file.size > limits.maxSize) {
+          if (probe.isAnimated) {
+            // Flattening an animation to one frame is a silent surprise, and
+            // the browser has no GIF encoder to reduce it with.
+            chatStore.mediaFailure = 'animation_too_large'
+            return
+          }
+          payload = await downscaleImage(file)
+          if (payload.size > limits.maxSize) {
+            chatStore.mediaFailure = 'too_large'
+            return
+          }
+        }
+
+        previewUrl = URL.createObjectURL(payload)
+        const { width, height } = await measureImage(previewUrl)
+
+        stageAttachment({
+          // A Blob keeps its bytes in an internal slot a proxy cannot forward,
+          // so valtio must store it as-is.
+          blob: ref(payload),
+          mimeType: payload.type || probe.mimeType,
+          previewUrl,
+          width,
+          height,
+        })
+        previewUrl = undefined
+      } catch {
+        chatStore.mediaFailure = 'unreadable'
+      } finally {
+        if (previewUrl) URL.revokeObjectURL(previewUrl)
+        chatStore.isPreparing = false
+      }
+    },
+    [limits]
+  )
+
+  const send = useCallback(async () => {
+    const pending = chatStore.pendingAttachment
+    if (!pending || chatStore.isSending) return
+
+    const caption = chatStore.textAreaValue.slice(0, MAX_CAPTION_LENGTH)
+    chatStore.isSending = true
+
+    try {
+      const bytes = new Uint8Array(await pending.blob.arrayBuffer())
+      const writer = await room.localParticipant.streamBytes({
+        topic: CHAT_MEDIA_TOPIC,
+        mimeType: pending.mimeType,
+        totalSize: bytes.byteLength,
+        // The real filename never leaves the sender.
+        // `IMG_20260115_client-negotiation.jpg` says plenty on its own.
+        name: `image.${pending.mimeType.split('/')[1] || 'bin'}`,
+        attributes: {
+          caption,
+          width: String(pending.width),
+          height: String(pending.height),
+        },
+      })
+
+      for (let offset = 0; offset < bytes.length; offset += CHUNK_SIZE) {
+        await writer.write(bytes.subarray(offset, offset + CHUNK_SIZE))
+      }
+      await writer.close()
+
+      appendLocalMediaRow({
+        id: writer.info.id,
+        identity: room.localParticipant.identity,
+        name: room.localParticipant.name,
+        caption,
+        mimeType: pending.mimeType,
+        size: bytes.byteLength,
+        width: pending.width,
+        height: pending.height,
+        // The row adopts the preview rather than decoding the image again.
+        // Byte streams do not echo to their sender, so without this the sender
+        // alone would not see what they just sent.
+        objectUrl: pending.previewUrl,
+      })
+      clearTextAreaValue()
+    } catch {
+      chatStore.mediaFailure = 'send_failed'
+    } finally {
+      chatStore.isSending = false
+    }
+  }, [room])
+
+  return { stage, send, clear: clearPendingAttachment, limits }
+}

--- a/src/frontend/src/features/chat/media/useSendChatMedia.ts
+++ b/src/frontend/src/features/chat/media/useSendChatMedia.ts
@@ -8,11 +8,7 @@ import {
   clearTextAreaValue,
   stageAttachment,
 } from '@/stores/chat'
-import {
-  CHAT_MEDIA_TOPIC,
-  CHUNK_SIZE,
-  MAX_CAPTION_LENGTH,
-} from './constants'
+import { CHAT_MEDIA_TOPIC, CHUNK_SIZE, MAX_CAPTION_LENGTH } from './constants'
 import { downscaleImage } from './downscaleImage'
 import { measureImage, probeImage } from './probeImage'
 import { useChatMediaLimits } from './useChatMediaLimits'

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -365,6 +365,15 @@
   },
   "chat": {
     "disclaimer": "The messages are visible to participants only at the time they are sent. All messages are deleted at the end of the call.",
+    "media": {
+      "receiving": "Receiving an image",
+      "alt": "Shared image",
+      "error": {
+        "transfer_failed": "This image could not be received.",
+        "decode_failed": "This image could not be displayed.",
+        "expired": "This image is no longer available."
+      }
+    },
     "messagesLog": "Chat messages"
   },
   "moreTools": {

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -176,7 +176,8 @@
       "input": {
         "textArea": {
           "label": "Enter a message",
-          "placeholder": "Enter a message"
+          "placeholder": "Enter a message",
+          "captionPlaceholder": "Add a caption"
         },
         "button": {
           "label": "Send message"
@@ -366,13 +367,25 @@
   "chat": {
     "disclaimer": "The messages are visible to participants only at the time they are sent. All messages are deleted at the end of the call.",
     "media": {
-      "receiving": "Receiving an image",
       "alt": "Shared image",
+      "attach": "Add an image",
+      "dropHint": "Drop the image to add it",
+      "dropZone": "Drop an image into the chat",
       "error": {
-        "transfer_failed": "This image could not be received.",
+        "animation_too_large": "This animation is too large to send, and reducing it would drop its frames.",
         "decode_failed": "This image could not be displayed.",
-        "expired": "This image is no longer available."
-      }
+        "expired": "This image is no longer available.",
+        "send_failed": "This image could not be sent.",
+        "too_large": "This image is too large to send.",
+        "transfer_failed": "This image could not be received.",
+        "type_not_allowed": "Only JPEG, PNG, WebP and GIF images can be sent.",
+        "unreadable": "This file could not be read as an image."
+      },
+      "preparing": "Preparing the image…",
+      "receiving": "Receiving an image",
+      "remove": "Remove the image",
+      "staged": "Image ready to send",
+      "stagedAlt": "Image about to be sent"
     },
     "messagesLog": "Chat messages"
   },

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -369,8 +369,10 @@
     "media": {
       "alt": "Shared image",
       "attach": "Add an image",
+      "download": "Download",
       "dropHint": "Drop the image to add it",
       "dropZone": "Drop an image into the chat",
+      "enlarge": "Open the image",
       "error": {
         "animation_too_large": "This animation is too large to send, and reducing it would drop its frames.",
         "decode_failed": "This image could not be displayed.",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -176,7 +176,8 @@
       "input": {
         "textArea": {
           "label": "Ecrire un message",
-          "placeholder": "Ecrire un message"
+          "placeholder": "Ecrire un message",
+          "captionPlaceholder": "Ajouter une légende"
         },
         "button": {
           "label": "Envoyer un message"
@@ -366,13 +367,25 @@
   "chat": {
     "disclaimer": "Les messages sont visibles par les participants uniquement au moment de\nleur envoi. Tous les messages sont supprimés à la fin de l'appel.",
     "media": {
-      "receiving": "Réception d’une image",
       "alt": "Image partagée",
+      "attach": "Ajouter une image",
+      "dropHint": "Déposez l’image pour l’ajouter",
+      "dropZone": "Déposer une image dans la conversation",
       "error": {
-        "transfer_failed": "Cette image n’a pas pu être reçue.",
+        "animation_too_large": "Cette animation est trop volumineuse, et la réduire supprimerait ses images.",
         "decode_failed": "Cette image n’a pas pu être affichée.",
-        "expired": "Cette image n’est plus disponible."
-      }
+        "expired": "Cette image n’est plus disponible.",
+        "send_failed": "Cette image n’a pas pu être envoyée.",
+        "too_large": "Cette image est trop volumineuse pour être envoyée.",
+        "transfer_failed": "Cette image n’a pas pu être reçue.",
+        "type_not_allowed": "Seules les images JPEG, PNG, WebP et GIF peuvent être envoyées.",
+        "unreadable": "Ce fichier n’a pas pu être lu comme une image."
+      },
+      "preparing": "Préparation de l’image…",
+      "receiving": "Réception d’une image",
+      "remove": "Retirer l’image",
+      "staged": "Image prête à envoyer",
+      "stagedAlt": "Image sur le point d’être envoyée"
     },
     "messagesLog": "Messages du chat"
   },

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -365,6 +365,15 @@
   },
   "chat": {
     "disclaimer": "Les messages sont visibles par les participants uniquement au moment de\nleur envoi. Tous les messages sont supprimés à la fin de l'appel.",
+    "media": {
+      "receiving": "Réception d’une image",
+      "alt": "Image partagée",
+      "error": {
+        "transfer_failed": "Cette image n’a pas pu être reçue.",
+        "decode_failed": "Cette image n’a pas pu être affichée.",
+        "expired": "Cette image n’est plus disponible."
+      }
+    },
     "messagesLog": "Messages du chat"
   },
   "moreTools": {

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -369,8 +369,10 @@
     "media": {
       "alt": "Image partagée",
       "attach": "Ajouter une image",
+      "download": "Télécharger",
       "dropHint": "Déposez l’image pour l’ajouter",
       "dropZone": "Déposer une image dans la conversation",
+      "enlarge": "Ouvrir l’image",
       "error": {
         "animation_too_large": "Cette animation est trop volumineuse, et la réduire supprimerait ses images.",
         "decode_failed": "Cette image n’a pas pu être affichée.",

--- a/src/frontend/src/stores/chat.ts
+++ b/src/frontend/src/stores/chat.ts
@@ -269,12 +269,18 @@ export function updateMediaProgress(id: string, progress: number | undefined) {
   if (row) row.progress = progress
 }
 
-export function resolveMediaRow(id: string, objectUrl: string) {
+export function resolveMediaRow(
+  id: string,
+  objectUrl: string,
+  mimeType: string
+) {
   const row = findMediaRow(id)
   if (!row) {
     URL.revokeObjectURL(objectUrl)
     return
   }
+  // Written from the sniffed bytes, not from what the sender declared.
+  row.mimeType = mimeType
   row.objectUrl = objectUrl
   row.status = 'ready'
   row.progress = 1

--- a/src/frontend/src/stores/chat.ts
+++ b/src/frontend/src/stores/chat.ts
@@ -4,55 +4,160 @@ import type { ReceivedChatMessage } from '@livekit/components-core'
 
 type ChatApi = ReturnType<typeof useChat>
 
-export type ChatRow = {
+/**
+ * Blobs held by the browser through `URL.createObjectURL` are unreachable by
+ * the garbage collector, so the number retained is capped explicitly.
+ */
+export const MAX_RETAINED_MEDIA = 50
+
+type ChatRowBase = {
   id: string
   identity?: string
-  message: string
   timestamp: number
   hideMetadata: boolean
   isLocal: boolean
 }
 
+export type ChatTextRow = ChatRowBase & {
+  kind: 'text'
+  message: string
+}
+
+export type ChatMediaStatus = 'receiving' | 'ready' | 'failed'
+
+export type ChatMediaError = 'transfer_failed' | 'decode_failed' | 'expired'
+
+export type ChatMediaRow = ChatRowBase & {
+  kind: 'media'
+  caption: string
+  mimeType: string
+  size: number
+  width?: number
+  height?: number
+  status: ChatMediaStatus
+  /** Between 0 and 1, or undefined while the total size is unknown. */
+  progress?: number
+  objectUrl?: string
+  error?: ChatMediaError
+}
+
+export type ChatRow = ChatTextRow | ChatMediaRow
+
+export type PendingAttachment = {
+  /**
+   * Wrapped in valtio's `ref`. A File keeps its bytes in an internal slot that
+   * a proxy cannot forward, so proxying one breaks its methods.
+   */
+  file: File
+  previewUrl: string
+  width: number
+  height: number
+}
+
 type State = {
   unreadMessages: number
   isSending: boolean
+  isPreparing: boolean
   rows: ChatRow[]
   names: Record<string, string>
   send?: ChatApi['send']
   textAreaValue: string
+  pendingAttachment?: PendingAttachment
 }
 
 const initialState: State = {
   unreadMessages: 0,
   isSending: false,
+  isPreparing: false,
   rows: [],
   names: {},
   send: undefined,
   textAreaValue: '',
+  pendingAttachment: undefined,
 }
 
 export const chatStore = proxy<State>({ ...initialState })
 
 const GROUPING_WINDOW_MS = 60_000
 
+/**
+ * Consecutive rows from the same participant within the grouping window repeat
+ * no name header. Shared by every row kind so an image sent right after a
+ * message groups with it.
+ */
+function shouldHideMetadata(identity: string | undefined, timestamp: number) {
+  const prev = chatStore.rows[chatStore.rows.length - 1]
+  return (
+    !!prev &&
+    prev.identity === identity &&
+    timestamp - prev.timestamp < GROUPING_WINDOW_MS
+  )
+}
+
+let lastReadTimestamp = 0
+let isChatVisible = false
+
+function countAsUnread(row: ChatRow) {
+  if (isChatVisible) {
+    lastReadTimestamp = row.timestamp
+    return
+  }
+  if (row.timestamp > lastReadTimestamp) chatStore.unreadMessages += 1
+}
+
+/**
+ * Unread is counted over rows rather than over LiveKit's `chatMessages`: byte
+ * streams never appear in `chatMessages`, and rows are the only place that sees
+ * both kinds.
+ */
+export function setChatVisibility(visible: boolean) {
+  isChatVisible = visible
+  if (!visible) return
+  const last = chatStore.rows[chatStore.rows.length - 1]
+  if (last) lastReadTimestamp = last.timestamp
+  chatStore.unreadMessages = 0
+}
+
 export function appendRow(msg: ReceivedChatMessage) {
   const p = msg.from
   if (p) chatStore.names[p.identity] = p.name || p.identity
 
   const identity = p?.identity
-  const prev = chatStore.rows[chatStore.rows.length - 1]
+  const timestamp = msg.timestamp
 
-  chatStore.rows.push({
-    id: msg.id ?? `${msg.timestamp}`,
+  const row: ChatTextRow = {
+    kind: 'text',
+    id: msg.id ?? `${timestamp}`,
     identity,
     isLocal: p?.isLocal ?? false,
     message: msg.message,
-    timestamp: msg.timestamp,
-    hideMetadata:
-      !!prev &&
-      prev.identity === identity &&
-      msg.timestamp - prev.timestamp < GROUPING_WINDOW_MS,
-  })
+    timestamp,
+    hideMetadata: shouldHideMetadata(identity, timestamp),
+  }
+
+  chatStore.rows.push(row)
+  countAsUnread(row)
+}
+
+function revokeMediaRow(row: ChatMediaRow) {
+  if (!row.objectUrl) return
+  URL.revokeObjectURL(row.objectUrl)
+  row.objectUrl = undefined
+  row.status = 'failed'
+  row.error = 'expired'
+}
+
+/**
+ * Drops the oldest blobs once more than `MAX_RETAINED_MEDIA` are held, marking
+ * their rows expired rather than leaving a broken image behind.
+ */
+export function enforceMediaRetention() {
+  const retained = chatStore.rows.filter(
+    (row): row is ChatMediaRow => row.kind === 'media' && !!row.objectUrl
+  )
+  for (let i = 0; i < retained.length - MAX_RETAINED_MEDIA; i++) {
+    revokeMediaRow(retained[i])
+  }
 }
 
 export const persistTextAreaValue = (value: string) => {
@@ -64,6 +169,15 @@ export const clearTextAreaValue = () => {
 }
 
 export function resetChatStore() {
+  for (const row of chatStore.rows) {
+    if (row.kind === 'media' && row.objectUrl)
+      URL.revokeObjectURL(row.objectUrl)
+  }
+  if (chatStore.pendingAttachment) {
+    URL.revokeObjectURL(chatStore.pendingAttachment.previewUrl)
+  }
+  lastReadTimestamp = 0
+  isChatVisible = false
   Object.assign(chatStore, {
     ...initialState,
     rows: [],

--- a/src/frontend/src/stores/chat.ts
+++ b/src/frontend/src/stores/chat.ts
@@ -45,14 +45,23 @@ export type ChatRow = ChatTextRow | ChatMediaRow
 
 export type PendingAttachment = {
   /**
-   * Wrapped in valtio's `ref`. A File keeps its bytes in an internal slot that
+   * Wrapped in valtio's `ref`. A Blob keeps its bytes in an internal slot that
    * a proxy cannot forward, so proxying one breaks its methods.
    */
-  file: File
+  blob: Blob
+  /** Sniffed from the bytes, never taken from the file extension. */
+  mimeType: string
   previewUrl: string
   width: number
   height: number
 }
+
+export type ChatMediaFailure =
+  | 'type_not_allowed'
+  | 'too_large'
+  | 'animation_too_large'
+  | 'unreadable'
+  | 'send_failed'
 
 type State = {
   unreadMessages: number
@@ -63,6 +72,7 @@ type State = {
   send?: ChatApi['send']
   textAreaValue: string
   pendingAttachment?: PendingAttachment
+  mediaFailure?: ChatMediaFailure
 }
 
 const initialState: State = {
@@ -74,6 +84,7 @@ const initialState: State = {
   send: undefined,
   textAreaValue: '',
   pendingAttachment: undefined,
+  mediaFailure: undefined,
 }
 
 export const chatStore = proxy<State>({ ...initialState })
@@ -118,9 +129,19 @@ export function setChatVisibility(visible: boolean) {
   chatStore.unreadMessages = 0
 }
 
+/**
+ * Rows carry an identity; the header shows a display name. Every path that
+ * appends a row has to register the name, because a participant whose first
+ * act is sending an image would otherwise be labelled with their raw identity
+ * until they also sent text.
+ */
+function rememberName(identity?: string, name?: string) {
+  if (identity) chatStore.names[identity] = name || identity
+}
+
 export function appendRow(msg: ReceivedChatMessage) {
   const p = msg.from
-  if (p) chatStore.names[p.identity] = p.name || p.identity
+  if (p) rememberName(p.identity, p.name)
 
   const identity = p?.identity
   const timestamp = msg.timestamp
@@ -160,6 +181,114 @@ export function enforceMediaRetention() {
   }
 }
 
+export function stageAttachment(attachment: PendingAttachment) {
+  clearPendingAttachment()
+  chatStore.pendingAttachment = attachment
+  chatStore.mediaFailure = undefined
+}
+
+export function clearPendingAttachment() {
+  const pending = chatStore.pendingAttachment
+  if (pending) URL.revokeObjectURL(pending.previewUrl)
+  chatStore.pendingAttachment = undefined
+}
+
+/**
+ * Hands the staged preview URL to the row rather than revoking it, so the
+ * sender's own copy renders from bytes already in memory. Byte streams do not
+ * echo to their sender, so without this the sender alone would not see it.
+ */
+export function appendLocalMediaRow({
+  name,
+  ...row
+}: {
+  id: string
+  identity?: string
+  name?: string
+  caption: string
+  mimeType: string
+  size: number
+  width?: number
+  height?: number
+  objectUrl: string
+}) {
+  const timestamp = Date.now()
+  rememberName(row.identity, name)
+  chatStore.rows.push({
+    kind: 'media',
+    isLocal: true,
+    status: 'ready',
+    timestamp,
+    hideMetadata: shouldHideMetadata(row.identity, timestamp),
+    ...row,
+  })
+  chatStore.pendingAttachment = undefined
+  enforceMediaRetention()
+}
+
+/**
+ * Inserted when the stream opens, before any bytes arrive, so a participant
+ * sees an image being sent rather than a silence.
+ */
+export function appendReceivingMediaRow({
+  name,
+  ...row
+}: {
+  id: string
+  identity?: string
+  name?: string
+  caption: string
+  mimeType: string
+  size: number
+  width?: number
+  height?: number
+}) {
+  const timestamp = Date.now()
+  rememberName(row.identity, name)
+  chatStore.rows.push({
+    kind: 'media',
+    isLocal: false,
+    status: 'receiving',
+    progress: 0,
+    timestamp,
+    hideMetadata: shouldHideMetadata(row.identity, timestamp),
+    ...row,
+  })
+  const inserted = chatStore.rows[chatStore.rows.length - 1]
+  countAsUnread(inserted)
+}
+
+function findMediaRow(id: string) {
+  return chatStore.rows.find(
+    (row): row is ChatMediaRow => row.kind === 'media' && row.id === id
+  )
+}
+
+export function updateMediaProgress(id: string, progress: number | undefined) {
+  const row = findMediaRow(id)
+  if (row) row.progress = progress
+}
+
+export function resolveMediaRow(id: string, objectUrl: string) {
+  const row = findMediaRow(id)
+  if (!row) {
+    URL.revokeObjectURL(objectUrl)
+    return
+  }
+  row.objectUrl = objectUrl
+  row.status = 'ready'
+  row.progress = 1
+  enforceMediaRetention()
+}
+
+export function failMediaRow(id: string, error: ChatMediaError) {
+  const row = findMediaRow(id)
+  if (!row) return
+  row.status = 'failed'
+  row.error = error
+  row.progress = undefined
+}
+
 export const persistTextAreaValue = (value: string) => {
   chatStore.textAreaValue = value
 }
@@ -176,6 +305,7 @@ export function resetChatStore() {
   if (chatStore.pendingAttachment) {
     URL.revokeObjectURL(chatStore.pendingAttachment.previewUrl)
   }
+
   lastReadTimestamp = 0
   isChatVisible = false
   Object.assign(chatStore, {


### PR DESCRIPTION

Participants can drop a screenshot into the chat instead of leaving the call to send it. [#948](https://github.com/suitenumerique/meet/issues/948) asked for this in February, and [#1547](https://github.com/suitenumerique/meet/issues/1547) splits the image half out of it. This is its first task. Six of the calls sit in a [decision record](https://claude.ai/code/artifact/334a19c4-468b-42c8-868f-c9c4ebb33a13) with the settled ones, each showing what it rejected.

Images move as [LiveKit byte streams](https://docs.livekit.io/transport/data/byte-streams/) on a `chat-media` topic and never reach object storage, following your note on [#965](https://github.com/suitenumerique/meet/pull/965). Nothing is provisioned, nothing is retained, nothing is purged, and an image is gone when the meeting ends.

Written with `streamBytes` rather than `sendFile`. The convenience wrapper accepts only a topic, a MIME type and destinations, and this needs three fields it drops. The caption rides in the stream's attributes, so an image and its text are one stream rather than two messages to reconcile, and an attachment cannot be forged by typing a marker into the message box, which is how #965's were. The name is `image.png`, never the sender's. The total size is what lets a receiver show a percentage instead of an indeterminate bar.

```
sender                                    receiver
  sniff type from the bytes                 handler fires as the stream opens
  downscale if over 5 MB                    row appears, empty, with progress
  streamBytes(topic, name,      ──────▶     re-check length once assembled
    mimeType, totalSize,                    sniff type again, ignore the claim
    attributes: {caption, w, h})            decode, then render
  write 15 kB chunks, close                 ▲
  insert own row locally                    └── one stream is one chat row
```

The receiver trusts nothing the sender declares, because a room admits unauthenticated participants. The declared size is checked before the stream is read and the assembled length again after it, the declared MIME type is ignored in favour of the payload's own leading bytes, and the result must decode as an image before it is shown. `image/svg+xml` is absent from the allowlist because SVG executes script, and a blob URL is only ever an `img` source or an anchor's download target, never navigated, since `blob:` is same-origin.

An image over 5 MB is reduced rather than refused. An animation over 5 MB is refused instead: the browser has no GIF encoder, and flattening it to a single frame is a silent surprise.

Metadata is deliberately not stripped, which is the second task on #1547. Doing it in a browser means either re-encoding every image, which ruins the lossless screenshots this feature exists for, or hand-writing a parser for each format, and neither belongs in the change that introduces the feature. Only the filename is withheld, which needs no code to withhold. Late joiners see no images, exactly as they see no earlier messages.

One thing rides along, because the feature does not work without it: the unread count moves from LiveKit's `chatMessages` to the row list. Byte streams never appear in `chatMessages`, and rows are the only place that sees both kinds.

## Visual evidence

Left is the sender, right the receiver, in one room. A screenshot dragged in and captioned, a photo through the picker, the receiver enlarging one, and a 6.8 MB PNG reduced on the way out.

<img width="1280" height="860" alt="receiver" src="https://github.com/user-attachments/assets/04ef39f4-bffc-43df-b28c-a74fbfb589c3" />

<img width="1280" height="860" alt="animation-refused" src="https://github.com/user-attachments/assets/5f1fa203-e51e-4096-9f4b-bbb315a32cbb" />

[chat-image-sharing.webm](https://github.com/user-attachments/assets/a0ecc9eb-ca20-4d12-92d3-c95b0ef7eb48)


## Verification

Every commit typechecks alone. CI builds only the tip of the branch, and this repository rebase-merges, so a commit that breaks in the middle would reach `main` with nothing to catch it.

The frontend has no test runner, so the rest was run by hand: two participants driven through a real meeting against a local stack, 34 checks, no console errors on either side. Drag and drop, the file picker and paste each stage an image. The caption travels with it and becomes the alt text. A PNG arrives byte-identical rather than re-encoded, an animated GIF arrives still animated rather than flattened, and a 6.8 MB PNG arrives at 1.71 MB. An 8.5 MB animation is refused with the message that explains why. SVG and text files do not even highlight the drop target. The lightbox opens, downloads under the sniffed extension and closes on Escape. A late joiner sees nothing earlier, and a sender vanishing mid-transfer leaves no row spinning.

---

Assisted by AI. The design calls are mine.



