### PR TITLE
✨(frontend) recover from stale lazy-loaded chunks after a deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- ✨(frontend) recover from stale lazy-loaded chunks after a deploy
+
 ## [1.26.0] - 2026-08-12
 
 ### Added

--- a/docker/dinum-frontend/nginx/default.conf
+++ b/docker/dinum-frontend/nginx/default.conf
@@ -74,6 +74,13 @@ server {
   location ~* ^/assets/.*\.(css|js|json|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
       expires 30d;
       add_header Cache-Control "public, max-age=2592000";
+      try_files $uri =404;
+      error_page 404 = @asset_missing;
+  }
+
+  location @asset_missing {
+      add_header Cache-Control "no-store" always;
+      return 404;
   }
 
   # Serve static files

--- a/src/frontend/default.conf
+++ b/src/frontend/default.conf
@@ -14,6 +14,13 @@ server {
   location ~* ^/assets/.*\.(css|js|json|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
       expires 30d;
       add_header Cache-Control "public, max-age=2592000";
+      try_files $uri =404;
+      error_page 404 = @asset_missing;
+  }
+
+  location @asset_missing {
+      add_header Cache-Control "no-store" always;
+      return 404;
   }
 
   # Serve static files

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -2,6 +2,26 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 
+const CHUNK_RELOAD_KEY = 'vite-preload-error-reload-at'
+const RELOAD_COOLDOWN_MS = 30_000
+
+window.addEventListener('vite:preloadError', (event) => {
+  try {
+    const lastReloadAt = Number(sessionStorage.getItem(CHUNK_RELOAD_KEY)) || 0
+    if (Date.now() - lastReloadAt <= RELOAD_COOLDOWN_MS) {
+      // Recent reload didn't help: not a stale deploy, surface the error.
+      return
+    }
+    sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()))
+  } catch {
+    // Without sessionStorage we cannot guard against a reload loop:
+    // don't auto-reload, let the error propagate.
+    return
+  }
+  event.preventDefault()
+  window.location.reload()
+})
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
Route components are code-split with content-hashed filenames. A user who loaded the app before a deployment (typically someone sitting in a call) still holds an `index.html` referencing old chunk names. When they navigate after the deploy — e.g. to `/feedback` on leaving a room — the old chunk is gone and the dynamic import fails with "TypeError: error loading dynamically imported module".

Reload the page on that failure to fetch a fresh `index.html` with the current hashes, which transparently fixes the stale-deploy case.

Guard against infinite reload loops with a `RELOAD_COOLDOWN_MS`: if the import fails again right after a reload, the cause is not a stale deploy (ad blocker, proxy, outage) and reloading further would loop forever. In that case, let the error propagate so it reaches monitoring.

Inspired by https://vite.dev/guide/build#load-error-handling