### PR TITLE
🔇(frontend) suppress leaked WebSocket error events from livekit-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to
 - 🐛(frontend) handle device-in-use errors on Chrome / Windows 10
 - 🐛(frontend) handle Firefox/Windows AbortError on device start
 - 🐛(frontend) treat "Timeout starting source" AbortError as device-in-use
+- 🔇(frontend) suppress leaked WebSocket error events from livekit-client
 
 ## [1.27.0] - 2026-08-14
 

--- a/src/frontend/src/features/analytics/exceptionFilters.ts
+++ b/src/frontend/src/features/analytics/exceptionFilters.ts
@@ -2,6 +2,12 @@ import type { CaptureResult } from 'posthog-js'
 
 const IGNORED_EXCEPTION_PATTERNS = [
   /ResizeObserver loop (completed with undelivered notifications|limit exceeded)/,
+  // livekit-client leaks the raw WebSocket error Event as an unhandled
+  // rejection when the signal ws errors after connect (Firefox-heavy,
+  // coincides with signal reconnects). Carries zero diagnostic content —
+  // the close reason is already logged by the SDK.
+  // See: https://github.com/livekit/client-sdk-js/issues/2062
+  /^Event captured as exception with keys: isTrusted$/,
 ]
 
 const shouldIgnoreException = (value: unknown): boolean =>


### PR DESCRIPTION
livekit-client leaks the raw WebSocket error Event as an unhandled rejection when the signal WebSocket errors after connect. This is mostly seen on Firefox and coincides with signal reconnects.

The event carries zero diagnostic content — the close reason is already logged by the SDK — so it only adds noise to error tracking.

Filter it out from our reporting.

Upstream issue: https://github.com/livekit/client-sdk-js/issues/2062
