### PR TITLE
🩹(frontend) stop declaring @mediapipe as a direct dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 
 - 📝(docs) fix minor typos in comments and docstrings
 - ⬆️(backend) bump sqlparse from 0.5.5 to 0.6.0
+- 🩹(frontend) stop declaring @mediapipe as a direct dependency
 
 ## [1.27.0] - 2026-08-14
 

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -15,7 +15,6 @@
         "@livekit/components-react": "2.9.23",
         "@livekit/components-styles": "1.2.0",
         "@livekit/track-processors": "0.7.2",
-        "@mediapipe/tasks-vision": "0.10.14",
         "@pandacss/preset-panda": "1.11.3",
         "@react-types/overlays": "3.10.0",
         "@remixicon/react": "4.9.0",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -22,7 +22,6 @@
     "@livekit/components-react": "2.9.23",
     "@livekit/components-styles": "1.2.0",
     "@livekit/track-processors": "0.7.2",
-    "@mediapipe/tasks-vision": "0.10.14",
     "@pandacss/preset-panda": "1.11.3",
     "@react-types/overlays": "3.10.0",
     "@remixicon/react": "4.9.0",


### PR DESCRIPTION
@mediapipe is a transitive dependency, brought in by @livekit/track-processors. It was mistakenly declared as a direct dependency in the frontend to make it easier to copy and serve its static assets through nginx.

Doing so pinned our own version of @mediapipe alongside the one resolved through @livekit/track-processors, which could lead to a dependency conflict.

Rely on the version declared by @livekit/track-processors instead, so the two stay in sync automatically.

