### PR TITLE
📝(docs) fix minor typos in comments and docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 📝(docs) fix minor typos in comments and docstrings
+
 ## [1.27.0] - 2026-08-14
 
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Security is very important to us.
 
-If you have any issue regarding security, please disclose the information responsibly submiting [this form](https://vdp.numerique.gouv.fr/p/Send-a-report?lang=en) and not by creating an issue on the repository. You can also email us at visio@numerique.gouv.fr
+If you have any issue regarding security, please disclose the information responsibly by submitting [this form](https://vdp.numerique.gouv.fr/p/Send-a-report?lang=en) and not by creating an issue on the repository. You can also email us at visio@numerique.gouv.fr
 
 We appreciate your effort to make Visio more secure.
 

--- a/src/frontend/src/features/chat/components/ChatProvider.tsx
+++ b/src/frontend/src/features/chat/components/ChatProvider.tsx
@@ -23,7 +23,7 @@ export const ChatProvider = () => {
     resetChatStore()
   }, [])
 
-  // Tigger the message notification (temporary)
+  // Trigger the message notification (temporary)
   useEffect(() => {
     // TEMPORARY: This is a brittle workaround that relies on message count tracking
     // due to recent LiveKit useChat changes breaking the previous implementation

--- a/src/frontend/src/features/rooms/livekit/components/blur/BackgroundCustomProcessor.ts
+++ b/src/frontend/src/features/rooms/livekit/components/blur/BackgroundCustomProcessor.ts
@@ -44,7 +44,7 @@ export class BackgroundCustomProcessor implements BackgroundProcessorInterface {
   videoElement?: HTMLVideoElement
   videoElementLoaded?: boolean
 
-  // Canvas containg the video processing result, of which we extract as stream.
+  // Canvas containing the video processing result, of which we extract as stream.
   outputCanvas?: HTMLCanvasElement
   outputCanvasCtx?: CanvasRenderingContext2D
 
@@ -55,7 +55,7 @@ export class BackgroundCustomProcessor implements BackgroundProcessorInterface {
   segmentationMaskCanvas?: HTMLCanvasElement
   segmentationMaskCanvasCtx?: CanvasRenderingContext2D
 
-  // Mask containg the inference result.
+  // Mask containing the inference result.
   segmentationMask?: ImageData
 
   // The resized image of the video source.

--- a/src/summary/summary/core/models.py
+++ b/src/summary/summary/core/models.py
@@ -26,7 +26,7 @@ class RecordingMetadata(BaseModel):
 
     cloud_storage_url: Url = Field(
         title="Cloud Storage URL",
-        description="The URL of the metadata file for speaker assignement.",
+        description="The URL of the metadata file for speaker assignment.",
     )
     started_at: AwareDatetime = Field(title="Start time of the recording to transcribe")
     ended_at: AwareDatetime = Field(title="End time of the recording to transcribe")


### PR DESCRIPTION
## Purpose

This PR fixes a few small spelling typos found in code comments and docstrings across the project — no functional or logic changes.

## Changes

- SECURITY.md: "submiting" → "submitting"
- ChatProvider.tsx: "Tigger" → "Trigger" (comment)
- BackgroundCustomProcessor.ts: "containg" → "containing" (x2, comments)
- models.py: "assignement" → "assignment" (docstring)
- Added changelog entry under [Unreleased] / Fixed