### PR TITLE
📈(frontend) stop double-reporting media device failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - 🐛(analytics) filter benign ResizeObserver loop error in Sentry/PostHog
 - 🐛(frontend) stop reporting screen-share denials as errors
 - 🐛(frontend) generalize screen-share error modal beyond macOS
+- 📈(frontend) stop double-reporting media device failures
 
 ## [1.26.0] - 2026-08-12
 

--- a/src/frontend/src/features/analytics/telemetry.ts
+++ b/src/frontend/src/features/analytics/telemetry.ts
@@ -23,6 +23,7 @@ export type LogCode =
   | 'livekit_room_error'
   | 'device_switch_failure'
   | 'permission_poll_failure'
+  | 'media_devices_error_event'
   // non-media families
   | 'participant_mute_api_failure'
   | 'permissions_api_failure'

--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -225,9 +225,10 @@ export const Conference = ({
             backgroundColor: 'primaryDark.50 !important',
           })}
           onError={(e) => {
+            const failure = MediaDeviceFailure.getFailure(e)
+            if (failure && failure !== MediaDeviceFailure.Other) return
             reportError('livekit_room_error', e, {
               path: 'connect_publish',
-              failure: MediaDeviceFailure.getFailure(e) ?? 'not-a-device-error',
             })
           }}
           onConnected={async () => {

--- a/src/frontend/src/features/rooms/livekit/hooks/useWatchMediaDeviceErrors.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useWatchMediaDeviceErrors.ts
@@ -50,15 +50,16 @@ export const useWatchMediaDeviceErrors = (): MediaDeviceAlert & {
   useEffect(() => {
     const onDeviceError = (error: Error, kind?: MediaDeviceKind) => {
       const failure = MediaDeviceFailure.getFailure(error)
-      if (!failure || !kind) return
-
-      void captureMediaEvent('media-device-error', {
-        log_code: 'media_devices_error_event',
-        path: 'connect_publish',
-        failure,
-        kind,
-      })
-
+      if (!failure) return
+      if (failure != MediaDeviceFailure.Other) {
+        void captureMediaEvent('media-device-error', {
+          log_code: 'media_devices_error_event',
+          path: 'connect_publish',
+          failure,
+          kind: kind ?? 'unknown',
+        })
+      }
+      if (!kind) return
       const permissionKind = PERMISSION_BY_DEVICE_KIND[kind]
       switch (failure) {
         case MediaDeviceFailure.DeviceInUse:


### PR DESCRIPTION
Only report `Other` `MediaDeviceFailure` cases as they genuinely need investigation.

Make sure we do not report the same situation both as a media event and as a media exception when it is already handled.