### PR TITLE
✨(backend) number a display name already taken in the room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(backend) number a display name already taken in the room
+
 ## [1.25.2] - 2026-08-06
 
 ### Fixed

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -197,13 +197,24 @@ class RoomSerializer(serializers.ModelSerializer):
         if should_access_room:
             room_id = f"{instance.id!s}"
             username = request.query_params.get("username", None)
-            output["livekit"] = utils.generate_livekit_config(
-                room_id=room_id,
-                user=request.user,
-                username=username,
-                configuration=output["configuration"],
-                role=role,
-            )
+
+            if self.context.get("joining"):
+                output["livekit"] = utils.generate_join_config(
+                    room_id=room_id,
+                    user=request.user,
+                    username=username,
+                    configuration=output["configuration"],
+                    role=role,
+                    participant_id=self.context.get("participant_id"),
+                )
+            else:
+                output["livekit"] = utils.generate_livekit_config(
+                    room_id=room_id,
+                    user=request.user,
+                    display_name=utils.resolve_display_name(request.user, username),
+                    configuration=output["configuration"],
+                    role=role,
+                )
         else:
             del output["pin_code"]
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -270,7 +270,13 @@ class RoomViewSet(
         """
         Allow unregistered rooms when activated.
         For unregistered rooms we only return a null id and the livekit room and token.
+
+        An anonymous participant leaves with the identifier their token was
+        minted under, so reloading the page comes back as the same participant
+        rather than as a second one holding a taken name.
         """
+        participant_id = LobbyService().get_or_create_participant_id(request)
+
         try:
             instance = self.get_object()
         except Http404:
@@ -283,18 +289,31 @@ class RoomViewSet(
                 "slug": slug,
                 "is_administrable": False,
                 "access_level": RoomAccessLevel.PUBLIC,
-                "livekit": {
-                    "url": settings.LIVEKIT_CONFIGURATION["url"],
-                    "room": slug,
-                    "token": utils.generate_token(
-                        room=slug, user=request.user, username=username
-                    ),
-                },
+                "livekit": utils.generate_join_config(
+                    room_id=slug,
+                    user=request.user,
+                    username=username,
+                    participant_id=participant_id,
+                ),
             }
         else:
-            data = self.get_serializer(instance).data
+            # Fetching one room is the only response whose token can meet a
+            # name already in the room: a room being created cannot hold
+            # anyone yet, and listing or updating rooms must not pay a LiveKit
+            # round trip each to number a name nobody is joining under.
+            data = self.get_serializer(
+                instance,
+                context={
+                    **self.get_serializer_context(),
+                    "joining": True,
+                    "participant_id": participant_id,
+                },
+            ).data
 
-        return drf_response.Response(data)
+        response = drf_response.Response(data)
+        LobbyService.prepare_response(response, participant_id)
+
+        return response
 
     def list(self, request, *args, **kwargs):
         """Limit listed rooms to the ones related to the authenticated user."""
@@ -952,7 +971,7 @@ class RoomViewSet(
         identity = request.auth.identity
 
         try:
-            ParticipantsManagement().update(
+            name = ParticipantsManagement().update(
                 room_name=str(room.pk),
                 identity=identity,
                 name=serializer.validated_data["name"],
@@ -969,7 +988,7 @@ class RoomViewSet(
             )
 
         return drf_response.Response(
-            {"status": "success"},
+            {"status": "success", "name": name},
             status=drf_status.HTTP_200_OK,
         )
 
@@ -1629,7 +1648,9 @@ class DiagnosticsViewSet(viewsets.ViewSet):
                     "token": generate_token(
                         room=room,
                         user=request.user,
-                        username="Connection Test",
+                        display_name=utils.resolve_display_name(
+                            request.user, "Connection Test"
+                        ),
                         ttl=timedelta(seconds=expires_in),
                     ),
                     "expires_in": expires_in,

--- a/src/backend/core/services/lobby.py
+++ b/src/backend/core/services/lobby.py
@@ -87,7 +87,7 @@ class LobbyService:
         return f"{settings.LOBBY_KEY_PREFIX}_{room_id!s}_{participant_id}"
 
     @staticmethod
-    def _get_or_create_participant_id(request) -> str:
+    def get_or_create_participant_id(request) -> str:
         """Extract unique participant identifier from the request."""
         return request.COOKIES.get(settings.LOBBY_COOKIE_NAME, str(uuid.uuid4()))
 
@@ -149,7 +149,7 @@ class LobbyService:
         5. If denied, do nothing.
         """
 
-        participant_id = self._get_or_create_participant_id(request)
+        participant_id = self.get_or_create_participant_id(request)
         participant = self._get_participant(room.id, participant_id)
 
         room_id = str(room.id)
@@ -166,7 +166,7 @@ class LobbyService:
             else:
                 participant.status = LobbyParticipantStatus.ACCEPTED
 
-            livekit_config = utils.generate_livekit_config(
+            livekit_config = utils.generate_join_config(
                 room_id=room_id,
                 user=request.user,
                 username=username,
@@ -187,7 +187,7 @@ class LobbyService:
 
         elif participant.status == LobbyParticipantStatus.ACCEPTED:
             # wrongly named, contains access token to join a room
-            livekit_config = utils.generate_livekit_config(
+            livekit_config = utils.generate_join_config(
                 room_id=room_id,
                 user=request.user,
                 username=username,

--- a/src/backend/core/services/participants_management.py
+++ b/src/backend/core/services/participants_management.py
@@ -111,8 +111,7 @@ class ParticipantsManagement:
         finally:
             await lkapi.aclose()
 
-    @async_to_sync
-    async def update(  # noqa: PLR0917
+    def update(  # noqa: PLR0917
         self,
         room_name: str,
         identity: str,
@@ -120,36 +119,53 @@ class ParticipantsManagement:
         attributes: Optional[Dict] = None,
         permission: Optional[Dict] = None,
         name: Optional[str] = None,
-    ):
-        """Update participant properties such as metadata, attributes, permissions, or name."""
+    ) -> Optional[str]:
+        """Update participant properties such as metadata, attributes, permissions, or name.
+
+        A name already held by someone else in the room is numbered first, so
+        renaming cannot recreate the collision joining is protected against.
+        Returns the name the participant now carries, which is not always the
+        one asked for.
+        """
+
+        if name:
+            name = utils.unique_display_name_in_room(room_name, identity, name)
+
+        self._send(
+            UpdateParticipantRequest(
+                room=room_name,
+                identity=identity,
+                metadata=json.dumps(metadata),
+                permission=permission,
+                attributes=attributes,
+                name=name,
+            )
+        )
+
+        return name
+
+    @async_to_sync
+    async def _send(self, request: UpdateParticipantRequest):
+        """Send a participant update to LiveKit."""
 
         lkapi = utils.create_livekit_client()
 
         try:
-            await lkapi.room.update_participant(
-                UpdateParticipantRequest(
-                    room=room_name,
-                    identity=identity,
-                    metadata=json.dumps(metadata),
-                    permission=permission,
-                    attributes=attributes,
-                    name=name,
-                )
-            )
+            await lkapi.room.update_participant(request)
 
         except TwirpError as e:
             if e.code == "not_found":
                 logger.warning(
                     "Participant %s not found in room %s, skipping update",
-                    identity,
-                    room_name,
+                    request.identity,
+                    request.room,
                 )
                 raise ParticipantNotFoundException("Participant does not exist") from e
 
             logger.exception(
                 "Unexpected error updating participant %s for room %s",
-                identity,
-                room_name,
+                request.identity,
+                request.room,
             )
             raise ParticipantsManagementException("Could not update participant") from e
 

--- a/src/backend/core/tests/conftest.py
+++ b/src/backend/core/tests/conftest.py
@@ -14,3 +14,14 @@ def mock_user_get_teams():
     """Mock for the "get_teams" method on the User model."""
     with mock.patch("core.models.User.get_teams") as mock_get_teams:
         yield mock_get_teams
+
+
+@pytest.fixture(autouse=True)
+def mock_list_participant_names():
+    """Answer "who is in this room" without reaching LiveKit.
+
+    Every path that mints a join token reads the room's roster, so without this
+    each test would open a session to the LiveKit URL and wait for it to fail.
+    """
+    with mock.patch("core.utils.list_participant_names", return_value={}) as mocked:
+        yield mocked

--- a/src/backend/core/tests/rooms/test_api_rooms_list.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_list.py
@@ -62,6 +62,22 @@ def test_api_rooms_list_authenticated():
     assert expected_ids == results_id
 
 
+def test_api_rooms_list_reads_no_livekit_roster(mock_list_participant_names):
+    """Listing rooms costs no LiveKit call: nobody is joining from this page."""
+    user = UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    RoomFactory(access_level=RoomAccessLevel.RESTRICTED, users=[user])
+    RoomFactory(access_level=RoomAccessLevel.RESTRICTED, users=[user])
+
+    response = client.get("/api/v1.0/rooms/")
+
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 2
+    mock_list_participant_names.assert_not_called()
+
+
 @mock.patch.object(PageNumberPagination, "get_page_size", return_value=2)
 def test_api_rooms_list_pagination(_mock_page_size):
     """Pagination should work as expected."""

--- a/src/backend/core/tests/rooms/test_api_rooms_lobby.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_lobby.py
@@ -207,10 +207,10 @@ def test_request_entry_public_room(settings):
     with (
         mock.patch.object(utils, "notify_participants", return_value=None),
         mock.patch.object(
-            LobbyService, "_get_or_create_participant_id", return_value="123"
+            LobbyService, "get_or_create_participant_id", return_value="123"
         ),
         mock.patch.object(
-            utils, "generate_livekit_config", return_value={"token": "test-token"}
+            utils, "generate_join_config", return_value={"token": "test-token"}
         ),
         mock.patch.object(utils, "generate_color", return_value="mocked-color"),
     ):
@@ -258,11 +258,11 @@ def test_request_entry_authenticated_user_public_room(settings):
         mock.patch.object(utils, "notify_participants", return_value=None),
         mock.patch.object(
             LobbyService,
-            "_get_or_create_participant_id",
+            "get_or_create_participant_id",
             return_value="2f7f162f-e7d1-421b-90e7-02bfbfbf8def",
         ),
         mock.patch.object(
-            utils, "generate_livekit_config", return_value={"token": "test-token"}
+            utils, "generate_join_config", return_value={"token": "test-token"}
         ),
         mock.patch.object(utils, "generate_color", return_value="mocked-color"),
     ):
@@ -317,7 +317,7 @@ def test_request_entry_waiting_participant_public_room(settings):
     with (
         mock.patch.object(utils, "notify_participants", return_value=None),
         mock.patch.object(
-            utils, "generate_livekit_config", return_value={"token": "test-token"}
+            utils, "generate_join_config", return_value={"token": "test-token"}
         ),
     ):
         response = client.post(
@@ -634,11 +634,9 @@ def test_list_waiting_participants_empty(settings):
 
 
 @mock.patch.object(utils, "notify_participants", return_value=None)
-@mock.patch.object(
-    utils, "generate_livekit_config", return_value={"token": "test-token"}
-)
+@mock.patch.object(utils, "generate_join_config", return_value={"token": "test-token"})
 def test_request_entry_throttling_anonymous_without_cookie(
-    mock_notify_participants, mock_generate_livekit_config, settings
+    mock_notify_participants, mock_generate_join_config, settings
 ):
     """Anonymous users without a cookie should not be throttled."""
 
@@ -667,11 +665,9 @@ def test_request_entry_throttling_anonymous_without_cookie(
 
 
 @mock.patch.object(utils, "notify_participants", return_value=None)
-@mock.patch.object(
-    utils, "generate_livekit_config", return_value={"token": "test-token"}
-)
+@mock.patch.object(utils, "generate_join_config", return_value={"token": "test-token"})
 def test_request_entry_throttling_anonymous_with_cookie(
-    mock_notify_participants, mock_generate_livekit_config, settings
+    mock_notify_participants, mock_generate_join_config, settings
 ):
     """Anonymous users with a cookie should be throttled after exceeding the rate limit."""
     room = RoomFactory(access_level=RoomAccessLevel.RESTRICTED)
@@ -704,11 +700,9 @@ def test_request_entry_throttling_anonymous_with_cookie(
 
 
 @mock.patch.object(utils, "notify_participants", return_value=None)
-@mock.patch.object(
-    utils, "generate_livekit_config", return_value={"token": "test-token"}
-)
+@mock.patch.object(utils, "generate_join_config", return_value={"token": "test-token"})
 def test_request_entry_throttling_authenticated_user(
-    mock_notify_participants, mock_generate_livekit_config, settings
+    mock_notify_participants, mock_generate_join_config, settings
 ):
     """Authenticated users should be throttled."""
     room = RoomFactory(access_level=RoomAccessLevel.RESTRICTED)

--- a/src/backend/core/tests/rooms/test_api_rooms_rename_toggle.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_rename_toggle.py
@@ -261,7 +261,7 @@ def test_rename_participant_success(mock_livekit_client, room, token):
     )
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == {"status": "success"}
+    assert response.data == {"status": "success", "name": "John Doe"}
 
     mock_livekit_client.room.update_participant.assert_called_once()
     mock_livekit_client.aclose.assert_called_once()
@@ -277,6 +277,23 @@ def test_rename_participant_sets_correct_name(mock_livekit_client, room, token):
 
     call_kwargs = mock_livekit_client.room.update_participant.call_args
     assert call_kwargs[0][0].name == "Jane Doe"
+
+
+def test_rename_participant_numbers_a_taken_name(
+    mock_livekit_client, mock_list_participant_names, room, token
+):
+    """Renaming to a name someone else holds numbers it, and says so."""
+    mock_list_participant_names.return_value = {"someone-else": "Jane Doe"}
+
+    client = APIClient()
+    url = reverse("rooms-rename", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"name": "Jane Doe"}, format="json", HTTP_AUTHORIZATION=f"Bearer {token}"
+    )
+
+    call_kwargs = mock_livekit_client.room.update_participant.call_args
+    assert call_kwargs[0][0].name == "Jane Doe (2)"
+    assert response.data == {"status": "success", "name": "Jane Doe (2)"}
 
 
 def test_rename_participant_uses_identity_from_token(
@@ -386,7 +403,7 @@ def test_rename_participant_success_anonymous(
     )
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == {"status": "success"}
+    assert response.data == {"status": "success", "name": "Guest User"}
 
     mock_livekit_client.room.update_participant.assert_called_once()
     mock_livekit_client.aclose.assert_called_once()

--- a/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
@@ -5,9 +5,11 @@ Test rooms API endpoints in the Meet core app: retrieve.
 import random
 from unittest import mock
 
+from django.conf import settings as django_settings
 from django.contrib.auth.models import AnonymousUser
 from django.test.utils import override_settings
 
+import jwt
 import pytest
 from rest_framework.test import APIClient
 
@@ -136,7 +138,13 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed(mock_token):
     }
 
     mock_token.assert_called_once_with(
-        room="unregistered-room", user=AnonymousUser(), username=None
+        room="unregistered-room",
+        user=AnonymousUser(),
+        display_name="Anonymous",
+        color=None,
+        sources=None,
+        role=None,
+        participant_id=mock.ANY,
     )
 
 
@@ -171,7 +179,13 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed_not_normalized(mock_t
     }
 
     mock_token.assert_called_once_with(
-        room="reunion", user=AnonymousUser(), username=None
+        room="reunion",
+        user=AnonymousUser(),
+        display_name="Anonymous",
+        color=None,
+        sources=None,
+        role=None,
+        participant_id=mock.ANY,
     )
 
 
@@ -268,11 +282,11 @@ def test_api_rooms_retrieve_authenticated_public(mock_token):
     mock_token.assert_called_once_with(
         room=expected_name,
         user=user,
-        username=None,
+        display_name=user.full_name,
         color=None,
         sources=["camera"],
         role=None,
-        participant_id=None,
+        participant_id=str(user.sub),
     )
 
 
@@ -319,11 +333,11 @@ def test_api_rooms_retrieve_authenticated_trusted(mock_token):
     mock_token.assert_called_once_with(
         room=expected_name,
         user=user,
-        username=None,
+        display_name=user.full_name,
         color=None,
         sources=None,
         role=None,
-        participant_id=None,
+        participant_id=str(user.sub),
     )
 
 
@@ -405,11 +419,11 @@ def test_api_rooms_retrieve_members(mock_token, django_assert_num_queries, setti
     mock_token.assert_called_once_with(
         room=expected_name,
         user=user,
-        username=None,
+        display_name=user.full_name,
         color=None,
         sources=["camera"],
         role=str(RoleChoices.MEMBER),
-        participant_id=None,
+        participant_id=str(user.sub),
     )
 
 
@@ -501,9 +515,52 @@ def test_api_rooms_retrieve_administrators(
     mock_token.assert_called_once_with(
         room=expected_name,
         user=user,
-        username=None,
+        display_name=user.full_name,
         color=None,
         sources=None,
         role=str(user_access.role),
-        participant_id=None,
+        participant_id=str(user.sub),
     )
+
+
+def test_api_rooms_retrieve_numbers_a_name_held_in_the_room(
+    mock_list_participant_names,
+):
+    """Fetching one room issues a token numbered against who is already there."""
+    room = RoomFactory(access_level=RoomAccessLevel.PUBLIC)
+    mock_list_participant_names.return_value = {"someone-else": "Jane Doe"}
+
+    response = APIClient().get(f"/api/v1.0/rooms/{room.id!s}/?username=Jane%20Doe")
+
+    assert response.status_code == 200
+    token = response.json()["livekit"]["token"]
+    claims = jwt.decode(
+        token, django_settings.LIVEKIT_CONFIGURATION["api_secret"], algorithms=["HS256"]
+    )
+    assert claims["name"] == "Jane Doe (2)"
+
+
+def test_api_rooms_retrieve_keeps_one_identity_across_fetches(
+    mock_list_participant_names,
+):
+    """A guest reloading is the same participant, not a second one."""
+    room = RoomFactory(access_level=RoomAccessLevel.PUBLIC)
+    client = APIClient()
+
+    first = client.get(f"/api/v1.0/rooms/{room.id!s}/?username=Jane%20Doe")
+    identity = jwt.decode(
+        first.json()["livekit"]["token"],
+        django_settings.LIVEKIT_CONFIGURATION["api_secret"],
+        algorithms=["HS256"],
+    )["sub"]
+
+    mock_list_participant_names.return_value = {identity: "Jane Doe"}
+    second = client.get(f"/api/v1.0/rooms/{room.id!s}/?username=Jane%20Doe")
+    claims = jwt.decode(
+        second.json()["livekit"]["token"],
+        django_settings.LIVEKIT_CONFIGURATION["api_secret"],
+        algorithms=["HS256"],
+    )
+
+    assert claims["sub"] == identity
+    assert claims["name"] == "Jane Doe"

--- a/src/backend/core/tests/services/test_lobby.py
+++ b/src/backend/core/tests/services/test_lobby.py
@@ -140,7 +140,7 @@ def test_get_or_create_participant_id_from_cookie(lobby_service):
     request = mock.Mock()
     request.COOKIES = {settings.LOBBY_COOKIE_NAME: "existing-id"}
 
-    participant_id = lobby_service._get_or_create_participant_id(request)
+    participant_id = lobby_service.get_or_create_participant_id(request)
 
     assert participant_id == "existing-id"
 
@@ -151,7 +151,7 @@ def test_get_or_create_participant_id_new(mock_uuid4, lobby_service):
     request = mock.Mock()
     request.COOKIES = {}
 
-    participant_id = lobby_service._get_or_create_participant_id(request)
+    participant_id = lobby_service.get_or_create_participant_id(request)
 
     assert participant_id == "generated-id"
     mock_uuid4.assert_called_once()
@@ -249,7 +249,7 @@ def test_can_bypass_lobby_private_room_with_any_role(role, lobby_service):
     assert lobby_service.can_bypass_lobby(room, user, role=role) is True
 
 
-@mock.patch("core.utils.generate_livekit_config")
+@mock.patch("core.utils.generate_join_config")
 def test_request_entry_public_room(
     mock_generate_config, lobby_service, participant_id, username
 ):
@@ -266,7 +266,7 @@ def test_request_entry_public_room(
         color="#123456",
     )
 
-    lobby_service._get_or_create_participant_id = mock.Mock(return_value=participant_id)
+    lobby_service.get_or_create_participant_id = mock.Mock(return_value=participant_id)
     lobby_service._get_participant = mock.Mock(return_value=mocked_participant)
     mock_generate_config.return_value = {"token": "test-token"}
 
@@ -287,7 +287,7 @@ def test_request_entry_public_room(
     lobby_service._get_participant.assert_called_once_with(room.id, participant_id)
 
 
-@mock.patch("core.utils.generate_livekit_config")
+@mock.patch("core.utils.generate_join_config")
 def test_request_entry_trusted_room(
     mock_generate_config, lobby_service, participant_id, username
 ):
@@ -304,7 +304,7 @@ def test_request_entry_trusted_room(
         color="#123456",
     )
 
-    lobby_service._get_or_create_participant_id = mock.Mock(return_value=participant_id)
+    lobby_service.get_or_create_participant_id = mock.Mock(return_value=participant_id)
     lobby_service._get_participant = mock.Mock(return_value=mocked_participant)
     mock_generate_config.return_value = {"token": "test-token"}
 
@@ -336,7 +336,7 @@ def test_request_entry_new_participant(
 
     room = RoomFactory(access_level=RoomAccessLevel.RESTRICTED)
 
-    lobby_service._get_or_create_participant_id = mock.Mock(return_value=participant_id)
+    lobby_service.get_or_create_participant_id = mock.Mock(return_value=participant_id)
     lobby_service._get_participant = mock.Mock(return_value=None)
 
     participant_data = LobbyParticipant(
@@ -372,7 +372,7 @@ def test_request_entry_waiting_participant(
         id=participant_id,
         color="#123456",
     )
-    lobby_service._get_or_create_participant_id = mock.Mock(return_value=participant_id)
+    lobby_service.get_or_create_participant_id = mock.Mock(return_value=participant_id)
     lobby_service._get_participant = mock.Mock(return_value=mocked_participant)
 
     participant, livekit_config = lobby_service.request_entry(room, request, username)
@@ -383,7 +383,7 @@ def test_request_entry_waiting_participant(
     lobby_service._get_participant.assert_called_once_with(room.id, participant_id)
 
 
-@mock.patch("core.utils.generate_livekit_config")
+@mock.patch("core.utils.generate_join_config")
 def test_request_entry_accepted_participant(
     mock_generate_config, lobby_service, participant_id, username
 ):
@@ -400,7 +400,7 @@ def test_request_entry_accepted_participant(
         id=participant_id,
         color="#123456",
     )
-    lobby_service._get_or_create_participant_id = mock.Mock(return_value=participant_id)
+    lobby_service.get_or_create_participant_id = mock.Mock(return_value=participant_id)
     lobby_service._get_participant = mock.Mock(return_value=mocked_participant)
 
     mock_generate_config.return_value = {"token": "test-token"}
@@ -421,7 +421,7 @@ def test_request_entry_accepted_participant(
     lobby_service._get_participant.assert_called_once_with(room.id, participant_id)
 
 
-@mock.patch("core.utils.generate_livekit_config")
+@mock.patch("core.utils.generate_join_config")
 def test_request_entry_participant_with_role(
     mock_generate_config, lobby_service, participant_id, username
 ):
@@ -440,7 +440,7 @@ def test_request_entry_participant_with_role(
         id=participant_id,
         color="#123456",
     )
-    lobby_service._get_or_create_participant_id = mock.Mock(return_value=participant_id)
+    lobby_service.get_or_create_participant_id = mock.Mock(return_value=participant_id)
     lobby_service._get_participant = mock.Mock(return_value=mocked_participant)
 
     mock_generate_config.return_value = {"token": "test-token"}

--- a/src/backend/core/tests/test_utils.py
+++ b/src/backend/core/tests/test_utils.py
@@ -12,13 +12,20 @@ from django.contrib.auth.models import AnonymousUser
 import jwt
 import pytest
 from livekit.api import TwirpError
+from livekit.protocol.models import ParticipantInfo
 
 from core.factories import UserFactory
 from core.utils import (
+    MAX_DISPLAY_NAME_BYTES,
+    MAX_DISPLAY_NAME_CHARACTERS,
     NotificationError,
     create_livekit_client,
+    generate_join_config,
     generate_token,
+    list_participant_names,
     notify_participants,
+    resolve_display_name,
+    unique_display_name,
 )
 
 pytestmark = pytest.mark.django_db
@@ -33,78 +40,74 @@ def decode_token(token: str) -> dict:
     )
 
 
-def test_generate_token_authenticated_uses_full_name():
-    """The token's display name should default to the user's full name."""
+def test_generate_token_signs_the_name_it_is_given():
+    """The token carries the display name resolved by its caller."""
     user = UserFactory(full_name="Jane Doe")
 
-    token = generate_token(room="my-room", user=user)
+    token = generate_token(room="my-room", user=user, display_name="Jane Doe")
 
     claims = decode_token(token)
     assert claims["name"] == "Jane Doe"
     assert claims["sub"] == str(user.sub)
 
 
-def test_generate_token_authenticated_fallback_user_representation():
+def test_resolve_display_name_authenticated_uses_full_name():
+    """An authenticated user with no requested name is shown their full name."""
+    user = UserFactory(full_name="Jane Doe")
+
+    assert resolve_display_name(user, None) == "Jane Doe"
+
+
+def test_resolve_display_name_authenticated_fallback_user_representation():
     """
-    When the user has no full name, the token's display name should fall back
-    to the user's string representation.
+    When the user has no full name, the display name falls back to the user's
+    string representation.
     """
     user = UserFactory(full_name=None)
 
-    token = generate_token(room="my-room", user=user)
-
-    claims = decode_token(token)
-    assert claims["name"] == str(user)
+    assert resolve_display_name(user, None) == str(user)
 
 
-def test_generate_token_explicit_username_overrides_default():
-    """An explicitly provided username should take precedence over the full name."""
+def test_resolve_display_name_explicit_username_overrides_default():
+    """An explicitly provided username takes precedence over the full name."""
     user = UserFactory(full_name="Jane Doe")
 
-    token = generate_token(room="my-room", user=user, username="Custom Name")
-
-    claims = decode_token(token)
-    assert claims["name"] == "Custom Name"
+    assert resolve_display_name(user, "Custom Name") == "Custom Name"
 
 
-def test_authenticated_username_ignored_when_editing_disabled(settings):
+def test_resolve_display_name_authenticated_username_ignored_when_editing_disabled(
+    settings,
+):
     """With editing disabled, an authenticated user's username is ignored."""
     settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME = False
     user = UserFactory(full_name="Jane Doe")
-    token = generate_token(room="my-room", user=user, username="Custom Name")
-    claims = decode_token(token)
-    assert claims["name"] == "Jane Doe"
+
+    assert resolve_display_name(user, "Custom Name") == "Jane Doe"
 
 
-def test_authenticated_default_name_unaffected_when_editing_disabled(settings):
+def test_resolve_display_name_default_unaffected_when_editing_disabled(settings):
     """Disabling editing doesn't disturb the default full-name path."""
     settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME = False
     user = UserFactory(full_name="Jane Doe")
-    token = generate_token(room="my-room", user=user)
-    claims = decode_token(token)
-    assert claims["name"] == "Jane Doe"
+
+    assert resolve_display_name(user, None) == "Jane Doe"
 
 
-def test_anonymous_uses_username_when_provided():
+def test_resolve_display_name_anonymous_uses_username_when_provided():
     """An anonymous user's provided username is used as the display name."""
-    token = generate_token(room="my-room", user=AnonymousUser(), username="Guest42")
-    claims = decode_token(token)
-    assert claims["name"] == "Guest42"
+    assert resolve_display_name(AnonymousUser(), "Guest42") == "Guest42"
 
 
-def test_anonymous_username_used_even_when_editing_disabled(settings):
+def test_resolve_display_name_anonymous_username_kept_when_editing_disabled(settings):
     """The setting governs authenticated users only; anonymous can still set a name."""
     settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME = False
-    token = generate_token(room="my-room", user=AnonymousUser(), username="Guest42")
-    claims = decode_token(token)
-    assert claims["name"] == "Guest42"
+
+    assert resolve_display_name(AnonymousUser(), "Guest42") == "Guest42"
 
 
-def test_anonymous_falls_back_to_anonymous_label():
+def test_resolve_display_name_anonymous_falls_back_to_anonymous_label():
     """With no username, an anonymous user is labelled 'Anonymous'."""
-    token = generate_token(room="my-room", user=AnonymousUser())
-    claims = decode_token(token)
-    assert claims["name"] == "Anonymous"
+    assert resolve_display_name(AnonymousUser(), None) == "Anonymous"
 
 
 @mock.patch("asyncio.get_running_loop")
@@ -262,3 +265,122 @@ def test_notify_participants_success(mock_create_livekit_client):
 
     # Verify aclose was called
     mock_api_instance.aclose.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "taken,expected",
+    [
+        ([], "Jane Doe"),
+        (["John Doe"], "Jane Doe"),
+        (["Jane Doe"], "Jane Doe (2)"),
+        (["Jane Doe", "Jane Doe (2)"], "Jane Doe (3)"),
+        (["Jane Doe", "Jane Doe (3)"], "Jane Doe (2)"),
+    ],
+)
+def test_unique_display_name(taken, expected):
+    """A taken name is numbered from two, taking the lowest free number."""
+    assert unique_display_name("Jane Doe", set(taken)) == expected
+
+
+@pytest.mark.parametrize(
+    "name,taken,expected",
+    [
+        (
+            "X" * (MAX_DISPLAY_NAME_BYTES + 50),
+            set(),
+            "X" * MAX_DISPLAY_NAME_CHARACTERS,
+        ),
+        (
+            "X" * MAX_DISPLAY_NAME_CHARACTERS,
+            {"X" * MAX_DISPLAY_NAME_CHARACTERS},
+            "X" * (MAX_DISPLAY_NAME_CHARACTERS - 4) + " (2)",
+        ),
+        ("A", {"A"}, "A (2)"),
+        # 85 CJK characters are 255 bytes, so the number does not fit beside them
+        ("\u540d" * 85, {"\u540d" * 85}, "\u540d" * 84 + " (2)"),
+    ],
+)
+def test_unique_display_name_stays_within_livekits_limit(name, taken, expected):
+    """A name too long for LiveKit loses its tail, never its number."""
+    numbered = unique_display_name(name, taken)
+
+    assert numbered == expected
+    assert len(numbered.encode("utf-8")) <= MAX_DISPLAY_NAME_BYTES
+    assert len(numbered) <= MAX_DISPLAY_NAME_CHARACTERS
+
+
+@mock.patch("core.utils.create_livekit_client")
+def test_list_participant_names_maps_identity_to_name(mock_create_livekit_client):
+    """Participants are returned as a name per identity, the disconnected left out."""
+
+    class MockResponse:
+        """LiveKit ListParticipants response mock."""
+
+        participants = [
+            ParticipantInfo(identity="id-1", name="Jane Doe"),
+            ParticipantInfo(identity="id-2", name="John Doe"),
+            ParticipantInfo(
+                identity="id-3", name="Gone", state=ParticipantInfo.State.DISCONNECTED
+            ),
+        ]
+
+    mock_api_instance = mock.Mock()
+    mock_api_instance.room = mock.Mock()
+    mock_api_instance.room.list_participants = mock.AsyncMock(
+        return_value=MockResponse()
+    )
+    mock_api_instance.aclose = mock.AsyncMock()
+    mock_create_livekit_client.return_value = mock_api_instance
+
+    assert list_participant_names("my-room") == {"id-1": "Jane Doe", "id-2": "John Doe"}
+    mock_api_instance.aclose.assert_called_once()
+
+
+@mock.patch("core.utils.create_livekit_client")
+def test_list_participant_names_empty_when_livekit_fails(mock_create_livekit_client):
+    """A room LiveKit cannot answer for reads as an empty room."""
+
+    mock_api_instance = mock.Mock()
+    mock_api_instance.room = mock.Mock()
+    mock_api_instance.room.list_participants = mock.AsyncMock(
+        side_effect=TwirpError(msg="room not found", code=404, status=404)
+    )
+    mock_api_instance.aclose = mock.AsyncMock()
+    mock_create_livekit_client.return_value = mock_api_instance
+
+    assert list_participant_names("my-room") == {}
+    mock_api_instance.aclose.assert_called_once()
+
+
+def test_generate_join_config_marks_a_taken_name(mock_list_participant_names):
+    """Joining under a name already in the room adds a number."""
+    mock_list_participant_names.return_value = {"someone-else": "Jane Doe"}
+
+    config = generate_join_config(
+        room_id="my-room", user=AnonymousUser(), username="Jane Doe"
+    )
+
+    assert decode_token(config["token"])["name"] == "Jane Doe (2)"
+
+
+def test_generate_join_config_ignores_own_identity(mock_list_participant_names):
+    """A participant rejoining keeps their name, their own entry aside."""
+    user = UserFactory(full_name="Jane Doe")
+    mock_list_participant_names.return_value = {str(user.sub): "Jane Doe"}
+
+    config = generate_join_config(room_id="my-room", user=user)
+
+    assert decode_token(config["token"])["name"] == "Jane Doe"
+
+
+def test_generate_join_config_marks_a_forced_name(
+    mock_list_participant_names, settings
+):
+    """Two people sharing one SSO name are still told apart."""
+    settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME = False
+    mock_list_participant_names.return_value = {"someone-else": "Jane Doe"}
+    user = UserFactory(full_name="Jane Doe")
+
+    config = generate_join_config(room_id="my-room", user=user, username="Another Name")
+
+    assert decode_token(config["token"])["name"] == "Jane Doe (2)"

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -14,7 +14,7 @@ import secrets
 import string
 from datetime import timedelta
 from functools import lru_cache
-from typing import List, Optional
+from typing import AbstractSet, Dict, List, Optional
 from uuid import uuid4
 
 from django.conf import settings
@@ -28,14 +28,24 @@ import phonenumbers
 from asgiref.sync import async_to_sync
 from livekit.api import (  # pylint: disable=E0611
     AccessToken,
+    ListParticipantsRequest,
     ListRoomsRequest,
     LiveKitAPI,
     SendDataRequest,
     TwirpError,
     VideoGrants,
 )
+from livekit.protocol.models import ParticipantInfo  # pylint: disable=E0611
 
 logger = logging.getLogger(__name__)
+
+# LiveKit rejects an update carrying a longer participant name, counted in
+# bytes: livekit-server checks len() over the UTF-8 string. Measured against
+# it, 256 bytes are accepted and 257 are refused, so 85 CJK characters pass
+# and 86 do not. The rename endpoints validate characters instead, so a name
+# assigned here stays within both and a participant can always send it back.
+MAX_DISPLAY_NAME_BYTES = 256
+MAX_DISPLAY_NAME_CHARACTERS = 255
 
 
 def generate_color(identity: str) -> str:
@@ -60,10 +70,150 @@ def generate_color(identity: str) -> str:
     return f"hsl({hue}, {saturation}%, {lightness}%)"
 
 
+def participant_identity(user, participant_id: Optional[str]) -> str:
+    """Return the LiveKit identity of a user, stable across their reconnections.
+
+    An authenticated user is their `sub`; anyone else is the identifier they
+    carry between requests, or a fresh one when they carry none.
+    """
+
+    if user.is_anonymous:
+        return participant_id or str(uuid4())
+
+    return str(user.sub)
+
+
+def fit_display_name(
+    display_name: str,
+    byte_limit: int = MAX_DISPLAY_NAME_BYTES,
+    character_limit: int = MAX_DISPLAY_NAME_CHARACTERS,
+) -> str:
+    """Return a name within `limit` bytes and `MAX_DISPLAY_NAME_CHARACTERS`.
+
+    LiveKit counts bytes, so a name of few characters can still be too long,
+    and the rename endpoints count characters, so a long name has to clear
+    both to be one a participant can send back.
+    """
+
+    if byte_limit <= 0 or character_limit <= 0:
+        return ""
+
+    display_name = display_name[:character_limit]
+    encoded = display_name.encode("utf-8")
+
+    if len(encoded) <= byte_limit:
+        return display_name
+
+    return encoded[:byte_limit].decode("utf-8", "ignore")
+
+
+def resolve_display_name(user, username: Optional[str]) -> str:
+    """Return the name a user is displayed under, before any deduplication.
+
+    The requested name, or the user's own representation when they requested
+    none or when the deployment does not let them choose one, bounded to what
+    LiveKit accepts.
+    """
+
+    default_username = "Anonymous" if user.is_anonymous else user.full_name or str(user)
+
+    can_edit = (
+        settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME or user.is_anonymous
+    )
+
+    display_name = (username or default_username) if can_edit else default_username
+
+    return fit_display_name(display_name)
+
+
+@async_to_sync
+async def list_participant_names(room_name: str) -> Dict[str, str]:
+    """Return the display name of every participant present in a room.
+
+    Disconnected participants are left out: LiveKit reports them for a while
+    after they leave, and their names are free to take. An unreachable LiveKit,
+    or a room with no session, reads as an empty room, so a participant keeps
+    the name they asked for rather than failing to join.
+
+    Args:
+        room_name (str): The name of the room.
+
+    Returns:
+        Dict[str, str]: Display name per participant identity.
+    """
+
+    lkapi = create_livekit_client()
+
+    try:
+        response = await lkapi.room.list_participants(
+            ListParticipantsRequest(room=room_name)
+        )
+    except TwirpError as e:
+        # A room with no session is the normal case for the first participant
+        if e.code == "not_found":
+            logger.debug("Room %s has no session yet", room_name)
+        else:
+            logger.warning("Failed to list participants of room %s: %s", room_name, e)
+        return {}
+    except (aiohttp.ClientError, TimeoutError) as e:
+        logger.warning("Failed to reach LiveKit for room %s: %s", room_name, e)
+        return {}
+    finally:
+        await lkapi.aclose()
+
+    return {
+        participant.identity: participant.name
+        for participant in response.participants
+        if participant.state != ParticipantInfo.State.DISCONNECTED
+    }
+
+
+def unique_display_name(display_name: str, taken: AbstractSet[str]) -> str:
+    """Return a display name held by nobody else.
+
+    Counts the way a reader does: a second "Camille Martin" reads
+    "Camille Martin (2)" and a third "Camille Martin (3)", so the first one
+    keeps the name they typed. A name long enough to leave no room for the
+    number loses its last characters instead, since LiveKit refuses to set a
+    name past `MAX_DISPLAY_NAME_BYTES`.
+    """
+
+    candidate, number = fit_display_name(display_name), 1
+
+    while candidate in taken:
+        number += 1
+        suffix = f" ({number})"
+        candidate = (
+            fit_display_name(
+                display_name,
+                MAX_DISPLAY_NAME_BYTES - len(suffix),
+                MAX_DISPLAY_NAME_CHARACTERS - len(suffix),
+            )
+            + suffix
+        )
+
+    return candidate
+
+
+def unique_display_name_in_room(
+    room_name: str, identity: str, display_name: str
+) -> str:
+    """Return a display name held by nobody else in a LiveKit room.
+
+    The participant's own entry never counts against them, so reconnecting or
+    renaming to the same name gives back the same name.
+    """
+
+    names = list_participant_names(room_name)
+    names.pop(identity, None)
+
+    return unique_display_name(display_name, set(names.values()))
+
+
 def generate_token(  # noqa: PLR0917
     room: str,
     user,
-    username: Optional[str] = None,
+    display_name: Optional[str] = None,
     color: Optional[str] = None,
     sources: Optional[List[str]] = None,
     role: Optional[str] = None,
@@ -75,8 +225,9 @@ def generate_token(  # noqa: PLR0917
     Args:
         room (str): The name of the room.
         user (User): The user which request the access token.
-        username (Optional[str]): The username to be displayed in the room.
-                         If none, a default value will be used.
+        display_name (Optional[str]): The name to display in the room, resolved by
+                         `resolve_display_name` and deduplicated against the room.
+                         If none, the user's own representation is used.
         color (Optional[str]): The color to be displayed in the room.
                          If none, a value will be generated
         sources: (Optional[List[str]]): List of media sources the user can publish
@@ -107,20 +258,13 @@ def generate_token(  # noqa: PLR0917
         can_subscribe=True,
     )
 
-    if user.is_anonymous:
-        identity = participant_id or str(uuid4())
-        default_username = "Anonymous"
-    else:
-        identity = str(user.sub)
-        default_username = user.full_name or str(user)
+    identity = participant_identity(user, participant_id)
 
     if color is None:
         color = generate_color(identity)
 
-    can_edit = (
-        settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME or user.is_anonymous
-    )
-    display_name = (username or default_username) if can_edit else default_username
+    if display_name is None:
+        display_name = resolve_display_name(user, None)
 
     token = (
         AccessToken(
@@ -147,7 +291,7 @@ def generate_token(  # noqa: PLR0917
 def generate_livekit_config(  # noqa: PLR0917
     room_id: str,
     user,
-    username: str,
+    display_name: str,
     role: Optional[str] = None,
     color: Optional[str] = None,
     configuration: Optional[dict] = None,
@@ -158,7 +302,7 @@ def generate_livekit_config(  # noqa: PLR0917
     Args:
         room_id: Room identifier
         user: User instance requesting access
-        username: Display name in room
+        display_name: Name to display in room, resolved by `resolve_display_name`
         role (str): Room's access role if any
         color (Optional[str]): Optional color to associate with the participant.
         configuration (Optional[dict]): Room configuration dict that can override default settings.
@@ -179,13 +323,59 @@ def generate_livekit_config(  # noqa: PLR0917
         "token": generate_token(
             room=room_id,
             user=user,
-            username=username,
+            display_name=display_name,
             color=color,
             sources=sources,
             role=role,
             participant_id=participant_id,
         ),
     }
+
+
+def generate_join_config(  # noqa: PLR0917
+    room_id: str,
+    user,
+    username: Optional[str] = None,
+    role: Optional[str] = None,
+    color: Optional[str] = None,
+    configuration: Optional[dict] = None,
+    participant_id: Optional[str] = None,
+) -> dict:
+    """Generate LiveKit configuration for a participant about to join.
+
+    Same as `generate_livekit_config`, and the requested name is resolved and
+    numbered against the room first, so no two participants of one room carry
+    the same display name. Costs one LiveKit round trip, so it is for the paths
+    that hand a token to someone joining, not for serializing a room.
+
+    Args:
+        room_id: Room identifier
+        user: User instance requesting access
+        username (Optional[str]): The name requested by the participant, if any
+        role (str): Room's access role if any
+        color (Optional[str]): Optional color to associate with the participant.
+        configuration (Optional[dict]): Room configuration dict that can override default settings.
+        participant_id (Optional[str]): Stable identifier for anonymous users;
+                         used as identity when user.is_anonymous.
+
+    Returns:
+        dict: LiveKit configuration with URL, room and access token
+    """
+
+    identity = participant_identity(user, participant_id)
+    display_name = unique_display_name_in_room(
+        room_id, identity, resolve_display_name(user, username)
+    )
+
+    return generate_livekit_config(
+        room_id=room_id,
+        user=user,
+        display_name=display_name,
+        role=role,
+        color=color,
+        configuration=configuration,
+        participant_id=identity,
+    )
 
 
 def generate_s3_authorization_headers(key):


### PR DESCRIPTION
Two people can join one room under the same display name, and every screen repeats the same string: the tiles, the participant list, the waiting room. Reported as #1585.

The second one now joins as `Camille Martin (2)`, the third as `Camille Martin (3)`. Reconnecting keeps the number, and the number is free again once its holder leaves. Renaming in the room goes through the same check, and the endpoint answers with the name it assigned.

![Three participants in one meeting, labelled Camille Martin, Camille Martin (2) and Camille Martin (3) on their tiles and in the Participants panel](https://raw.githubusercontent.com/davd-gzl/meet/triage-media/duplicate-display-names/three-participants-numbered.png)

The waiting room is left out: two people waiting under one name still show a moderator two identical rows. Numbering those rows is the obvious next step, and it belongs in its own change, since a number computed as the list is read moves when a row is admitted.

If LiveKit cannot be reached, the join goes through under the name that was asked for.
