### PR TITLE
💡(frontend) warn in vite config on MediaPipe asset/track-processor drift

### DIFF
--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -5,15 +5,25 @@ import { visualizer } from 'rollup-plugin-visualizer'
 import svgr from 'vite-plugin-svgr'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
-const mediapipeVersion: string = JSON.parse(
-  readFileSync(
-    new URL(
-      './node_modules/@mediapipe/tasks-vision/package.json',
-      import.meta.url
-    ),
-    'utf-8'
-  )
+const readPackageJson = (path: string) =>
+  JSON.parse(readFileSync(new URL(path, import.meta.url), 'utf-8'))
+
+const mediapipeVersion: string = readPackageJson(
+  './node_modules/@mediapipe/tasks-vision/package.json'
 ).version
+
+const livekitMediapipeVersion: string = readPackageJson(
+  './node_modules/@livekit/track-processors/package.json'
+).dependencies['@mediapipe/tasks-vision']
+
+if (mediapipeVersion !== livekitMediapipeVersion) {
+  throw new Error(
+    `@mediapipe/tasks-vision@${mediapipeVersion} is installed, but ` +
+      `@livekit/track-processors declares "${livekitMediapipeVersion}". ` +
+      `The two must stay in sync: pin "@mediapipe/tasks-vision" to ` +
+      `"${livekitMediapipeVersion}" in package.json.`
+  )
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
Add a build-time warning in the Vite config that fires when the MediaPipe assets copied by `vite-plugin-static-copy` fall out of sync with the version used by `@livekit/track-processors`.

This catches at build time the kind of drift that would otherwise only surface at runtime as broken virtual backgrounds.
