### PR TITLE
🐛(frontend) clear raised hand position when participant disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(frontend) clear raised hand position when participant disconnects
 - 📝(docs) fix minor typos in comments and docstrings
 - ⬆️(backend) bump sqlparse from 0.5.5 to 0.6.0
 

--- a/src/frontend/src/features/rooms/livekit/hooks/useRaisedHand.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useRaisedHand.ts
@@ -24,7 +24,10 @@ export function useRaisedHandPosition({ participant }: useRaisedHandProps) {
   })
 
   const remoteParticipants = useRemoteParticipants({
-    updateOnlyOn: [RoomEvent.ParticipantAttributesChanged],
+    updateOnlyOn: [
+      RoomEvent.ParticipantAttributesChanged,
+      RoomEvent.ParticipantDisconnected,
+    ],
   })
 
   const raisedHands = useMemo(() => {


### PR DESCRIPTION
## Problem
Participants who disconnect while their hand is raised remain in the
raised-hand queue until an unrelated ParticipantAttributesChanged
event fires elsewhere. This produces incorrect positionInQueue values
for remaining participants and can leave the "first in queue" tile
highlight (RaisedHandMetadataWrapper) stuck on the wrong or a
now-disconnected participant.

## Root cause
useRaisedHandPosition (src/frontend/src/features/rooms/livekit/hooks/useRaisedHand.ts)
uses useRemoteParticipants({ updateOnlyOn: [RoomEvent.ParticipantAttributesChanged] }),
which does not recompute when a participant disconnects.

## Fix
Added RoomEvent.ParticipantDisconnected to updateOnlyOn so the remote
participants list — and therefore the raised-hand queue — updates
immediately when someone leaves.

## Testing
Verified on a two-participant setup: Participant A raised their hand
(queue position and highlight visible to Participant B), then A
disconnected without lowering their hand. B's view updated
immediately, clearing the stale queue entry — confirming the fix
resolves the reported issue.

