### PR TITLE
✨(fullstack) show how many people are in the meeting on the join screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(fullstack) show how many people are in the meeting on the join screen
+
 ### Fixed
 
 - 📝(docs) fix minor typos in comments and docstrings

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -185,13 +185,8 @@ class RoomSerializer(serializers.ModelSerializer):
             )
             output["accesses"] = access_serializer.data
 
-        should_access_room = (
-            (
-                instance.access_level == models.RoomAccessLevel.TRUSTED
-                and request.user.is_authenticated
-            )
-            or role is not None
-            or instance.is_public
+        should_access_room = instance.is_joinable_by(
+            request.user, has_role=role is not None
         )
 
         if should_access_room:

--- a/src/backend/core/api/throttling.py
+++ b/src/backend/core/api/throttling.py
@@ -87,6 +87,18 @@ class RoomKitJoinRateThrottle(MonitoredUserRateThrottle):
     scope = "roomkit_join"
 
 
+class ParticipantsCountUserRateThrottle(MonitoredUserRateThrottle):
+    """Throttle authenticated users polling a room's participants count."""
+
+    scope = "participants_count"
+
+
+class ParticipantsCountAnonRateThrottle(MonitoredAnonRateThrottle):
+    """Throttle anonymous users polling a room's participants count."""
+
+    scope = "participants_count"
+
+
 class ConnectionTestUserRateThrottle(MonitoredUserRateThrottle):
     """Throttle authenticated users requesting connection test tokens."""
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -248,6 +248,8 @@ class RoomViewSet(
     API endpoints to access and perform actions on rooms.
     """
 
+    # pylint: disable=too-many-public-methods
+
     pagination_class = Pagination
     permission_classes = [permissions.RoomPermissions]
     queryset = models.Room.objects.all()
@@ -390,6 +392,49 @@ class RoomViewSet(
                 "Failed to sync metadata to LiveKit for room %s",
                 room.id,
             )
+
+    @decorators.action(
+        detail=True,
+        methods=["get"],
+        url_path="participants-count",
+        url_name="participants-count",
+        permission_classes=[],
+        throttle_classes=[
+            throttling.ParticipantsCountUserRateThrottle,
+            throttling.ParticipantsCountAnonRateThrottle,
+        ],
+    )
+    def participants_count(self, request, pk=None):  # pylint: disable=unused-argument
+        """Return how many people are currently in the room's meeting.
+
+        Open to anonymous users, and only to the ones the room would let in
+        without approval: someone the retrieve endpoint already hands a token to
+        learns nothing here they could not learn by joining, which is the point.
+        Everyone else gets the same answer as a room that does not exist.
+        """
+
+        try:
+            room = self.get_object()
+        except Http404:
+            if not settings.ALLOW_UNREGISTERED_ROOMS:
+                raise
+            # An unregistered room is public and named after its slug in
+            # LiveKit, exactly as the token the retrieve endpoint mints for it.
+            livekit_room = slugify(self.kwargs["pk"])
+        else:
+            if not room.is_joinable_by(request.user):
+                raise Http404
+            livekit_room = str(room.id)
+
+        try:
+            count = RoomManagement().get_participants_count(livekit_room)
+        except RoomManagementException:
+            return drf_response.Response(
+                {"detail": "Could not reach the meeting."},
+                status=drf_status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        return drf_response.Response({"count": count})
 
     @decorators.action(
         detail=True,

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -483,6 +483,20 @@ class Room(Resource):
         """Check if a room is public"""
         return self.access_level == RoomAccessLevel.PUBLIC
 
+    def is_joinable_by(self, user, has_role=None):
+        """Check if a user can enter the room without asking for approval.
+
+        This is the rule applied before handing out a LiveKit token, so anything
+        answering a question about a live meeting asks it without repeating the
+        condition. Pass `has_role` when the caller has already resolved whether
+        the user holds a role, which is a query this makes otherwise.
+        """
+        return (
+            self.is_public
+            or (self.access_level == RoomAccessLevel.TRUSTED and user.is_authenticated)
+            or (self.has_any_role(user) if has_role is None else has_role)
+        )
+
     @staticmethod
     def generate_unique_pin_code(length):
         """Generate a unique n-digit PIN code"""

--- a/src/backend/core/services/room_management.py
+++ b/src/backend/core/services/room_management.py
@@ -6,6 +6,7 @@ import json
 from logging import getLogger
 from typing import Dict, Optional
 
+import aiohttp
 from asgiref.sync import async_to_sync
 from livekit.api import (
     DeleteRoomRequest,
@@ -89,6 +90,41 @@ class RoomManagement:
 
         finally:
             await lkapi.aclose()
+
+    @async_to_sync
+    async def get_participants_count(self, room_name: str) -> int:
+        """Count the people currently in a LiveKit room.
+
+        LiveKit creates a room when its first participant joins, so a name it
+        does not know has nobody in it. Its count leaves out agents and
+        recorders, which is what makes it the number to show a human.
+
+        Raises:
+            RoomManagementException: the count could not be read.
+        """
+
+        lkapi = utils.create_livekit_client()
+
+        try:
+            response = await lkapi.room.list_rooms(ListRoomsRequest(names=[room_name]))
+
+        # A LiveKit outage would otherwise surface as a 500 on every poll of the
+        # join screen, so the connection error is turned into the same failure
+        # as a refusal.
+        except (TwirpError, aiohttp.ClientError) as e:
+            logger.exception(
+                "Unexpected error counting participants in room %s",
+                room_name,
+            )
+            raise RoomManagementException("Could not count participants") from e
+
+        finally:
+            await lkapi.aclose()
+
+        if not response.rooms:
+            return 0
+
+        return response.rooms[0].num_participants
 
     @async_to_sync
     async def delete_room(self, room_name: str):

--- a/src/backend/core/tests/rooms/test_api_rooms_participants_count.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_participants_count.py
@@ -1,0 +1,168 @@
+"""
+Test rooms API endpoints in the Meet core app: participants count.
+"""
+
+# pylint: disable=redefined-outer-name,unused-argument,no-name-in-module
+
+import random
+from unittest import mock
+
+from django.test.utils import override_settings
+from django.urls import reverse
+
+import pytest
+from livekit.api import TwirpError
+from livekit.protocol.models import Room as LiveKitRoom
+from livekit.protocol.room import ListRoomsResponse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.factories import RoomFactory, UserFactory, UserResourceAccessFactory
+from core.models import RoomAccessLevel
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mock_livekit_client():
+    """Mock LiveKit API client, reporting two people in every room."""
+    with mock.patch("core.utils.create_livekit_client") as mock_create:
+        mock_client = mock.AsyncMock()
+        mock_client.room.list_rooms.return_value = ListRoomsResponse(
+            rooms=[LiveKitRoom(num_participants=2)]
+        )
+        mock_create.return_value = mock_client
+        yield mock_client
+
+
+def test_participants_count_anonymous_public_room(mock_livekit_client):
+    """Anyone can read the count of a room anyone may enter."""
+    room = RoomFactory(access_level=RoomAccessLevel.PUBLIC)
+
+    response = APIClient().get(
+        reverse("rooms-participants-count", kwargs={"pk": room.id})
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"count": 2}
+
+    request = mock_livekit_client.room.list_rooms.call_args.args[0]
+    assert list(request.names) == [str(room.id)]
+
+
+def test_participants_count_by_slug(mock_livekit_client):
+    """The room code in the address reaches the same count as the id."""
+    room = RoomFactory(access_level=RoomAccessLevel.PUBLIC)
+
+    response = APIClient().get(
+        reverse("rooms-participants-count", kwargs={"pk": room.slug})
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"count": 2}
+
+
+def test_participants_count_empty_meeting(mock_livekit_client):
+    """A room LiveKit has never created reports nobody."""
+    room = RoomFactory(access_level=RoomAccessLevel.PUBLIC)
+    mock_livekit_client.room.list_rooms.return_value = ListRoomsResponse(rooms=[])
+
+    response = APIClient().get(
+        reverse("rooms-participants-count", kwargs={"pk": room.id})
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"count": 0}
+
+
+def test_participants_count_anonymous_trusted_room(mock_livekit_client):
+    """Someone who would have to wait for approval is told nothing."""
+    room = RoomFactory(access_level=RoomAccessLevel.TRUSTED)
+
+    response = APIClient().get(
+        reverse("rooms-participants-count", kwargs={"pk": room.id})
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    mock_livekit_client.room.list_rooms.assert_not_called()
+
+
+def test_participants_count_authenticated_trusted_room(mock_livekit_client):
+    """A signed-in user walks into a trusted room, so they get the count."""
+    room = RoomFactory(access_level=RoomAccessLevel.TRUSTED)
+    client = APIClient()
+    client.force_authenticate(user=UserFactory())
+
+    response = client.get(reverse("rooms-participants-count", kwargs={"pk": room.id}))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"count": 2}
+
+
+def test_participants_count_restricted_room_without_access(mock_livekit_client):
+    """A restricted room tells a signed-in stranger nothing."""
+    room = RoomFactory(access_level=RoomAccessLevel.RESTRICTED)
+    client = APIClient()
+    client.force_authenticate(user=UserFactory())
+
+    response = client.get(reverse("rooms-participants-count", kwargs={"pk": room.id}))
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    mock_livekit_client.room.list_rooms.assert_not_called()
+
+
+def test_participants_count_restricted_room_with_access(mock_livekit_client):
+    """An invited member of a restricted room gets the count."""
+    room = RoomFactory(access_level=RoomAccessLevel.RESTRICTED)
+    user = UserFactory()
+    UserResourceAccessFactory(
+        resource=room,
+        user=user,
+        role=random.choice(["member", "administrator", "owner"]),
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get(reverse("rooms-participants-count", kwargs={"pk": room.id}))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"count": 2}
+
+
+@override_settings(ALLOW_UNREGISTERED_ROOMS=True)
+def test_participants_count_unregistered_room(mock_livekit_client):
+    """An unregistered room is counted under the slug it is named by."""
+    response = APIClient().get(
+        reverse("rooms-participants-count", kwargs={"pk": "tst-room-dev"})
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"count": 2}
+
+    request = mock_livekit_client.room.list_rooms.call_args.args[0]
+    assert list(request.names) == ["tst-room-dev"]
+
+
+@override_settings(ALLOW_UNREGISTERED_ROOMS=False)
+def test_participants_count_unregistered_room_disabled(mock_livekit_client):
+    """With unregistered rooms off, an unknown room stays unknown."""
+    response = APIClient().get(
+        reverse("rooms-participants-count", kwargs={"pk": "tst-room-dev"})
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    mock_livekit_client.room.list_rooms.assert_not_called()
+
+
+def test_participants_count_livekit_unreachable(mock_livekit_client):
+    """A media server that cannot answer gives 503, never a 500."""
+    room = RoomFactory(access_level=RoomAccessLevel.PUBLIC)
+    mock_livekit_client.room.list_rooms.side_effect = TwirpError(
+        "internal", "boom", status=500
+    )
+
+    response = APIClient().get(
+        reverse("rooms-participants-count", kwargs={"pk": room.id})
+    )
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/src/backend/core/tests/services/test_room_management.py
+++ b/src/backend/core/tests/services/test_room_management.py
@@ -113,8 +113,9 @@ def test_get_participants_count_raises_management_exception(
     mock_api.room.list_rooms = mock.AsyncMock(side_effect=error)
     mock_api.aclose = mock.AsyncMock()
     mock_create_livekit_client.return_value = mock_api
+    service = RoomManagement()
 
     with pytest.raises(RoomManagementException):
-        RoomManagement().get_participants_count("room-abc")
+        service.get_participants_count("room-abc")
 
     mock_api.aclose.assert_awaited_once()

--- a/src/backend/core/tests/services/test_room_management.py
+++ b/src/backend/core/tests/services/test_room_management.py
@@ -2,8 +2,11 @@
 
 from unittest import mock
 
+import aiohttp
 import pytest
 from livekit.api import TwirpError
+from livekit.protocol.models import Room as LiveKitRoom
+from livekit.protocol.room import ListRoomsResponse
 
 from core.services.room_management import (
     RoomManagement,
@@ -56,5 +59,62 @@ def test_delete_room_raises_management_exception(mock_create_livekit_client):
 
     with pytest.raises(RoomManagementException):
         RoomManagement().delete_room("room-abc")
+
+    mock_api.aclose.assert_awaited_once()
+
+
+@mock.patch("core.services.room_management.utils.create_livekit_client")
+def test_get_participants_count_reads_livekit(mock_create_livekit_client):
+    """The count is the one LiveKit reports for the room."""
+    mock_api = mock.MagicMock()
+    mock_api.room.list_rooms = mock.AsyncMock(
+        return_value=ListRoomsResponse(
+            rooms=[LiveKitRoom(name="room-abc", num_participants=3)]
+        )
+    )
+    mock_api.aclose = mock.AsyncMock()
+    mock_create_livekit_client.return_value = mock_api
+
+    assert RoomManagement().get_participants_count("room-abc") == 3
+
+    request = mock_api.room.list_rooms.await_args.args[0]
+    assert list(request.names) == ["room-abc"]
+    mock_api.aclose.assert_awaited_once()
+
+
+@mock.patch("core.services.room_management.utils.create_livekit_client")
+def test_get_participants_count_of_a_room_livekit_does_not_know(
+    mock_create_livekit_client,
+):
+    """A room LiveKit has never created has nobody in it."""
+    mock_api = mock.MagicMock()
+    mock_api.room.list_rooms = mock.AsyncMock(return_value=ListRoomsResponse(rooms=[]))
+    mock_api.aclose = mock.AsyncMock()
+    mock_create_livekit_client.return_value = mock_api
+
+    assert RoomManagement().get_participants_count("room-abc") == 0
+
+    mock_api.aclose.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        TwirpError("internal", "boom", status=500),
+        aiohttp.ClientConnectorError(mock.Mock(), OSError("connection refused")),
+    ],
+)
+@mock.patch("core.services.room_management.utils.create_livekit_client")
+def test_get_participants_count_raises_management_exception(
+    mock_create_livekit_client, error
+):
+    """A refusal and an unreachable server both fail the same way."""
+    mock_api = mock.MagicMock()
+    mock_api.room.list_rooms = mock.AsyncMock(side_effect=error)
+    mock_api.aclose = mock.AsyncMock()
+    mock_create_livekit_client.return_value = mock_api
+
+    with pytest.raises(RoomManagementException):
+        RoomManagement().get_participants_count("room-abc")
 
     mock_api.aclose.assert_awaited_once()

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -359,6 +359,11 @@ class Base(Configuration):
                 environ_name="CONNECTION_TEST_THROTTLE_RATES",
                 environ_prefix=None,
             ),
+            "participants_count": values.Value(
+                default="60/minute",
+                environ_name="PARTICIPANTS_COUNT_THROTTLE_RATES",
+                environ_prefix=None,
+            ),
         },
     }
     MONITORED_THROTTLE_FAILURE_CALLBACK = (

--- a/src/frontend/src/api/queryKeys.ts
+++ b/src/frontend/src/api/queryKeys.ts
@@ -3,6 +3,7 @@ export const keys = {
   room: 'room',
   config: 'config',
   requestEntry: 'requestEntry',
+  participantsCount: 'participantsCount',
   waitingParticipants: 'waitingParticipants',
   roomCreationCallback: 'roomCreationCallback',
   files: 'files',

--- a/src/frontend/src/features/rooms/api/fetchParticipantsCount.ts
+++ b/src/frontend/src/features/rooms/api/fetchParticipantsCount.ts
@@ -1,0 +1,8 @@
+import { fetchApi } from '@/api/fetchApi'
+
+export type ApiParticipantsCount = {
+  count: number
+}
+
+export const fetchParticipantsCount = ({ roomId }: { roomId: string }) =>
+  fetchApi<ApiParticipantsCount>(`/rooms/${roomId}/participants-count/`)

--- a/src/frontend/src/features/rooms/components/JoinParticipantsCount.tsx
+++ b/src/frontend/src/features/rooms/components/JoinParticipantsCount.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next'
+import { Text } from '@/primitives'
+import { useParticipantsCount } from '../hooks/useParticipantsCount'
+
+/**
+ * Isolated from the join form so the poll re-renders this line alone, and never
+ * the name field someone is typing in.
+ */
+export const JoinParticipantsCount = ({ roomId }: { roomId: string }) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'join.participants' })
+  const count = useParticipantsCount(roomId)
+
+  if (count === undefined) {
+    return null
+  }
+
+  return (
+    <Text as="p" variant="note" centered role="status" margin="sm">
+      {count === 0 ? t('empty') : t('count', { count })}
+    </Text>
+  )
+}

--- a/src/frontend/src/features/rooms/components/Lobby.tsx
+++ b/src/frontend/src/features/rooms/components/Lobby.tsx
@@ -18,6 +18,7 @@ import { fetchRoom } from '../api/fetchRoom'
 import { ApiAccessLevel } from '../api/ApiRoom'
 import { ApiLobbyStatus, type ApiRequestEntry } from '../api/requestEntry'
 import { useLobby } from '../hooks/useLobby'
+import { JoinParticipantsCount } from './JoinParticipantsCount'
 
 export const Lobby = ({
   roomId,
@@ -143,6 +144,7 @@ export const Lobby = ({
             <H lvl={1} margin="sm" centered>
               {t('heading')}
             </H>
+            <JoinParticipantsCount roomId={roomId} />
             {(!isLoggedIn ||
               configData?.authenticated_users_can_edit_display_name) && (
               <Field

--- a/src/frontend/src/features/rooms/hooks/useParticipantsCount.ts
+++ b/src/frontend/src/features/rooms/hooks/useParticipantsCount.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+import { keys } from '@/api/queryKeys'
+import { fetchParticipantsCount } from '../api/fetchParticipantsCount'
+
+export const POLL_INTERVAL_MS = 5000
+
+/**
+ * How many people are in the meeting, refreshed while the join screen is open.
+ *
+ * The answer is `undefined` until it arrives, and stays `undefined` for a room
+ * the API will not report on, which is every room the caller cannot enter
+ * without approval.
+ */
+export const useParticipantsCount = (roomId: string) => {
+  const { data } = useQuery({
+    queryKey: [keys.participantsCount, roomId],
+    queryFn: () => fetchParticipantsCount({ roomId }),
+    // A room that refuses once refuses for as long as this screen is open, so
+    // the poll stops rather than asking every five seconds for nothing.
+    refetchInterval: (query) => (query.state.error ? false : POLL_INTERVAL_MS),
+    retry: false,
+  })
+
+  return data?.count
+}

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -62,6 +62,11 @@
     "toggleOn": "Klicken, um einzuschalten",
     "usernameHint": "Wird anderen Teilnehmenden angezeigt",
     "usernameLabel": "Dein Name",
+    "participants": {
+      "empty": "Es ist noch niemand beigetreten",
+      "count_one": "{{count}} Person ist bereits da",
+      "count_other": "{{count}} Personen sind bereits da"
+    },
     "errors": {
       "usernameEmpty": "Dein Name darf nicht leer sein"
     },

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -62,6 +62,11 @@
     "toggleOn": "Click to turn on",
     "usernameHint": "Shown to other participants",
     "usernameLabel": "Your name",
+    "participants": {
+      "empty": "No one has joined yet",
+      "count_one": "{{count}} person is already here",
+      "count_other": "{{count}} people are already here"
+    },
     "errors": {
       "usernameEmpty": "Your name cannot be empty"
     },

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -62,6 +62,11 @@
     "toggleOn": "Cliquez pour activer",
     "usernameHint": "Affiché aux autres participants",
     "usernameLabel": "Votre nom",
+    "participants": {
+      "empty": "Personne n'a encore rejoint",
+      "count_one": "{{count}} personne est déjà là",
+      "count_other": "{{count}} personnes sont déjà là"
+    },
     "errors": {
       "usernameEmpty": "Votre nom ne peut pas être vide"
     },

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -62,6 +62,11 @@
     "toggleOn": "Klik om in te schakelen",
     "usernameHint": "Getoond aan andere deelnemers",
     "usernameLabel": "Uw naam",
+    "participants": {
+      "empty": "Er heeft nog niemand deelgenomen",
+      "count_one": "{{count}} deelnemer is er al",
+      "count_other": "{{count}} deelnemers zijn er al"
+    },
     "errors": {
       "usernameEmpty": "Uw naam kan niet leeg zijn"
     },


### PR DESCRIPTION
The join screen asks for a name and previews the camera, and says nothing about the meeting behind it. Whoever arrives cannot tell whether the meeting has started, or whether the people they came for are there. Finding out means joining, which everyone inside sees and hears.

The screen now states how many people are in the meeting, and follows the meeting while it is open.

Filmed against this branch on a local instance. The panel under the page is the media server's own roster, read over `ListParticipants` beside what the screen says, and the stretch where the fourth browser boots runs at 12x.

![the join screen of a meeting three people are already in: it reads "3 people are already here", a fourth person joins, the line becomes "4 people are already here" with nothing reloaded, and the four are on screen one click later](https://raw.githubusercontent.com/davd-gzl/agent-artifact/main/meet/who-is-in-the-meeting/count-only.gif)

`GET /rooms/<id>/participants-count/` answers with the count the media server keeps for the room, which [already leaves out every agent and recorder](https://github.com/livekit/livekit/blob/v1.13.5/pkg/rtc/room.go#L1582-L1585). It answers only the people the room would let in without approval, the rule `retrieve` applies before minting a token, lifted to `Room.is_joinable_by` so the two cannot drift. Anyone who would have to wait for approval sees the screen exactly as before.

A media server that cannot be reached answers 503 and the line is absent, rather than a 500 on every poll. The browser asks again every five seconds, and stops once it has been refused.

This is the first of the two shapes [#1611](https://github.com/suitenumerique/meet/issues/1611) describes. The second, the count with the names, is open at https://github.com/davd-gzl/meet/pull/8; choosing it changes this endpoint's payload and this one component.

Left out on purpose: no feature flag, no cache in front of the media server, and nobody waiting for approval is told the count.
