### PR TITLE
🐛(frontend) add trailing slash on the fetch-room URL

### DIFF
--- a/src/frontend/src/features/rooms/api/fetchRoom.ts
+++ b/src/frontend/src/features/rooms/api/fetchRoom.ts
@@ -10,5 +10,5 @@ export const fetchRoom = ({
 }) => {
   const query = username ? `?username=${encodeURIComponent(username)}` : ''
 
-  return fetchApi<ApiRoom>(`/rooms/${roomId}${query}`)
+  return fetchApi<ApiRoom>(`/rooms/${roomId}/${query}`)
 }


### PR DESCRIPTION
The fetch-room URL was missing its trailing slash, which caused the backend to issue a 301 redirect. Query parameters were being dropped in the process, leading to incorrect requests.

Append the trailing slash so the request hits the correct endpoint directly, without going through a redirect.
