### PR TITLE
🌐(i18n) add Spanish language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(agent) support Voxtral realtime as inference engine
+- 🌐(i18n) add Spanish language support
 
 ### Changed
 

--- a/src/backend/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/backend/locale/de_DE/LC_MESSAGES/django.po
@@ -677,3 +677,7 @@ msgstr "Niederländisch"
 #: meet/settings.py:231
 msgid "German"
 msgstr "Deutsch"
+
+#: meet/settings.py:232
+msgid "Spanish"
+msgstr "Spanisch"

--- a/src/backend/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/backend/locale/de_DE/LC_MESSAGES/django.po
@@ -678,6 +678,6 @@ msgstr "Niederländisch"
 msgid "German"
 msgstr "Deutsch"
 
-#: meet/settings.py:232
+#: meet/settings.py:233
 msgid "Spanish"
 msgstr "Spanisch"

--- a/src/backend/locale/en_US/LC_MESSAGES/django.po
+++ b/src/backend/locale/en_US/LC_MESSAGES/django.po
@@ -672,3 +672,7 @@ msgstr "Dutch"
 #: meet/settings.py:231
 msgid "German"
 msgstr "German"
+
+#: meet/settings.py:232
+msgid "Spanish"
+msgstr "Spanish"

--- a/src/backend/locale/en_US/LC_MESSAGES/django.po
+++ b/src/backend/locale/en_US/LC_MESSAGES/django.po
@@ -673,6 +673,6 @@ msgstr "Dutch"
 msgid "German"
 msgstr "German"
 
-#: meet/settings.py:232
+#: meet/settings.py:233
 msgid "Spanish"
 msgstr "Spanish"

--- a/src/backend/locale/es_ES/LC_MESSAGES/django.po
+++ b/src/backend/locale/es_ES/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: core/admin.py:67
 msgid "Personal info"
-msgstr "Información personal"
+msgstr "Datos Personales"
 
 #: core/admin.py:80
 msgid "Permissions"
@@ -35,19 +35,20 @@ msgstr "Contenido"
 
 #: core/admin.py:217
 msgid "Deletion"
-msgstr "Eliminación"
+msgstr "Eliminar Salas"
 
 #: core/admin.py:226
 msgid "Derived info"
-msgstr "Información derivada"
+msgstr ""
 
 #: core/admin.py:237
+# 'Marcas de tiempo' is a bad translation for spanish
 msgid "Timestamps"
-msgstr "Marcas de tiempo"
+msgstr "" 
 
 #: core/admin.py:240
 msgid "File preview"
-msgstr "Vista previa del archivo"
+msgstr "Vista previa"
 
 #: core/admin.py:300 core/admin.py:443
 msgid "No owner"
@@ -97,7 +98,7 @@ msgstr "Se han omitido %(count)s grabación(es) con un estado no elegible."
 
 #: core/admin.py:510
 msgid "No scopes"
-msgstr "Sin ámbitos"
+msgstr ""
 
 #: core/admin.py:512
 msgid "Scopes"
@@ -109,7 +110,7 @@ msgstr "Yo soy el creador"
 
 #: core/api/serializers.py:89
 msgid "You must be administrator or owner of a room to add accesses to it."
-msgstr "Debes ser administrador o propietario de una sala para añadirle accesos."
+msgstr "Debes ser administrador o propietario de una reunión para añadirle accesos."
 
 #: core/api/serializers.py:534
 msgid "This file extension is not allowed."
@@ -132,6 +133,7 @@ msgid "Owner"
 msgstr "Propietario"
 
 #: core/models.py:55
+# To check here and following lines for gender agreement (Masculine/Feminine)
 msgid "Initiated"
 msgstr "Iniciada"
 
@@ -161,15 +163,15 @@ msgstr "Error al detener"
 
 #: core/models.py:62
 msgid "Notification succeeded"
-msgstr "Notificación correcta"
+msgstr "Notificado correctamente"
 
 #: core/models.py:65
 msgid "External process successful"
-msgstr "Proceso externo: correcto"
+msgstr "Proceso externo finalizado correctamente"
 
 #: core/models.py:67
 msgid "External process failed"
-msgstr "Proceso externo: error"
+msgstr "Error en el Proceso externo"
 
 #: core/models.py:96
 msgid "SCREEN_RECORDING"
@@ -185,7 +187,7 @@ msgstr "Acceso público"
 
 #: core/models.py:104
 msgid "Trusted Access"
-msgstr "Acceso de confianza"
+msgstr "Acceso usuarios autorizados"
 
 #: core/models.py:105
 msgid "Restricted Access"
@@ -233,7 +235,7 @@ msgstr "Opcional para los usuarios pendientes; obligatorio al activar la cuenta.
 
 #: core/models.py:168
 msgid "identity email address"
-msgstr "dirección de correo electrónico de identidad"
+msgstr "dirección de correo electrónico"
 
 #: core/models.py:173
 msgid "admin email address"
@@ -253,7 +255,7 @@ msgstr "idioma"
 
 #: core/models.py:184
 msgid "The language in which the user wants to see the interface."
-msgstr "El idioma en el que el usuario quiere ver la interfaz."
+msgstr "El idioma preferido de interfaz."
 
 #: core/models.py:190
 msgid "The timezone in which the user wants to see times."
@@ -269,7 +271,7 @@ msgstr "Si el usuario es un dispositivo o un usuario real."
 
 #: core/models.py:198
 msgid "staff status"
-msgstr "estado de miembro del personal"
+msgstr "estado del personal"
 
 #: core/models.py:200
 msgid "Whether the user can log into this admin site."
@@ -303,11 +305,11 @@ msgstr "Recursos"
 
 #: core/models.py:345
 msgid "Resource access"
-msgstr "Acceso al recurso"
+msgstr "Acceso a recursos"
 
 #: core/models.py:346
 msgid "Resource accesses"
-msgstr "Accesos a los recursos"
+msgstr "Accesos a recursos"
 
 #: core/models.py:352
 msgid "Resource access with this User and Resource already exists."
@@ -315,27 +317,27 @@ msgstr "Ya existe un acceso al recurso con este usuario y este recurso."
 
 #: core/models.py:409
 msgid "Visio room configuration"
-msgstr "Configuración de la sala de videoconferencia"
+msgstr "Configuración de la videoconferencia"
 
 #: core/models.py:410
 msgid "Values for Visio parameters to configure the room."
-msgstr "Valores de los parámetros de videoconferencia para configurar la sala."
+msgstr "Valores de los parámetros de videoconferencia para configurar la reunión."
 
 #: core/models.py:417
 msgid "Room PIN code"
-msgstr "Código PIN de la sala"
+msgstr "Código PIN de la reunión"
 
 #: core/models.py:418
 msgid "Unique n-digit code that identifies this room in telephony mode."
-msgstr "Código único de n dígitos que identifica esta sala en modo telefónico."
+msgstr "Código único de n dígitos que identifica esta reunión en modo telefónico."
 
 #: core/models.py:424 core/models.py:578
 msgid "Room"
-msgstr "Sala"
+msgstr "Reunión"
 
 #: core/models.py:425
 msgid "Rooms"
-msgstr "Salas"
+msgstr "Reuniones"
 
 #: core/models.py:589
 msgid "Worker ID"
@@ -353,7 +355,7 @@ msgstr "Modo de grabación"
 
 #: core/models.py:600
 msgid "Defines the mode of recording being called."
-msgstr "Define el modo de grabación invocado."
+msgstr "Define el modo de grabación a utilizar."
 
 #: core/models.py:605 core/models.py:606
 msgid "Recording options"
@@ -397,23 +399,23 @@ msgstr "Debe definirse el usuario o el equipo, pero no ambos."
 
 #: core/models.py:767
 msgid "Create rooms"
-msgstr "Crear salas"
+msgstr "Crear reunión"
 
 #: core/models.py:768
 msgid "List rooms"
-msgstr "Listar salas"
+msgstr "Listar reuniones"
 
 #: core/models.py:769
 msgid "Retrieve room details"
-msgstr "Ver los detalles de una sala"
+msgstr "Ver los detalles de una reunión"
 
 #: core/models.py:770
 msgid "Update rooms"
-msgstr "Actualizar las salas"
+msgstr "Actualizar las reuniones"
 
 #: core/models.py:771
 msgid "Delete rooms"
-msgstr "Eliminar las salas"
+msgstr "Eliminar las reuniones"
 
 #: core/models.py:784
 msgid "Application name"

--- a/src/backend/locale/es_ES/LC_MESSAGES/django.po
+++ b/src/backend/locale/es_ES/LC_MESSAGES/django.po
@@ -19,181 +19,177 @@ msgstr ""
 
 #: core/admin.py:67
 msgid "Personal info"
-msgstr "Persoonlijke informatie"
+msgstr "Información personal"
 
 #: core/admin.py:80
 msgid "Permissions"
-msgstr "Rechten"
+msgstr "Permisos"
 
 #: core/admin.py:92
 msgid "Important dates"
-msgstr "Belangrijke datums"
+msgstr "Fechas importantes"
 
 #: core/admin.py:206
 msgid "Content"
-msgstr ""
+msgstr "Contenido"
 
 #: core/admin.py:217
-#, fuzzy
-#| msgid "Delete rooms"
 msgid "Deletion"
-msgstr "Ruimtes verwijderen"
+msgstr "Eliminación"
 
 #: core/admin.py:226
 msgid "Derived info"
-msgstr ""
+msgstr "Información derivada"
 
 #: core/admin.py:237
 msgid "Timestamps"
-msgstr ""
+msgstr "Marcas de tiempo"
 
 #: core/admin.py:240
 msgid "File preview"
-msgstr ""
+msgstr "Vista previa del archivo"
 
 #: core/admin.py:300 core/admin.py:443
 msgid "No owner"
-msgstr "Geen eigenaar"
+msgstr "Sin propietario"
 
 #: core/admin.py:303 core/admin.py:446
 msgid "Multiple owners"
-msgstr "Meerdere eigenaren"
+msgstr "Varios propietarios"
 
 #: core/admin.py:316
 msgid "Resend notification to external service"
-msgstr "Melding opnieuw verzenden naar externe dienst"
+msgstr "Reenviar la notificación al servicio externo"
 
 #: core/admin.py:339
 #, python-format
 msgid "Failed to notify for recording %(id)s"
-msgstr "Melding voor opname %(id)s mislukt"
+msgstr "Error al notificar la grabación %(id)s"
 
 #: core/admin.py:347
 #, python-format
 msgid "Failed to notify for recording %(id)s: %(error)s"
-msgstr "Melding voor opname %(id)s mislukt: %(error)s"
+msgstr "Error al notificar la grabación %(id)s: %(error)s"
 
 #: core/admin.py:355
 #, python-format
 msgid "Successfully sent notifications for %(count)s recording(s)."
-msgstr "Meldingen succesvol verzonden voor %(count)s opname(n)."
+msgstr "Notificaciones enviadas correctamente para %(count)s grabación(es)."
 
 #: core/admin.py:363
 #, python-format
 msgid "Skipped %(count)s expired recording(s)."
-msgstr "%(count)s verlopen opname(n) overgeslagen."
+msgstr "Se han omitido %(count)s grabación(es) caducada(s)."
 
 #: core/admin.py:368
 msgid "Mark selected recordings as 'Failed to Stop'"
-msgstr "Geselecteerde opnames markeren als 'Mislukt bij stoppen'"
+msgstr "Marcar las grabaciones seleccionadas como «Error al detener»"
 
 #: core/admin.py:386
 #, python-format
 msgid "%(count)s recording(s) successfully marked as 'Failed to Stop'."
-msgstr "%(count)s opname(s) succesvol gemarkeerd als 'Mislukt bij stoppen'."
+msgstr "%(count)s grabación(es) marcada(s) correctamente como «Error al detener»."
 
 #: core/admin.py:394
-#, fuzzy, python-format
-#| msgid "Skipped %(count)s expired recording(s)."
+#, python-format
 msgid "Skipped %(count)s recording(s) with an ineligible status."
-msgstr "%(count)s opname(s) met een niet-toegestane status overgeslagen."
+msgstr "Se han omitido %(count)s grabación(es) con un estado no elegible."
 
 #: core/admin.py:510
 msgid "No scopes"
-msgstr "Geen scopes"
+msgstr "Sin ámbitos"
 
 #: core/admin.py:512
 msgid "Scopes"
-msgstr "Scopes"
+msgstr "Ámbitos"
 
 #: core/api/filters.py:25
 msgid "Creator is me"
-msgstr "Maker ben ik"
+msgstr "Yo soy el creador"
 
 #: core/api/serializers.py:89
 msgid "You must be administrator or owner of a room to add accesses to it."
-msgstr ""
-"Je moet beheerder of eigenaar van een ruimte zijn om toegang toe te voegen."
+msgstr "Debes ser administrador o propietario de una sala para añadirle accesos."
 
 #: core/api/serializers.py:534
 msgid "This file extension is not allowed."
-msgstr "Deze bestandsextensie is niet toegestaan."
+msgstr "Esta extensión de archivo no está permitida."
 
 #: core/api/viewsets.py:1222
 msgid "You have reached the maximum number of files for this type."
-msgstr "Het maximale aantal bestanden voor dit type is bereikt."
+msgstr "Has alcanzado el número máximo de archivos de este tipo."
 
 #: core/models.py:37
 msgid "Member"
-msgstr "Lid"
+msgstr "Miembro"
 
 #: core/models.py:38
 msgid "Administrator"
-msgstr "Beheerder"
+msgstr "Administrador"
 
 #: core/models.py:39
 msgid "Owner"
-msgstr "Eigenaar"
+msgstr "Propietario"
 
 #: core/models.py:55
 msgid "Initiated"
-msgstr "Gestart"
+msgstr "Iniciada"
 
 #: core/models.py:56
 msgid "Active"
-msgstr "Actief"
+msgstr "Activa"
 
 #: core/models.py:57
 msgid "Stopped"
-msgstr "Gestopt"
+msgstr "Detenida"
 
 #: core/models.py:58
 msgid "Saved"
-msgstr "Opgeslagen"
+msgstr "Guardada"
 
 #: core/models.py:59
 msgid "Aborted"
-msgstr "Afgebroken"
+msgstr "Cancelada"
 
 #: core/models.py:60
 msgid "Failed to Start"
-msgstr "Starten mislukt"
+msgstr "Error al iniciar"
 
 #: core/models.py:61
 msgid "Failed to Stop"
-msgstr "Stoppen mislukt"
+msgstr "Error al detener"
 
 #: core/models.py:62
 msgid "Notification succeeded"
-msgstr "Notificatie geslaagd"
+msgstr "Notificación correcta"
 
 #: core/models.py:65
 msgid "External process successful"
-msgstr "Externe procedure succesvol"
+msgstr "Proceso externo: correcto"
 
 #: core/models.py:67
 msgid "External process failed"
-msgstr "Het externe proces is mislukt."
+msgstr "Proceso externo: error"
 
 #: core/models.py:96
 msgid "SCREEN_RECORDING"
-msgstr "SCHERM_OPNAME"
+msgstr "GRABACIÓN_DE_PANTALLA"
 
 #: core/models.py:97
 msgid "TRANSCRIPT"
-msgstr "TRANSCRIPT"
+msgstr "TRANSCRIPCIÓN"
 
 #: core/models.py:103
 msgid "Public Access"
-msgstr "Openbare toegang"
+msgstr "Acceso público"
 
 #: core/models.py:104
 msgid "Trusted Access"
-msgstr "Vertrouwde toegang"
+msgstr "Acceso de confianza"
 
 #: core/models.py:105
 msgid "Restricted Access"
-msgstr "Beperkte toegang"
+msgstr "Acceso restringido"
 
 #: core/models.py:117
 msgid "id"
@@ -201,31 +197,29 @@ msgstr "id"
 
 #: core/models.py:118
 msgid "primary key for the record as UUID"
-msgstr "primaire sleutel voor het record als UUID"
+msgstr "clave primaria del registro en forma de UUID"
 
 #: core/models.py:124
 msgid "created on"
-msgstr "aangemaakt op"
+msgstr "creado el"
 
 #: core/models.py:125
 msgid "date and time at which a record was created"
-msgstr "datum en tijd waarop een record werd aangemaakt"
+msgstr "fecha y hora en que se creó un registro"
 
 #: core/models.py:130
 msgid "updated on"
-msgstr "bijgewerkt op"
+msgstr "actualizado el"
 
 #: core/models.py:131
 msgid "date and time at which a record was last updated"
-msgstr "datum en tijd waarop een record voor het laatst werd bijgewerkt"
+msgstr "fecha y hora de la última actualización de un registro"
 
 #: core/models.py:151
 msgid ""
 "Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
 "_ characters."
-msgstr ""
-"Voer een geldige sub in. Deze waarde mag alleen letters, cijfers en @/./+/-/"
-"_ tekens bevatten."
+msgstr "Introduce un sub válido. Este valor solo puede contener letras, números y los caracteres @/./+/-/_."
 
 #: core/models.py:157
 msgid "sub"
@@ -235,348 +229,333 @@ msgstr "sub"
 msgid ""
 "Optional for pending users; required upon account activation. 255 characters "
 "or fewer. Letters, numbers, and @/./+/-/_ characters only."
-msgstr ""
-"Optioneel voor gebruikers in afwachting; vereist bij accountactivering. "
-"Maximum 255 tekens. Alleen letters, cijfers en @/./+/-/_ toegestaan."
+msgstr "Opcional para los usuarios pendientes; obligatorio al activar la cuenta. 255 caracteres como máximo. Solo letras, números y los caracteres @/./+/-/_."
 
 #: core/models.py:168
 msgid "identity email address"
-msgstr "identiteit e-mailadres"
+msgstr "dirección de correo electrónico de identidad"
 
 #: core/models.py:173
 msgid "admin email address"
-msgstr "beheerder e-mailadres"
+msgstr "dirección de correo electrónico de administrador"
 
 #: core/models.py:175
 msgid "full name"
-msgstr "volledige naam"
+msgstr "nombre completo"
 
 #: core/models.py:177
 msgid "short name"
-msgstr "korte naam"
+msgstr "nombre corto"
 
 #: core/models.py:183
 msgid "language"
-msgstr "taal"
+msgstr "idioma"
 
 #: core/models.py:184
 msgid "The language in which the user wants to see the interface."
-msgstr "De taal waarin de gebruiker de interface wil zien."
+msgstr "El idioma en el que el usuario quiere ver la interfaz."
 
 #: core/models.py:190
 msgid "The timezone in which the user wants to see times."
-msgstr "De tijdzone waarin de gebruiker tijden wil zien."
+msgstr "La zona horaria en la que el usuario quiere ver las horas."
 
 #: core/models.py:193
 msgid "device"
-msgstr "apparaat"
+msgstr "dispositivo"
 
 #: core/models.py:195
 msgid "Whether the user is a device or a real user."
-msgstr "Of de gebruiker een apparaat is of een echte gebruiker."
+msgstr "Si el usuario es un dispositivo o un usuario real."
 
 #: core/models.py:198
 msgid "staff status"
-msgstr "personeelsstatus"
+msgstr "estado de miembro del personal"
 
 #: core/models.py:200
 msgid "Whether the user can log into this admin site."
-msgstr "Of de gebruiker kan inloggen op deze beheersite."
+msgstr "Si el usuario puede acceder a este sitio de administración."
 
 #: core/models.py:203
 msgid "active"
-msgstr "actief"
+msgstr "activo"
 
 #: core/models.py:206
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
-msgstr ""
-"Of deze gebruiker als actief moet worden behandeld. Deselecteer dit in "
-"plaats van accounts te verwijderen."
+msgstr "Si este usuario debe considerarse activo. Desmarca esta opción en lugar de eliminar cuentas."
 
 #: core/models.py:219
 msgid "user"
-msgstr "gebruiker"
+msgstr "usuario"
 
 #: core/models.py:220
 msgid "users"
-msgstr "gebruikers"
+msgstr "usuarios"
 
 #: core/models.py:286
 msgid "Resource"
-msgstr "Bron"
+msgstr "Recurso"
 
 #: core/models.py:287
 msgid "Resources"
-msgstr "Bronnen"
+msgstr "Recursos"
 
 #: core/models.py:345
 msgid "Resource access"
-msgstr "Brontoegang"
+msgstr "Acceso al recurso"
 
 #: core/models.py:346
 msgid "Resource accesses"
-msgstr "Brontoegangsrechten"
+msgstr "Accesos a los recursos"
 
 #: core/models.py:352
 msgid "Resource access with this User and Resource already exists."
-msgstr "Brontoegang met deze gebruiker en bron bestaat al."
+msgstr "Ya existe un acceso al recurso con este usuario y este recurso."
 
 #: core/models.py:409
 msgid "Visio room configuration"
-msgstr "Visio-ruimteconfiguratie"
+msgstr "Configuración de la sala de videoconferencia"
 
 #: core/models.py:410
 msgid "Values for Visio parameters to configure the room."
-msgstr "Waarden voor Visio-parameters om de ruimte te configureren."
+msgstr "Valores de los parámetros de videoconferencia para configurar la sala."
 
 #: core/models.py:417
 msgid "Room PIN code"
-msgstr "Pincode van de kamer"
+msgstr "Código PIN de la sala"
 
 #: core/models.py:418
 msgid "Unique n-digit code that identifies this room in telephony mode."
-msgstr ""
-"Unieke n-cijferige code die deze kamer identificeert in telefonie-modus."
+msgstr "Código único de n dígitos que identifica esta sala en modo telefónico."
 
 #: core/models.py:424 core/models.py:578
 msgid "Room"
-msgstr "Ruimte"
+msgstr "Sala"
 
 #: core/models.py:425
 msgid "Rooms"
-msgstr "Ruimtes"
+msgstr "Salas"
 
 #: core/models.py:589
 msgid "Worker ID"
-msgstr "Worker ID"
+msgstr "ID del worker"
 
 #: core/models.py:591
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
-msgstr ""
-"Voer een identificatie in voor de worker-opname. Deze ID blijft behouden, "
-"zelfs wanneer de worker stopt, waardoor eenvoudige tracking mogelijk is."
+msgstr "Introduce un identificador para la grabación del worker. Este identificador se conserva incluso cuando el worker se detiene, lo que permite un seguimiento sencillo."
 
 #: core/models.py:599
 msgid "Recording mode"
-msgstr "Opnamemodus"
+msgstr "Modo de grabación"
 
 #: core/models.py:600
 msgid "Defines the mode of recording being called."
-msgstr "Definieert de modus van opname die wordt aangeroepen."
+msgstr "Define el modo de grabación invocado."
 
 #: core/models.py:605 core/models.py:606
 msgid "Recording options"
-msgstr "Opnameopties"
+msgstr "Opciones de grabación"
 
 #: core/models.py:613
 msgid "External Process ID"
-msgstr "Externe proces-ID"
+msgstr "ID del proceso externo"
 
 #: core/models.py:614
 msgid "ID of the external process associated with the recording."
-msgstr "ID van het externe proces dat aan de opname is gekoppeld."
+msgstr "ID del proceso externo asociado a la grabación."
 
 #: core/models.py:620
 msgid "Recording"
-msgstr "Opname"
+msgstr "Grabación"
 
 #: core/models.py:621
 msgid "Recordings"
-msgstr "Opnames"
+msgstr "Grabaciones"
 
 #: core/models.py:731
 msgid "Recording/user relation"
-msgstr "Opname/gebruiker-relatie"
+msgstr "Relación grabación/usuario"
 
 #: core/models.py:732
 msgid "Recording/user relations"
-msgstr "Opname/gebruiker-relaties"
+msgstr "Relaciones grabación/usuario"
 
 #: core/models.py:738
 msgid "This user is already in this recording."
-msgstr "Deze gebruiker is al in deze opname."
+msgstr "Este usuario ya está en esta grabación."
 
 #: core/models.py:744
 msgid "This team is already in this recording."
-msgstr "Dit team is al in deze opname."
+msgstr "Este equipo ya está en esta grabación."
 
 #: core/models.py:750
 msgid "Either user or team must be set, not both."
-msgstr "Ofwel gebruiker of team moet worden ingesteld, niet beide."
+msgstr "Debe definirse el usuario o el equipo, pero no ambos."
 
 #: core/models.py:767
 msgid "Create rooms"
-msgstr "Ruimtes aanmaken"
+msgstr "Crear salas"
 
 #: core/models.py:768
 msgid "List rooms"
-msgstr "Ruimtes weergeven"
+msgstr "Listar salas"
 
 #: core/models.py:769
 msgid "Retrieve room details"
-msgstr "Details van een ruimte ophalen"
+msgstr "Ver los detalles de una sala"
 
 #: core/models.py:770
 msgid "Update rooms"
-msgstr "Ruimtes bijwerken"
+msgstr "Actualizar las salas"
 
 #: core/models.py:771
 msgid "Delete rooms"
-msgstr "Ruimtes verwijderen"
+msgstr "Eliminar las salas"
 
 #: core/models.py:784
 msgid "Application name"
-msgstr "Naam van de applicatie"
+msgstr "Nombre de la aplicación"
 
 #: core/models.py:785
 msgid "Descriptive name for this application."
-msgstr "Beschrijvende naam voor deze applicatie."
+msgstr "Nombre descriptivo de esta aplicación."
 
 #: core/models.py:795
 msgid "Hashed on Save. Copy it now if this is a new secret."
-msgstr ""
-"Wordt gehasht bij het opslaan. Kopieer het nu als dit een nieuw geheim is."
+msgstr "Se cifra al guardar. Cópialo ahora si se trata de un secreto nuevo."
 
 #: core/models.py:806
 msgid "Application"
-msgstr "Applicatie"
+msgstr "Aplicación"
 
 #: core/models.py:807
 msgid "Applications"
-msgstr "Applicaties"
+msgstr "Aplicaciones"
 
 #: core/models.py:830
 msgid "Enter a valid domain"
-msgstr "Voer een geldig domein in"
+msgstr "Introduce un dominio válido"
 
 #: core/models.py:833
 msgid "Domain"
-msgstr "Domein"
+msgstr "Dominio"
 
 #: core/models.py:834
 msgid "Email domain this application can act on behalf of."
-msgstr "E-maildomein namens welke deze applicatie kan handelen."
+msgstr "Dominio de correo electrónico en cuyo nombre puede actuar esta aplicación."
 
 #: core/models.py:846
 msgid "Application domain"
-msgstr "Applicatiedomein"
+msgstr "Dominio de aplicación"
 
 #: core/models.py:847
 msgid "Application domains"
-msgstr "Applicatiedomeinen"
+msgstr "Dominios de aplicación"
 
 #: core/models.py:865
 msgid "Pending"
-msgstr "In afwachting"
+msgstr "Pendiente"
 
 #: core/models.py:866
 msgid "Analyzing"
-msgstr ""
+msgstr "Analizando"
 
 #: core/models.py:873
 msgid "Ready"
-msgstr "Klaar"
+msgstr "Listo"
 
 #: core/models.py:879
 msgid "Background image"
-msgstr "Achtergrondafbeelding"
+msgstr "Imagen de fondo"
 
 #: core/models.py:891
 msgid "title"
-msgstr "Titel"
+msgstr "título"
 
 #: core/models.py:915
 msgid "Malware detection info when the analysis status is unsafe."
-msgstr "Informatie over malwaredetectie wanneer de analysestatus onveilig is."
+msgstr "Información sobre la detección de malware cuando el estado del análisis no es seguro."
 
 #: core/models.py:920
 msgid "File"
-msgstr "Bestand"
+msgstr "Archivo"
 
 #: core/models.py:921
 msgid "Files"
-msgstr "Bestanden"
+msgstr "Archivos"
 
 #: core/models.py:1041
 msgid "This file is already hard deleted."
-msgstr "Dit bestand is al definitief verwijderd."
+msgstr "Este archivo ya se ha eliminado definitivamente."
 
 #: core/models.py:1051
-#, fuzzy
-#| msgid "To hard delete a file, it must first be soft deleted."
 msgid "To hard delete a file, it must first be soft deleted."
-msgstr ""
-"Om een bestand definitief te verwijderen, moet het eerst zacht verwijderd "
-"zijn."
+msgstr "Para eliminar definitivamente un archivo, primero debe haberse marcado como eliminado."
 
 #: core/recording/event/notification.py:123
 msgid "Your recording is ready"
-msgstr "Je opname is klaar"
+msgstr "Tu grabación está lista"
 
 #: core/recording/event/notification.py:194
 msgid "Transcription"
-msgstr "Transcriptie"
+msgstr "Transcripción"
 
 #: core/recording/event/notification.py:204
 #, python-brace-format
 msgid "Meeting \"{room}\" on {room_recording_date} at {room_recording_time}"
-msgstr ""
-"Vergadering \"{room}\" op {room_recording_date} om {room_recording_time}"
+msgstr "Reunión \"{room}\" del {room_recording_date} a las {room_recording_time}"
 
 #: core/services/invitation.py:44
 #, python-brace-format
 msgid "Video call in progress: {sender.email} is waiting for you to connect"
-msgstr "Video-oproep bezig: {sender.email} wacht op je verbinding"
+msgstr "Videollamada en curso: {sender.email} está esperando a que te conectes"
 
 #: core/templates/mail/html/invitation.html:159
 #: core/templates/mail/html/screen_recording.html:159
 #: core/templates/mail/text/invitation.txt:3
 #: core/templates/mail/text/screen_recording.txt:3
 msgid "Logo email"
-msgstr "Logo e-mail"
+msgstr "Logotipo del correo"
 
 #: core/templates/mail/html/invitation.html:189
 #: core/templates/mail/text/invitation.txt:5
 msgid "invites you to join an ongoing video call"
-msgstr "nodigt je uit om deel te nemen aan een lopende video-oproep"
+msgstr "te invita a unirte a una videollamada en curso"
 
 #: core/templates/mail/html/invitation.html:200
 #: core/templates/mail/text/invitation.txt:7
 msgid "JOIN THE CALL"
-msgstr "NEEM DEEL AAN DE OPROEP"
+msgstr "UNIRSE A LA LLAMADA"
 
 #: core/templates/mail/html/invitation.html:227
 #: core/templates/mail/text/invitation.txt:13
 msgid ""
 "If you can't click the button, copy and paste the URL into your browser to "
 "join the call."
-msgstr ""
-"Als je niet op de knop kunt klikken, kopieer en plak dan de URL in je "
-"browser om deel te nemen aan de oproep."
+msgstr "Si no puedes hacer clic en el botón, copia y pega la URL en tu navegador para unirte a la llamada."
 
 #: core/templates/mail/html/invitation.html:235
 #: core/templates/mail/text/invitation.txt:15
 msgid "Tips for a better experience:"
-msgstr "Tips voor een betere ervaring:"
+msgstr "Consejos para una mejor experiencia:"
 
 #: core/templates/mail/html/invitation.html:237
 #: core/templates/mail/text/invitation.txt:17
 msgid "Use Chrome or Firefox for better call quality"
-msgstr "Gebruik Chrome of Firefox voor betere gesprekskwaliteit"
+msgstr "Usa Chrome o Firefox para una mejor calidad de llamada"
 
 #: core/templates/mail/html/invitation.html:238
 #: core/templates/mail/text/invitation.txt:18
 msgid "Test your microphone and camera before joining"
-msgstr "Test je microfoon en camera voordat je deelneemt"
+msgstr "Prueba tu micrófono y tu cámara antes de unirte"
 
 #: core/templates/mail/html/invitation.html:239
 #: core/templates/mail/text/invitation.txt:19
 msgid "Make sure you have a stable internet connection"
-msgstr "Zorg ervoor dat je een stabiele internetverbinding hebt"
+msgstr "Asegúrate de tener una conexión a internet estable"
 
 #: core/templates/mail/html/invitation.html:248
 #: core/templates/mail/html/screen_recording.html:245
@@ -584,12 +563,12 @@ msgstr "Zorg ervoor dat je een stabiele internetverbinding hebt"
 #: core/templates/mail/text/screen_recording.txt:23
 #, python-format
 msgid " Thank you for using %(brandname)s. "
-msgstr " Bedankt voor het gebruik van %(brandname)s. "
+msgstr " Gracias por usar %(brandname)s. "
 
 #: core/templates/mail/html/screen_recording.html:188
 #: core/templates/mail/text/screen_recording.txt:6
 msgid "Your recording is ready!"
-msgstr "Je opname is klaar!"
+msgstr "¡Tu grabación está lista!"
 
 #: core/templates/mail/html/screen_recording.html:195
 #: core/templates/mail/text/screen_recording.txt:8
@@ -597,49 +576,45 @@ msgstr "Je opname is klaar!"
 msgid ""
 " Your recording of \"%(room_name)s\" on %(recording_date)s at "
 "%(recording_time)s is now ready to download. "
-msgstr ""
-" Je opname van \"%(room_name)s\" op %(recording_date)s om %(recording_time)s "
-"is nu klaar om te downloaden. "
+msgstr " Tu grabación de \"%(room_name)s\" del %(recording_date)s a las %(recording_time)s ya está lista para descargar. "
 
 #: core/templates/mail/html/screen_recording.html:195
 #: core/templates/mail/text/screen_recording.txt:8
 #, python-format
 msgid " The recording will expire in %(days)s days. "
-msgstr " De opname verloopt over %(days)s dagen. "
+msgstr " La grabación caducará dentro de %(days)s días. "
 
 #: core/templates/mail/html/screen_recording.html:200
 #: core/templates/mail/text/screen_recording.txt:9
 msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
-msgstr ""
-"Het delen van de opname via een link is nog niet beschikbaar. Alleen "
-"organisatoren kunnen deze downloaden."
+msgstr " Compartir la grabación mediante un enlace todavía no está disponible. Solo los organizadores pueden descargarla. "
 
 #: core/templates/mail/html/screen_recording.html:206
 #: core/templates/mail/text/screen_recording.txt:11
 msgid "To keep this recording permanently:"
-msgstr "Om deze opname permanent te bewaren:"
+msgstr "Para conservar esta grabación de forma permanente:"
 
 #: core/templates/mail/html/screen_recording.html:208
 #, python-format
 msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
-msgstr "Klik op de \"<a href=\"%(link)s\">Openen</a>\"-link hieronder "
+msgstr "Haz clic en el enlace \"<a href=\"%(link)s\">Abrir</a>\" que aparece abajo "
 
 #: core/templates/mail/html/screen_recording.html:209
 #: core/templates/mail/text/screen_recording.txt:14
 msgid "Use the \"Download\" button in the interface "
-msgstr "Gebruik de \"Download\"-knop in de interface "
+msgstr "Usa el botón \"Descargar\" de la interfaz "
 
 #: core/templates/mail/html/screen_recording.html:210
 #: core/templates/mail/text/screen_recording.txt:15
 msgid "Save the file to your preferred location"
-msgstr "Sla het bestand op naar je gewenste locatie"
+msgstr "Guarda el archivo en la ubicación que prefieras"
 
 #: core/templates/mail/html/screen_recording.html:221
 #: core/templates/mail/text/screen_recording.txt:17
 msgid "Open"
-msgstr "Openen"
+msgstr "Abrir"
 
 #: core/templates/mail/html/screen_recording.html:230
 #: core/templates/mail/text/screen_recording.txt:19
@@ -647,32 +622,29 @@ msgstr "Openen"
 msgid ""
 " If you have any questions or need assistance, please contact our support "
 "team at %(support_email)s. "
-msgstr ""
-" Als je vragen hebt of hulp nodig hebt, neem dan contact op met ons support "
-"team via %(support_email)s. "
+msgstr " Si tienes alguna pregunta o necesitas ayuda, ponte en contacto con nuestro equipo de soporte en %(support_email)s. "
 
 #: core/templates/mail/text/screen_recording.txt:13
-#, fuzzy, python-format
-#| msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
+#, python-format
 msgid "Click the \"Open [%(link)s]\" link below "
-msgstr "Klik op de \"<a href=\"%(link)s\">Openen</a>\"-link hieronder "
+msgstr "Haz clic en el enlace \"Abrir [%(link)s]\" que aparece abajo "
 
 #: meet/settings.py:228
 msgid "English"
-msgstr "Engels"
+msgstr "Inglés"
 
 #: meet/settings.py:229
 msgid "French"
-msgstr "Frans"
+msgstr "Francés"
 
 #: meet/settings.py:230
 msgid "Dutch"
-msgstr "Nederlands"
+msgstr "Neerlandés"
 
 #: meet/settings.py:231
 msgid "German"
-msgstr "Duits"
+msgstr "Alemán"
 
 #: meet/settings.py:232
 msgid "Spanish"
-msgstr "Spaans"
+msgstr "Español"

--- a/src/backend/locale/es_ES/LC_MESSAGES/django.po
+++ b/src/backend/locale/es_ES/LC_MESSAGES/django.po
@@ -645,6 +645,6 @@ msgstr "Neerlandés"
 msgid "German"
 msgstr "Alemán"
 
-#: meet/settings.py:232
+#: meet/settings.py:233
 msgid "Spanish"
 msgstr "Español"

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -679,6 +679,6 @@ msgstr "Néerlandais"
 msgid "German"
 msgstr "Allemand"
 
-#: meet/settings.py:232
+#: meet/settings.py:233
 msgid "Spanish"
 msgstr "Espagnol"

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -678,3 +678,7 @@ msgstr "Néerlandais"
 #: meet/settings.py:231
 msgid "German"
 msgstr "Allemand"
+
+#: meet/settings.py:232
+msgid "Spanish"
+msgstr "Espagnol"

--- a/src/backend/locale/nl_NL/LC_MESSAGES/django.po
+++ b/src/backend/locale/nl_NL/LC_MESSAGES/django.po
@@ -673,6 +673,6 @@ msgstr "Nederlands"
 msgid "German"
 msgstr "Duits"
 
-#: meet/settings.py:232
+#: meet/settings.py:233
 msgid "Spanish"
 msgstr "Spaans"

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -230,6 +230,7 @@ class Base(Configuration):
             ("fr-fr", _("French")),
             ("nl-nl", _("Dutch")),
             ("de-de", _("German")),
+            ("es-es", _("Spanish")),
         )
     )
 

--- a/src/frontend/i18next-parser.config.json
+++ b/src/frontend/i18next-parser.config.json
@@ -3,6 +3,6 @@
   "input": ["src/**/*.{ts,tsx}", "!src/styled-system/**/*", "!src/**/*.d.ts"],
   "output": "src/locales/$LOCALE/$NAMESPACE.json",
   "createOldCatalogs": false,
-  "locales": ["en", "fr", "de", "nl"],
+  "locales": ["en", "fr", "de", "nl", "es"],
   "sort": true
 }

--- a/src/frontend/src/i18n/init.ts
+++ b/src/frontend/src/i18n/init.ts
@@ -15,7 +15,7 @@ i18n
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({
-    supportedLngs: ['en', 'fr', 'nl', 'de'],
+    supportedLngs: ['en', 'fr', 'nl', 'de', 'es'],
     fallbackLng,
     ns: i18nDefaultNamespace,
     detection: {

--- a/src/frontend/src/i18n/useLanguageLabels.ts
+++ b/src/frontend/src/i18n/useLanguageLabels.ts
@@ -5,6 +5,7 @@ const languageLabels: Record<string, string> = {
   fr: 'Français',
   de: 'Deutsch',
   nl: 'Nederlands',
+  es: 'Español',
 }
 
 export const useLanguageLabels = () => {

--- a/src/frontend/src/locales/es/accessibility.json
+++ b/src/frontend/src/locales/es/accessibility.json
@@ -1,0 +1,34 @@
+{
+  "accessibility": {
+    "title": "Accesibilidad",
+    "introduction": "<i>Visio</i> se compromete a hacer accesibles sus servicios digitales, de conformidad con el artículo 47 de la ley n.º 2005-102 de 11 de febrero de 2005.",
+    "declaration": {
+      "title": "Declaración de accesibilidad",
+      "date": "Redactada el 4 de diciembre de 2024."
+    },
+    "scope": "Esta declaración de accesibilidad se aplica al sitio visio.numerique.gouv.fr",
+    "complianceStatus": {
+      "title": "Estado de conformidad",
+      "body": "visio.numerique.gouv.fr no es conforme con el RGAA 4.1. El sitio todavía no ha sido auditado. No obstante, el equipo trabaja para crear un sitio accesible para todo el mundo siguiendo las recomendaciones del RGAA."
+    },
+    "improvement": {
+      "title": "Mejora y contacto",
+      "body": "Si no consigues acceder a un contenido o a un servicio, puedes ponerte en contacto con el responsable de lasuite.numerique.gouv.fr para que te oriente hacia una alternativa accesible u obtener el contenido en otro formato.",
+      "contact": {
+        "email": "Correo electrónico: visio@numerique.gouv.fr",
+        "address": "Dirección: DINUM, 20 avenue de Ségur 75007 París"
+      },
+      "response": "Intentamos responder en un plazo de 2 días laborables."
+    },
+    "recourse": {
+      "title": "Vía de recurso",
+      "introduction": "Este procedimiento debe utilizarse en el siguiente caso: has comunicado al responsable del sitio web un defecto de accesibilidad que te impide acceder a un contenido o a uno de los servicios del portal y no has obtenido una respuesta satisfactoria.",
+      "options": {
+        "intro": "Puedes:",
+        "option1": "Escribir un mensaje al Defensor de Derechos",
+        "option2": "Ponerte en contacto con el delegado del Defensor de Derechos de tu región",
+        "option3": "Enviar una carta por correo postal (gratuito, sin sello): </br> Défenseur des droits Libre réponse 71120 75342 Paris CEDEX 07"
+      }
+    }
+  }
+}

--- a/src/frontend/src/locales/es/accessibility.json
+++ b/src/frontend/src/locales/es/accessibility.json
@@ -18,7 +18,7 @@
         "email": "Correo electrónico: visio@numerique.gouv.fr",
         "address": "Dirección: DINUM, 20 avenue de Ségur 75007 París"
       },
-      "response": "Intentamos responder en un plazo de 2 días laborables."
+      "response": "Intentamos responder en un plazo de 2 días laborales."
     },
     "recourse": {
       "title": "Vía de recurso",

--- a/src/frontend/src/locales/es/connectionTest.json
+++ b/src/frontend/src/locales/es/connectionTest.json
@@ -46,9 +46,9 @@
     "passedHint": "Tu navegador, tus dispositivos y tu red están listos para una reunión.",
     "partial": "Prueba parcial",
     "partialHint": "Se han omitido algunas comprobaciones. Autoriza el acceso a tu cámara y a tu micrófono para probarlos.",
-    "failed_one": "{{count}} comprobación con errores",
-    "failed_other": "{{count}} comprobaciones con errores",
-    "failedHint": "Abre las comprobaciones con errores para ver el detalle y transmite después el informe a tu servicio informático."
+    "failed_one": "{{count}} verificación en error",
+    "failed_other": "{{count}} verificaciones en error",
+    "failedHint": "Abre las verificaciones en error para ver el detalle y transmite después el informe a tu servicio informático."
   },
   "help": {
     "firewall": "Si las pruebas de red fallan, comprueba los permisos de tu navegador y las reglas de filtrado de red (WebRTC, WebSocket, TURN) con tu servicio informático."

--- a/src/frontend/src/locales/es/connectionTest.json
+++ b/src/frontend/src/locales/es/connectionTest.json
@@ -1,0 +1,56 @@
+{
+  "title": "Prueba tu configuración",
+  "runTest": "Iniciar la prueba",
+  "runAgain": "Repetir",
+  "cancel": "Cancelar",
+  "detailsFor": "Detalles del paso {{step}}",
+  "downloadReport": "Descargar el informe",
+  "homeLink": "Prueba tu configuración",
+  "progress": "{{done}}/{{total}}",
+  "progressLabel": "Progreso de la prueba de conexión",
+  "groups": {
+    "local": "Navegador y dispositivos",
+    "network": "Conexión al servidor"
+  },
+  "steps": {
+    "browser": "Navegador",
+    "microphone": "Micrófono",
+    "camera": "Cámara",
+    "devices": "Dispositivos multimedia",
+    "websocket": "WebSocket",
+    "webrtc": "WebRTC",
+    "turn": "TURN",
+    "reconnect": "Reconexión",
+    "selectedCandidate": "Ruta seleccionada",
+    "publishAudio": "Publicación de audio",
+    "publishVideo": "Publicación de vídeo"
+  },
+  "status": {
+    "pending": "En espera",
+    "running": "En curso…",
+    "success": "Correcto",
+    "failed": "Error",
+    "skipped": "Omitido"
+  },
+  "counts": {
+    "passed": "correctas",
+    "failed": "con errores",
+    "skipped": "omitidas"
+  },
+  "summary": {
+    "idle": "Listo para la prueba",
+    "idleHint": "La prueba dura aproximadamente un minuto. Tu cámara y tu micrófono solo se utilizan durante la prueba.",
+    "running": "Prueba en curso…",
+    "runningHint": "Mantén esta página abierta hasta que terminen las comprobaciones.",
+    "passed": "Todo funciona",
+    "passedHint": "Tu navegador, tus dispositivos y tu red están listos para una reunión.",
+    "partial": "Prueba parcial",
+    "partialHint": "Se han omitido algunas comprobaciones. Autoriza el acceso a tu cámara y a tu micrófono para probarlos.",
+    "failed_one": "{{count}} comprobación con errores",
+    "failed_other": "{{count}} comprobaciones con errores",
+    "failedHint": "Abre las comprobaciones con errores para ver el detalle y transmite después el informe a tu servicio informático."
+  },
+  "help": {
+    "firewall": "Si las pruebas de red fallan, comprueba los permisos de tu navegador y las reglas de filtrado de red (WebRTC, WebSocket, TURN) con tu servicio informático."
+  }
+}

--- a/src/frontend/src/locales/es/global.json
+++ b/src/frontend/src/locales/es/global.json
@@ -1,0 +1,62 @@
+{
+  "backToHome": "Volver al inicio",
+  "cancel": "Cancelar",
+  "closeDialog": "Cerrar la ventana modal",
+  "error": {
+    "heading": "Se ha producido un error al cargar la página"
+  },
+  "feedback": {
+    "context": "¡Tu opinión es fundamental!",
+    "cta": "Comparte tu opinión - nueva ventana"
+  },
+  "forbidden": {
+    "heading": "Acceso denegado"
+  },
+  "loading": "Cargando…",
+  "loggedInUserTooltip": "Con la sesión iniciada como ",
+  "login": {
+    "buttonLabel": "Iniciar sesión",
+    "proconnectButtonLabel": "Identificarse con ProConnect",
+    "proconnectLinkLabel": "¿Qué es ProConnect? - nueva ventana",
+    "proconnectLink": "¿Qué es ProConnect?"
+  },
+  "logout": "Cerrar sesión",
+  "notFound": {
+    "heading": "Comprueba tu código de reunión",
+    "body": "Comprueba que has introducido el código de reunión correcto en la URL. Ejemplo:"
+  },
+  "selected": "seleccionado",
+  "submit": "Aceptar",
+  "footer": {
+    "links": {
+      "legifrance": "legifrance.gouv.fr",
+      "infogouv": "info.gouv.fr",
+      "servicepublic": "service-public.fr",
+      "datagouv": "data.gouv.fr",
+      "legalsTerms": "Aviso legal",
+      "data": "Datos personales y cookies",
+      "accessibility": "Accesibilidad: no conforme",
+      "connectionTest": "Prueba tu configuración",
+      "ariaLabel": "nueva ventana",
+      "codeAnnotation": "Nuestro código es abierto y está disponible en este",
+      "code": "repositorio de código abierto",
+      "technicalDetails": "Ficha técnica",
+      "termsOfService": "Condiciones de uso"
+    },
+    "mentions": "Salvo que se indique lo contrario, los contenidos de este sitio están disponibles bajo",
+    "license": "licencia etalab 2.0"
+  },
+  "loginHint": {
+    "title": "Inicia sesión con tu cuenta",
+    "body": "En lugar de esperar, inicia sesión con tu cuenta.",
+    "button": {
+      "ariaLabel": "Cerrar la sugerencia",
+      "label": "Aceptar"
+    }
+  },
+  "skipLink": "Ir al contenido principal",
+  "clipboardContent": {
+    "url": "Para participar en la videoconferencia, haz clic en este enlace: {{roomUrl}}",
+    "numberAndPin": "Para participar por teléfono, marca el {{phoneNumber}} e introduce este código: {{pinCode}}"
+  }
+}

--- a/src/frontend/src/locales/es/home.json
+++ b/src/frontend/src/locales/es/home.json
@@ -1,0 +1,63 @@
+{
+  "createMeeting": "Crear una reunión",
+  "heading": "Videoconferencias sencillas y seguras",
+  "intro": "Comunícate y trabaja con total sencillez, sin renunciar a tu soberanía",
+  "joinInputError": "Introduce un enlace o un código de reunión. Ejemplos:",
+  "joinInputExample": "Un código de reunión tiene este aspecto: abc-defg-hij",
+  "joinInputLabel": "Enlace completo o código de la reunión",
+  "joinInputSubmit": "Unirse a la reunión",
+  "joinMeeting": "Unirse a una reunión",
+  "joinMeetingTipContent": "Puedes unirte a una reunión copiando directamente su enlace completo en la barra de direcciones del navegador.",
+  "joinMeetingTipHeading": "Consejo",
+  "loginToCreateMeeting": "Inicia sesión para crear una reunión",
+  "moreLinkLabel": "Más información sobre {{appTitle}} - nueva ventana",
+  "moreLink": "Más información",
+  "moreAbout": "sobre {{appTitle}}",
+  "connectionTestLink": "Prueba tu configuración",
+  "createMenu": {
+    "laterOption": "Crear una reunión para una fecha posterior",
+    "instantOption": "Iniciar una reunión instantánea"
+  },
+  "laterMeetingDialog": {
+    "heading": "Tus datos de conexión",
+    "description": "Comparte estos datos con los invitados. Podrán unirse a la reunión sin necesidad de iniciar sesión. Esta reunión es permanente y puede reutilizarse.",
+    "permissions": "Las personas que dispongan de este enlace no necesitan tu autorización para unirse a esta reunión.",
+    "copy": "Copiar los datos",
+    "copied": "Copiados en el portapapeles",
+    "copyUrl": "Copiar el enlace de la reunión",
+    "phone": {
+      "call": "Llama al:",
+      "pinCode": "Código:"
+    }
+  },
+  "introSlider": {
+    "carouselLabel": "Presentación de diapositivas",
+    "previous": {
+      "label": "Diapositiva anterior",
+      "labelWithPosition": "Diapositiva anterior ({{current}} de {{total}})",
+      "tooltip": "Diapositiva anterior"
+    },
+    "next": {
+      "label": "Diapositiva siguiente",
+      "labelWithPosition": "Diapositiva siguiente ({{current}} de {{total}})",
+      "tooltip": "Diapositiva siguiente"
+    },
+    "slidePosition": "Diapositiva {{current}} de {{total}}",
+    "beta": {
+      "text": "Probar la beta",
+      "tooltip": "Acceder al formulario"
+    },
+    "slide1": {
+      "title": "Pásate a la sencillez. ¡Pruébanos ahora mismo!",
+      "body": "Descubre una solución intuitiva y accesible, diseñada para todos los empleados públicos y sus colaboradores, y mucho más."
+    },
+    "slide2": {
+      "title": "Organiza llamadas de grupo sin límite",
+      "body": "Reuniones sin límite de tiempo, con una comunicación fluida y de alta calidad, sea cual sea el número de participantes."
+    },
+    "slide3": {
+      "title": "Transforma tus reuniones con la IA",
+      "body": "Obtén transcripciones precisas y accionables para impulsar tu productividad. Función en beta, ¡pruébala ahora!"
+    }
+  }
+}

--- a/src/frontend/src/locales/es/home.json
+++ b/src/frontend/src/locales/es/home.json
@@ -1,7 +1,7 @@
 {
   "createMeeting": "Crear una reunión",
   "heading": "Videoconferencias sencillas y seguras",
-  "intro": "Comunícate y trabaja con total sencillez, sin renunciar a tu soberanía",
+  "intro": "Comunícate y trabaja con facilidad, manteniendo siempre el control de tus datos",
   "joinInputError": "Introduce un enlace o un código de reunión. Ejemplos:",
   "joinInputExample": "Un código de reunión tiene este aspecto: abc-defg-hij",
   "joinInputLabel": "Enlace completo o código de la reunión",
@@ -15,8 +15,8 @@
   "moreAbout": "sobre {{appTitle}}",
   "connectionTestLink": "Prueba tu configuración",
   "createMenu": {
-    "laterOption": "Crear una reunión para una fecha posterior",
-    "instantOption": "Iniciar una reunión instantánea"
+    "laterOption": "Crear una reunión para más tarde",
+    "instantOption": "Iniciar una reunión ahora"
   },
   "laterMeetingDialog": {
     "heading": "Tus datos de conexión",
@@ -49,7 +49,7 @@
     },
     "slide1": {
       "title": "Pásate a la sencillez. ¡Pruébanos ahora mismo!",
-      "body": "Descubre una solución intuitiva y accesible, diseñada para todos los empleados públicos y sus colaboradores, y mucho más."
+      "body": "Descubre una solución intuitiva y accesible, pensada para el sector público y todos sus colaboradores."
     },
     "slide2": {
       "title": "Organiza llamadas de grupo sin límite",
@@ -57,7 +57,7 @@
     },
     "slide3": {
       "title": "Transforma tus reuniones con la IA",
-      "body": "Obtén transcripciones precisas y accionables para impulsar tu productividad. Función en beta, ¡pruébala ahora!"
+      "body": "Obtén transcripciones precisas y accionables para impulsar tu productividad. Función experimental, ¡pruébala ahora!"
     }
   }
 }

--- a/src/frontend/src/locales/es/legals.json
+++ b/src/frontend/src/locales/es/legals.json
@@ -1,0 +1,37 @@
+{
+  "title": "Aviso legal",
+  "creator": {
+    "title": "Editor",
+    "body": "El servicio Visio está editado por la Dirección Interministerial de lo Digital del Estado (DINUM), con domicilio en:",
+    "contact": {
+      "title": "Datos de contacto",
+      "address": "20 avenue de Ségur",
+      "city": "75007 París",
+      "phone": "Tel. Recepción: 01.71.21.01.70",
+      "siret": "SIRET: 12000101100010 (secretaría general del gobierno)",
+      "siren": "SIREN: 120 001 011"
+    }
+  },
+  "director": {
+    "title": "Director de la publicación",
+    "body": "La directora de la publicación es la señora Stéphanie Schaer, directora interministerial de lo digital."
+  },
+  "hosting": {
+    "title": "Alojamiento",
+    "body": "El servicio está alojado por Outscale West-1 CloudGouv SecNumCloud, situado en Francia."
+  },
+  "accessibility": {
+    "title": "Accesibilidad",
+    "body": "La conformidad con las normas de accesibilidad digital es un objetivo posterior. El sitio todavía no ha sido auditado. No obstante, el equipo trabaja para crear un sitio accesible para todo el mundo siguiendo las recomendaciones del RGAA.",
+    "more": "Para saber más: ",
+    "link": "enlace a la página de accesibilidad",
+    "status": "Estado de accesibilidad: no conforme"
+  },
+  "reuse": {
+    "title": "Reutilización de los contenidos y enlaces",
+    "body1": "Salvo mención explícita de propiedad intelectual perteneciente a terceros, los contenidos de este sitio se ofrecen bajo ",
+    "license": "licencia abierta Etalab 2.0",
+    "body2": "En particular, eres libre de reproducirlos, copiarlos, modificarlos, extraerlos, transformarlos, comunicarlos, difundirlos, redistribuirlos, publicarlos, transmitirlos y explotarlos siempre que menciones su fuente y su fecha de última actualización, y no induzcas a error a terceros sobre la información que contienen.",
+    "body3": "Todo sitio público o privado está autorizado a establecer, sin autorización previa, un enlace (incluido un enlace profundo) hacia la información difundida en este sitio."
+  }
+}

--- a/src/frontend/src/locales/es/notifications.json
+++ b/src/frontend/src/locales/es/notifications.json
@@ -1,0 +1,66 @@
+{
+  "defaultName": "Un colaborador",
+  "joined": {
+    "description": "{{name}} participa en la llamada"
+  },
+  "raised": {
+    "description": "{{name}} ha levantado la mano.",
+    "cta": "Abrir la lista de espera"
+  },
+  "muted": "{{name}} ha silenciado tu micrófono. Ningún participante puede oírte.",
+  "openChat": "Abrir el chat",
+  "chatMessageReceived": "{{name}} dice: {{message}}",
+  "lowerHand": {
+    "auto": "Parece que has tomado la palabra, así que se va a bajar la mano.",
+    "dismiss": "Dejar la mano levantada"
+  },
+  "autoMuteLargeRoom": {
+    "auto": "Acabas de unirte a una reunión numerosa. Tu micrófono se ha silenciado automáticamente.",
+    "dismiss": "Reactivar el micrófono"
+  },
+  "reaction": {
+    "description": "{{name}} ha reaccionado con {{emoji}}"
+  },
+  "permissionsRemoved": {
+    "camera": "El organizador ha desactivado el vídeo de todos los participantes.",
+    "microphone": "El organizador ha desactivado el micrófono de todos los participantes.",
+    "screen_share": "El organizador ha desactivado la pantalla compartida de todos los participantes."
+  },
+  "waitingParticipants": {
+    "one": "Una persona quiere participar en esta llamada.",
+    "several": "Varias personas quieren participar en esta llamada.",
+    "open": "Mostrar",
+    "accept": "Aceptar"
+  },
+  "transcript": {
+    "started": "{{name}} ha iniciado la transcripción de la reunión.",
+    "stopped": "{{name}} ha detenido la transcripción de la reunión.",
+    "limitReached": "La transcripción ha superado la duración máxima permitida, se va a guardar automáticamente.",
+    "requested": "{{name}} ha solicitado iniciar la transcripción."
+  },
+  "screenRecording": {
+    "started": "{{name}} ha iniciado la grabación de la reunión.",
+    "stopped": "{{name}} ha detenido la grabación de la reunión.",
+    "limitReached": "La grabación ha superado la duración máxima permitida, se va a guardar automáticamente.",
+    "requested": "{{name}} ha solicitado iniciar la grabación."
+  },
+  "recordingSave": {
+    "transcript": {
+      "message": "¡Estamos finalizando tu grabación! Recibirás un correo electrónico en <strong>{{email}}</strong> en cuanto la transcripción esté lista.",
+      "default": "¡Estamos finalizando tu grabación! Recibirás un correo electrónico en cuanto la transcripción esté lista."
+    },
+    "screenRecording": {
+      "message": "¡Estamos finalizando tu grabación! Recibirás un correo electrónico en <strong>{{email}}</strong> en cuanto esté lista.",
+      "default": "¡Estamos finalizando tu grabación! Recibirás un correo electrónico en cuanto esté lista."
+    }
+  },
+  "roleChanged": {
+    "body": "Tu rol ha cambiado, ahora eres {{role}}.",
+    "roles": {
+      "owner": "Organizador",
+      "administrator": "Coorganizador",
+      "member": "Miembro"
+    }
+  },
+  "openMenu": "Abrir el menú"
+}

--- a/src/frontend/src/locales/es/recording.json
+++ b/src/frontend/src/locales/es/recording.json
@@ -1,0 +1,28 @@
+{
+  "error": {
+    "title": "Grabación no disponible",
+    "body": "No se encuentra la grabación. Solo el organizador de la reunión puede acceder a ella. No dudes en ponerte en contacto con él si lo necesitas."
+  },
+  "expired": {
+    "title": "Grabación caducada",
+    "body": "Esta grabación se eliminó el {{date}}."
+  },
+  "authentication": {
+    "title": "Autenticación necesaria",
+    "body": "Inicia sesión para acceder a esta grabación."
+  },
+  "unsaved": {
+    "title": "Descarga no disponible",
+    "body": "Esta grabación aún no está lista para descargarse. Inténtalo de nuevo más tarde."
+  },
+  "success": {
+    "title": "¡Tu grabación está lista!",
+    "body": "Grabación de la reunión {{room}} del {{created_at}}.",
+    "expiration": "Atención: esta grabación caducará al cabo de {{expiration_days}} día(s).",
+    "button": "Descargar",
+    "warning": {
+      "title": "Uso compartido por enlace desactivado",
+      "body": "Compartir la grabación mediante un enlace todavía no está disponible. Solo los organizadores pueden descargarla."
+    }
+  }
+}

--- a/src/frontend/src/locales/es/rooms.json
+++ b/src/frontend/src/locales/es/rooms.json
@@ -102,7 +102,7 @@
     "copyUrl": "Copiar el enlace",
     "copied": "Copiados en el portapapeles",
     "heading": "Tu reunión está lista",
-    "description": "Comparte estos datos con las personas que quieras invitar a la reunión.",
+    "description": "Comparte este enlace con las personas que quieras invitar a la reunión.",
     "permissions": "Las personas que dispongan de este enlace no necesitan tu autorización para unirse a esta reunión.",
     "closeDialog": "Cerrar la ventana modal",
     "phone": {
@@ -594,7 +594,7 @@
       "levels": {
         "public": {
           "label": "Abierta",
-          "description": "Todo el mundo puede unirse a la reunión sin autorización."
+          "description": "Cualquier persona puede unirse a la reunión sin autorización."
         },
         "trusted": {
           "label": "Abierta a personas de confianza",

--- a/src/frontend/src/locales/es/rooms.json
+++ b/src/frontend/src/locales/es/rooms.json
@@ -1,0 +1,801 @@
+{
+  "feedback": {
+    "heading": {
+      "normal": "Has salido de la reunión",
+      "duplicateIdentity": "Te has unido a la reunión desde otro dispositivo",
+      "participantRemoved": "Un administrador te ha expulsado de la llamada"
+    },
+    "home": "Volver al inicio",
+    "back": "Volver a la reunión"
+  },
+  "selectDevice": {
+    "loading": "Cargando…",
+    "select": "Selecciona un valor",
+    "permissionsNeeded": "Permisos necesarios",
+    "deviceNotFound": {
+      "videoinput": "No se ha detectado ninguna cámara. Comprueba que esté bien conectada.",
+      "audioinput": "No se ha detectado ningún micrófono. Comprueba que esté bien conectado."
+    },
+    "deviceInUse": {
+      "videoinput": "Cámara no disponible: probablemente la esté usando otra aplicación u otra pestaña.",
+      "audioinput": "Micrófono no disponible: probablemente lo esté usando otra aplicación u otra pestaña."
+    },
+    "settings": {
+      "audio": "Configuración de audio",
+      "video": "Configuración de vídeo"
+    },
+    "effects": "Fondos y efectos",
+    "videoinput": {
+      "choose": "Elegir la cámara web",
+      "permissionsNeeded": "Elegir la cámara web - permisos necesarios",
+      "disable": "Desactivar la cámara web",
+      "enable": "Activar la cámara web",
+      "turnedOff": "Cámara web desactivada",
+      "turnedOn": "Cámara web activada",
+      "label": "Cámara web",
+      "placeholder": "Activa la cámara web para previsualizar la imagen"
+    },
+    "audioinput": {
+      "choose": "Elegir el micrófono",
+      "level": "Nivel de entrada del micrófono",
+      "muteTest": "Activa tu micrófono para probarlo",
+      "permissionsNeeded": "Elegir el micrófono - permisos necesarios",
+      "disable": "Desactivar el micrófono",
+      "enable": "Activar el micrófono",
+      "turnedOff": "Micrófono desactivado",
+      "turnedOn": "Micrófono activado",
+      "label": "Micrófono"
+    },
+    "audiooutput": {
+      "choose": "Elegir el altavoz",
+      "permissionsNeeded": "Elegir el altavoz - permisos necesarios",
+      "test": "Probar los altavoces",
+      "testing": "Reproduciendo el sonido de prueba…"
+    }
+  },
+  "join": {
+    "heading": "¿Unirse a la reunión?",
+    "effects": {
+      "description": "Fondos y efectos",
+      "title": "Fondos y efectos",
+      "subTitle": "Configura los efectos de tu cámara."
+    },
+    "joinLabel": "Unirse",
+    "joinMeeting": "Unirse a la reunión",
+    "toggleOff": "Haz clic para desactivar",
+    "toggleOn": "Haz clic para activar",
+    "usernameHint": "Se muestra a los demás participantes",
+    "usernameLabel": "Tu nombre",
+    "errors": {
+      "usernameEmpty": "Tu nombre no puede estar vacío"
+    },
+    "cameraDisabled": "La cámara está desactivada.",
+    "cameraNotFound": "No se ha detectado ninguna cámara. Comprueba que esté bien conectada.",
+    "cameraInUse": "Tu cámara no está disponible. Probablemente la esté usando otra aplicación u otra pestaña.",
+    "cameraStarting": "La cámara va a iniciarse…",
+    "cameraNotGranted": "¿Quieres que los demás puedan verte durante la reunión?",
+    "cameraAndMicNotGranted": "¿Quieres que los demás puedan verte y oírte durante la reunión?",
+    "videoPreview": {
+      "enabled": "Vista previa de vídeo activada",
+      "disabled": "Vista previa de vídeo desactivada"
+    },
+    "permissionsButton": {
+      "cameraAndMicNotGranted": "Autoriza el acceso a la cámara y al micrófono",
+      "cameraNotGranted": "Autoriza el acceso a la cámara"
+    },
+    "waiting": {
+      "title": "Solicitud de participación…",
+      "body": "Podrás participar en esta llamada cuando alguien te lo autorice"
+    },
+    "denied": {
+      "title": "No puedes participar en esta llamada",
+      "body": "Tu solicitud de participación ha sido rechazada."
+    },
+    "timeoutInvite": {
+      "title": "No puedes participar en esta llamada",
+      "body": "Nadie ha respondido a tu solicitud de participación en la llamada"
+    }
+  },
+  "leaveRoomPrompt": "Volver al inicio hará que salgas de la reunión.",
+  "shareDialog": {
+    "copy": "Copiar los datos",
+    "copyUrl": "Copiar el enlace",
+    "copied": "Copiados en el portapapeles",
+    "heading": "Tu reunión está lista",
+    "description": "Comparte estos datos con las personas que quieras invitar a la reunión.",
+    "permissions": "Las personas que dispongan de este enlace no necesitan tu autorización para unirse a esta reunión.",
+    "closeDialog": "Cerrar la ventana modal",
+    "phone": {
+      "call": "Llama al:",
+      "pinCode": "Código:"
+    }
+  },
+  "pagination": {
+    "label": "Páginas de participantes",
+    "count": "{{currentPage}} de {{totalPageCount}}",
+    "next": "página siguiente",
+    "previous": "página anterior"
+  },
+  "mediaErrorDialog": {
+    "DeviceInUse": {
+      "title": {
+        "audioinput": "No se puede activar el micrófono",
+        "videoinput": "No se puede activar la cámara"
+      },
+      "body": {
+        "audioinput": "Tu micrófono ya se está usando en otra pestaña o en otra aplicación, lo que impide activarlo en esta videoconferencia. Si quieres, cierra la otra pestaña o aplicación para usarlo aquí.",
+        "videoinput": "Tu cámara ya se está usando en otra pestaña o en otra aplicación, lo que impide activarla en esta videoconferencia. Si quieres, cierra la otra pestaña o aplicación para usarla aquí."
+      }
+    },
+    "NotFound": {
+      "title": {
+        "audioinput": "No se ha detectado ningún micrófono",
+        "videoinput": "No se ha detectado ninguna cámara"
+      },
+      "body": {
+        "audioinput": "No se ha detectado ningún micrófono en tu dispositivo. Comprueba que esté bien conectado y que ningún botón lo silencie, y vuelve a intentarlo.",
+        "videoinput": "No se ha detectado ninguna cámara en tu dispositivo. Comprueba que esté bien conectada y que ninguna tapa o botón la bloquee, y vuelve a intentarlo."
+      }
+    },
+    "close": "Aceptar"
+  },
+  "permissionErrorDialog": {
+    "heading": {
+      "camera": "{{appTitle}} no tiene permiso para usar tu cámara",
+      "microphone": "{{appTitle}} no tiene permiso para usar tu micrófono",
+      "cameraAndMicrophone": "{{appTitle}} no tiene permiso para usar tu micrófono ni tu cámara",
+      "default": "{{appTitle}} no tiene permiso para usar algunas funciones necesarias."
+    },
+    "body": {
+      "openMenu": {
+        "others": "Haz clic en el icono de configuración ICON_PLACEHOLDER en la barra de direcciones de tu navegador",
+        "safari": "Haz clic en el menú \"Safari\" y abre \"Configuración para {{appDomain}}\"."
+      },
+      "details": {
+        "camera": "Autoriza el acceso a la cámara",
+        "microphone": "Autoriza el acceso al micrófono",
+        "cameraAndMicrophone": "Autoriza el acceso a la cámara y al micrófono",
+        "default": "Activa los permisos necesarios."
+      }
+    }
+  },
+  "systemPermissionDialog": {
+    "heading": {
+      "camera": "Autoriza a tu navegador a usar tu cámara",
+      "microphone": "Autoriza a tu navegador a usar tu micrófono",
+      "cameraAndMicrophone": "Autoriza a tu navegador a usar tu cámara y tu micrófono"
+    },
+    "device": {
+      "camera": "cámara",
+      "microphone": "micrófono",
+      "cameraAndMicrophone": "cámara y tu micrófono"
+    },
+    "intro": "Tu navegador ya tiene el permiso, pero la configuración de tu ordenador bloquea el acceso a tu {{device}}.",
+    "steps": {
+      "macos": {
+        "1": "En los ajustes del Sistema, abre «Privacidad y seguridad».",
+        "2": "Autoriza a tu navegador a acceder a tu {{device}}."
+      },
+      "windows": {
+        "1": "En la configuración de Windows, abre «Privacidad y seguridad».",
+        "2": "Activa el acceso a tu {{device}} y autoriza a las aplicaciones de escritorio a usarlo."
+      },
+      "android": {
+        "1": "En los ajustes de Android, abre «Aplicaciones» y selecciona tu navegador.",
+        "2": "En «Permisos», autoriza el acceso a tu {{device}} y recarga la página."
+      },
+      "other": {
+        "1": "En los ajustes de privacidad de tu sistema, autoriza a tu navegador a acceder a tu {{device}}.",
+        "2": "Después, vuelve a intentarlo."
+      }
+    },
+    "openSettings": "Abrir los ajustes del sistema"
+  },
+  "silentMic": {
+    "tooltip": "Tu micrófono está activado, pero no se detecta ningún sonido. Haz clic para saber más.",
+    "dialog": {
+      "title": "No se detecta ningún sonido",
+      "intro": "Tu micrófono está activado, pero hace un rato que no se detecta ningún sonido. Comprueba los siguientes puntos:",
+      "causes": {
+        "system": "Puede que el acceso al micrófono esté bloqueado en los ajustes de privacidad de tu sistema.",
+        "hardware": "Puede que un botón o interruptor silencie el micrófono, o que esté desconectado o defectuoso.",
+        "wrongDevice": "Puede que haya otro micrófono seleccionado. Prueba a elegir otro en el menú del micrófono."
+      },
+      "hint": "Vuelve a hablar después de comprobar estos puntos. El aviso desaparecerá en cuanto se detecte un sonido.",
+      "close": "Entendido",
+      "discard": "Desactivar esta detección"
+    }
+  },
+  "permissionsButton": {
+    "tooltip": "Más información",
+    "ariaLabel": "Problema de permisos. Mostrar más información"
+  },
+  "error": {
+    "createRoom": {
+      "heading": "Autenticación necesaria",
+      "body": "Esta reunión todavía no se ha creado. Autentícate para crearla o espera a que lo haga un usuario autenticado."
+    },
+    "screenShare": {
+      "title": "No se puede compartir tu pantalla",
+      "ariaLabel": "No se puede compartir tu pantalla",
+      "message": "Puede que tu navegador no tenga permiso para grabar la pantalla en tu ordenador.",
+      "settingsInstructions": "Accede a tus",
+      "settingsLabel": {
+        "macos": "Preferencias del sistema",
+        "windows": "ajustes de privacidad de Windows"
+      },
+      "helpLinkText": "Para saber más, consulta",
+      "helpLinkLabel": "Problema de presentación",
+      "closeButton": "Ignorar",
+      "newTab": "Nueva ventana"
+    }
+  },
+  "isIdleDisconnectModal": {
+    "title": "¿Sigues ahí?",
+    "body": "Eres el único participante. Por eso, esta llamada terminará dentro de {{duration}}. ¿Quieres continuar la llamada?",
+    "settingsPrefix": "Para no volver a ver este mensaje, ve a",
+    "settingsLink": "Configuración > General",
+    "settingsSuffix": ".",
+    "stayButton": "Continuar la llamada",
+    "leaveButton": "Salir ahora",
+    "countdownAnnouncement": "La llamada termina dentro de {{duration}}."
+  },
+  "controls": {
+    "region": "Controles de la llamada",
+    "microphone": "Micrófono",
+    "camera": "Cámara",
+    "chat": {
+      "open": "Ocultar el chat",
+      "closed": "Mostrar el chat",
+      "input": {
+        "textArea": {
+          "label": "Escribir un mensaje",
+          "placeholder": "Escribir un mensaje"
+        },
+        "button": {
+          "label": "Enviar un mensaje"
+        }
+      }
+    },
+    "info": {
+      "open": "Ocultar la información",
+      "closed": "Mostrar la información"
+    },
+    "hand": {
+      "raise": "Levantar la mano",
+      "lower": "Bajar la mano"
+    },
+    "subtitles": {
+      "closed": "Mostrar los subtítulos",
+      "open": "Ocultar los subtítulos"
+    },
+    "screenShare": {
+      "start": "Compartir pantalla",
+      "stop": "Dejar de compartir"
+    },
+    "leave": "Salir",
+    "participants": {
+      "open": "Ocultar los participantes",
+      "closed": "Mostrar los participantes",
+      "count_one": "{{count}} participante",
+      "count_other": "{{count}} participantes"
+    },
+    "tools": {
+      "open": "Ocultar las herramientas de reunión",
+      "closed": "Mostrar las herramientas de reunión"
+    },
+    "admin": {
+      "open": "Ocultar la administración",
+      "closed": "Mostrar la administración"
+    },
+    "moreOptions": "Más opciones",
+    "reactions": {
+      "button": "Enviar una reacción",
+      "toolbar": "Enviar una reacción",
+      "announce": "{{name}}: {{emoji}}",
+      "you": "tú",
+      "emojis": {
+        "thumbs-up": "pulgar hacia arriba",
+        "thumbs-down": "pulgar hacia abajo",
+        "clapping-hands": "aplausos",
+        "red-heart": "corazón",
+        "face-with-tears-of-joy": "cara llorando de risa",
+        "face-with-open-mouth": "cara de asombro",
+        "party-popper": "confeti",
+        "folded-hands": "manos juntas"
+      }
+    }
+  },
+  "pictureInPicture": {
+    "placeholder": {
+      "title": "Tu videollamada está en otra ventana.",
+      "description": "El modo imagen en imagen te permite seguir conectado a la llamada mientras haces otras tareas.",
+      "bringBack": "Traer la llamada aquí"
+    },
+    "stage": "Participantes",
+    "controlBar": "Controles de la reunión",
+    "title": "Reunión en imagen en imagen"
+  },
+  "options": {
+    "buttonLabel": "Más opciones",
+    "items": {
+      "feedback": "Comparte tu opinión",
+      "settings": "Configuración",
+      "screenRecording": "Grabación",
+      "transcript": "Transcripción",
+      "username": "Elegir tu nombre",
+      "effects": "Fondos y efectos",
+      "switchCamera": "Cambiar de cámara",
+      "pictureInPicture": {
+        "enter": "Imagen en imagen",
+        "exit": "Cerrar la imagen en imagen"
+      },
+      "fullscreen": {
+        "enter": "Pantalla completa",
+        "exit": "Salir del modo de pantalla completa"
+      },
+      "support": "Contactar con el soporte",
+      "documentation": "Documentación"
+    }
+  },
+  "effects": {
+    "activateCamera": "Tu cámara está desactivada. Elige una opción para activarla.",
+    "cameraDisabled": "Tu cámara está desactivada.",
+    "notAvailable": "Los efectos de vídeo estarán disponibles pronto en tu navegador. ¡Estamos trabajando en ello! Mientras tanto, puedes usar Google Chrome para un mejor rendimiento, o Firefox :(",
+    "heading": "Desenfoque",
+    "clear": "Desactivar el efecto",
+    "blur": {
+      "title": "Desenfoque del fondo",
+      "status": {
+        "none": "Fondo nítido.",
+        "light": "Fondo ligeramente desenfocado.",
+        "strong": "Fondo muy desenfocado."
+      },
+      "light": {
+        "apply": "Desenfocar el fondo",
+        "clear": "Desactivar el desenfoque"
+      },
+      "normal": {
+        "apply": "Desenfocar aún más el fondo",
+        "clear": "Desactivar el desenfoque"
+      }
+    },
+    "virtual": {
+      "title": "Fondos virtuales",
+      "selectedLabel": "Fondo aplicado:",
+      "apply": "Sustituye tu fondo:",
+      "personal": {
+        "title": "Mis fondos",
+        "selectedLabel": "Dejar de usar como fondo (actualmente activo).",
+        "apply": "Usar como fondo.",
+        "selectFileTooltip": "Selecciona una imagen para usarla como fondo",
+        "notLoggedInWarning": "No has iniciado sesión, el fondo personal no se guardará de una reunión a otra.",
+        "warningUploadDisabled": "Actualmente los fondos personales no se guardan de una reunión a otra.",
+        "uploadLimitReached": "No puedes añadir más fondos personales.",
+        "uploadInProgress": "Enviando la imagen…",
+        "deleteLabel": "Eliminar el fondo.",
+        "errors": {
+          "close": "Cerrar",
+          "file_too_large": {
+            "title": "Archivo demasiado grande",
+            "description": "El archivo es demasiado grande. Elige un archivo de menos de {{maxSize, number}} MB."
+          },
+          "invalid_file_type": {
+            "title": "Tipo de archivo no válido",
+            "description": "El tipo de archivo no es compatible. Elige un archivo {{allowedExtension}}."
+          }
+        }
+      },
+      "presets": {
+        "title": "Sugerencias",
+        "descriptions": {
+          "0": "Mueble acanalado de madera",
+          "1": "Sala de reuniones",
+          "2": "Loft con cristalera negra",
+          "3": "Comedor",
+          "4": "Estanterías de madera",
+          "5": "Escalera de madera",
+          "6": "Estantería gris",
+          "7": "Barra de cafetería"
+        }
+      }
+    },
+    "faceLandmarks": {
+      "title": "Efectos visuales",
+      "glasses": {
+        "apply": "Añadir gafas",
+        "clear": "Quitar las gafas"
+      },
+      "french": {
+        "apply": "Añadir el toque francés",
+        "clear": "Quitar el toque francés"
+      }
+    }
+  },
+  "sidePanel": {
+    "ariaLabel": "Panel lateral - {{title}}",
+    "backToTools": "Volver a las herramientas de reunión",
+    "heading": {
+      "participants": "Participantes",
+      "effects": "Fondos y efectos",
+      "chat": "Mensajes de la llamada",
+      "transcript": "Transcribir",
+      "screenRecording": "Grabar",
+      "admin": "Controles del organizador",
+      "tools": "Herramientas de reunión",
+      "info": "Información sobre la reunión"
+    },
+    "content": {
+      "participants": "los participantes",
+      "effects": "los efectos",
+      "chat": "los mensajes",
+      "transcript": "transcribir",
+      "screenRecording": "grabar",
+      "admin": "controles del organizador",
+      "tools": "herramientas de reunión",
+      "info": "información sobre la reunión"
+    },
+    "closeButton": "Ocultar {{content}}"
+  },
+  "chat": {
+    "disclaimer": "Los mensajes solo son visibles para los participantes en el momento de\nsu envío. Todos los mensajes se eliminan al final de la llamada.",
+    "messagesLog": "Mensajes del chat"
+  },
+  "moreTools": {
+    "body": "Accede a más herramientas para mejorar tus reuniones.",
+    "linkAriaLabel": "Abrir la documentación sobre las herramientas - se abre en una nueva ventana",
+    "moreLink": "Abrir la documentación",
+    "tools": {
+      "transcript": {
+        "title": "Transcribir",
+        "body": "Transcribir la reunión."
+      },
+      "screenRecording": {
+        "title": "Grabar",
+        "body": "Grabar la reunión en vídeo."
+      }
+    }
+  },
+  "info": {
+    "roomInformation": {
+      "title": "Datos de conexión",
+      "button": {
+        "ariaLabel": "Copiar los datos de tu reunión",
+        "copy": "Copiar los datos",
+        "copied": "Datos copiados"
+      },
+      "phone": {
+        "call": "Llama al:",
+        "pinCode": "Código:"
+      }
+    }
+  },
+  "transcript": {
+    "heading": "Transcribe tu reunión con el Asistente de IA",
+    "body": "Transcribe hasta {{max_duration}} de reunión.",
+    "bodyWithoutMaxDuration": "Transcribe tu reunión sin límite.",
+    "details": {
+      "receiver": "La transcripción se enviará al organizador y a los coorganizadores.",
+      "destination": "Se creará un nuevo documento en",
+      "destinationUnknown": "Se creará un nuevo documento",
+      "language": "Idioma de la reunión:",
+      "recording": "Iniciar también una grabación"
+    },
+    "button": {
+      "start": "Empezar a transcribir la reunión",
+      "stop": "Dejar de transcribir la reunión",
+      "saving": "Guardando…",
+      "starting": "Iniciando…",
+      "anotherModeStarted": "Hay una grabación en curso. <br/> Cambia de menú y deténla."
+    },
+    "linkMore": "Abrir la documentación",
+    "linkAriaLabel": "Abrir la documentación sobre la transcripción - se abre en una nueva ventana",
+    "notAdminOrOwner": {
+      "heading": "Acceso restringido",
+      "body": "Por razones de seguridad, solo el creador o un administrador de la reunión puede iniciar una transcripción (beta).",
+      "linkMore": "Abrir la documentación",
+      "linkAriaLabel": "Abrir la documentación sobre el acceso a la transcripción - se abre en una nueva ventana",
+      "dividerLabel": "O",
+      "login": {
+        "heading": "Inicio de sesión necesario",
+        "body": "Solo el creador de la reunión o un administrador puede iniciar la transcripción. Inicia sesión para comprobar tus permisos."
+      },
+      "request": {
+        "heading": "Pedírselo al organizador",
+        "body": "El anfitrión recibirá una notificación y podrá iniciar la transcripción por ti.",
+        "buttonLabel": "Solicitar"
+      }
+    },
+    "premium": {
+      "heading": "Función avanzada",
+      "body": "Esta función no está disponible para ti. Ponte en contacto con el soporte para obtener más información.",
+      "linkMore": "Abrir la documentación",
+      "dividerLabel": "O",
+      "login": {
+        "heading": "¡No has iniciado sesión!",
+        "body": "Debes haber iniciado sesión para usar esta función. Inicia sesión y vuelve a intentarlo."
+      },
+      "request": {
+        "heading": "Pedírselo al organizador",
+        "body": "El anfitrión recibirá una notificación y podrá iniciar la transcripción por ti.",
+        "buttonLabel": "Solicitar"
+      },
+      "linkAriaLabel": "Abrir la documentación sobre la función avanzada - se abre en una nueva ventana"
+    }
+  },
+  "screenRecording": {
+    "heading": "Graba esta llamada para más tarde",
+    "body": "Graba hasta {{max_duration}} de reunión.",
+    "bodyWithoutMaxDuration": "Graba tu reunión sin límite.",
+    "linkMore": "Abrir la documentación",
+    "linkAriaLabel": "Abrir la documentación sobre la grabación - se abre en una nueva ventana",
+    "details": {
+      "receiver": "La grabación se enviará al organizador y a los coorganizadores.",
+      "destination": "Esta grabación se conservará temporalmente en nuestros servidores",
+      "loading": "Iniciando la grabación",
+      "linkMore": "Más información",
+      "transcription": "Transcribir esta grabación"
+    },
+    "button": {
+      "start": "Empezar a grabar la reunión",
+      "stop": "Dejar de grabar la reunión",
+      "saving": "Guardando…",
+      "starting": "Iniciando…",
+      "anotherModeStarted": "Hay una transcripción en curso. <br/> Cambia de menú y deténla."
+    },
+    "notAdminOrOwner": {
+      "heading": "Acceso restringido",
+      "body": "Por razones de seguridad, solo el creador o un administrador de la reunión puede iniciar una grabación (beta).",
+      "linkMore": "Abrir la documentación",
+      "linkAriaLabel": "Abrir la documentación sobre el acceso a la grabación - se abre en una nueva ventana",
+      "dividerLabel": "O",
+      "login": {
+        "heading": "Inicio de sesión necesario",
+        "body": "Solo el creador de la reunión o un administrador puede iniciar la grabación. Inicia sesión para comprobar tus permisos."
+      },
+      "request": {
+        "heading": "Pedírselo al organizador",
+        "body": "El anfitrión recibirá una notificación y podrá iniciar la grabación por ti.",
+        "buttonLabel": "Solicitar"
+      }
+    },
+    "premium": {
+      "heading": "Función avanzada",
+      "body": "Esta función no está disponible para ti. Ponte en contacto con el soporte para obtener más información.",
+      "linkMore": "Abrir la documentación",
+      "dividerLabel": "O",
+      "login": {
+        "heading": "¡No has iniciado sesión!",
+        "body": "Debes haber iniciado sesión para usar esta función. Inicia sesión y vuelve a intentarlo."
+      },
+      "request": {
+        "heading": "Pedírselo al organizador",
+        "body": "El anfitrión recibirá una notificación y podrá iniciar la grabación por ti.",
+        "buttonLabel": "Solicitar"
+      },
+      "linkAriaLabel": "Abrir la documentación sobre la función avanzada - se abre en una nueva ventana"
+    },
+    "durationMessage": "(limitado a {{max_duration}}) "
+  },
+  "errorRecordingAlertDialog": {
+    "title": "Error de grabación",
+    "body": {
+      "stop": "No hemos podido detener la grabación. Inténtalo de nuevo dentro de unos instantes.",
+      "start": "No hemos podido iniciar la grabación. Inténtalo de nuevo dentro de unos instantes."
+    },
+    "button": "Aceptar"
+  },
+  "admin": {
+    "description": "Esta configuración de organizador te permite mantener el control de tu reunión. Solo los organizadores pueden acceder a estos controles.",
+    "access": {
+      "title": "Acceso a la reunión",
+      "description": "Esta configuración se aplicará también a las futuras ediciones de esta reunión.",
+      "type": "Tipo de acceso a la reunión",
+      "levels": {
+        "public": {
+          "label": "Abierta",
+          "description": "Todo el mundo puede unirse a la reunión sin autorización."
+        },
+        "trusted": {
+          "label": "Abierta a personas de confianza",
+          "description": "Las personas autenticadas no tienen que pedir permiso para unirse a la reunión."
+        },
+        "restricted": {
+          "label": "Restringida",
+          "description": "Las personas que no hayan sido invitadas a la reunión deben pedir unirse a ella."
+        }
+      }
+    },
+    "moderation": {
+      "title": "Moderación de la reunión",
+      "description": "Esta configuración limita las acciones que pueden realizar los colaboradores durante la reunión.",
+      "microphone": {
+        "label": "Encender el micrófono",
+        "description": ""
+      },
+      "camera": {
+        "label": "Activar el vídeo",
+        "description": ""
+      },
+      "screenshare": {
+        "label": "Compartir su pantalla",
+        "description": "Si desactivas esta opción, los participantes ya no podrán compartir su pantalla y cualquier pantalla compartida en curso se interrumpirá de inmediato."
+      },
+      "mute": {
+        "label": "Silenciar a los demás",
+        "description": "Si desactivas esta opción, los participantes ya no podrán silenciar a otros participantes."
+      }
+    }
+  },
+  "rating": {
+    "submit": "Enviar",
+    "question": "¿Qué te ha parecido la calidad de tu llamada?",
+    "levels": {
+      "min": "muy mala",
+      "max": "excelente"
+    }
+  },
+  "openFeedback": {
+    "question": "¿Qué podemos hacer para mejorar?",
+    "placeholder": "Describe los errores o comparte tus sugerencias…",
+    "submit": "Enviar",
+    "skip": "Omitir"
+  },
+  "confirmationMessage": {
+    "heading": "Gracias por tu opinión",
+    "body": "Nuestro equipo de producto se toma el tiempo de analizar atentamente tus respuestas. Nos pondremos en contacto contigo lo antes posible."
+  },
+  "authenticationMessage": {
+    "heading": "¿Cómo podemos ponernos en contacto contigo?",
+    "placeholder": "Tu correo electrónico",
+    "submit": "Enviar",
+    "ignore": "Ignorar"
+  },
+  "participants": {
+    "subheading": "En la reunión",
+    "you": "Tú",
+    "unknown": "Participante desconocido",
+    "contributors": "Colaboradores",
+    "host": "Organizador de la reunión",
+    "cohost": "Coorganizador",
+    "member": "Miembro",
+    "collapsable": {
+      "open": "Abrir la lista {{name}}",
+      "close": "Cerrar la lista {{name}}"
+    },
+    "unauthenticated": {
+      "badge": "Usuario no autenticado"
+    },
+    "muteYourself": "Silenciar tu micrófono",
+    "muteParticipant": "Silenciar el micrófono de {{name}}",
+    "muteParticipantAlert": {
+      "heading": "Silenciar el micrófono de {{name}}",
+      "description": "¿Silenciar el micrófono de {{name}} para todos los participantes? {{name}} es la única persona autorizada a reactivar su micrófono",
+      "confirm": "Silenciar el micrófono",
+      "cancel": "Cancelar"
+    },
+    "raisedHands": "Manos levantadas",
+    "lowerParticipantHand": "Bajar la mano de {{name}}",
+    "lowerParticipantsHand": "Bajar todas las manos",
+    "muteParticipants": "Silenciar todos los micrófonos",
+    "waiting": {
+      "title": "Sala de espera",
+      "accept": {
+        "button": "Aceptar",
+        "label": "Aceptar a {{name}} en la reunión",
+        "all": "Aceptar todo"
+      },
+      "deny": {
+        "button": "Rechazar",
+        "label": "Rechazar a {{name}} en la reunión",
+        "all": "Rechazar todo"
+      }
+    },
+    "moreOptions": "Más opciones"
+  },
+  "participantMenu": {
+    "remove": {
+      "label": "Expulsar de la llamada",
+      "ariaLabel": "Expulsar a {{name}} de la llamada"
+    },
+    "unpin": {
+      "label": "Dejar de fijar",
+      "ariaLabel": "Dejar de fijar a {{name}}"
+    },
+    "pin": {
+      "label": "Fijar",
+      "ariaLabel": "Fijar a {{name}}"
+    },
+    "promote": {
+      "label": "Nombrar coorganizador",
+      "ariaLabel": "Nombrar coorganizador a {{name}}"
+    },
+    "demote": {
+      "label": "Retirar el rol de coorganizador",
+      "ariaLabel": "Retirar el rol de coorganizador a {{name}}"
+    }
+  },
+  "pinAnnouncements": {
+    "pin": "El vídeo de {{name}} está fijado.",
+    "unpin": "El vídeo de {{name}} ya no está fijado.",
+    "self": {
+      "pin": "Tu vídeo está fijado.",
+      "unpin": "Tu vídeo ya no está fijado."
+    }
+  },
+  "recordingStateToast": {
+    "transcript": {
+      "started": "Transcripción en curso",
+      "starting": "Iniciando la transcripción",
+      "stopping": "Deteniendo la transcripción"
+    },
+    "screen_recording": {
+      "started": "Grabación en curso",
+      "starting": "Iniciando la grabación",
+      "stopping": "Deteniendo la grabación"
+    },
+    "any": {
+      "started": "Grabación en curso"
+    },
+    "limitReachedAlert": {
+      "title": "Límite de grabación superado",
+      "description": "La grabación ha superado la duración máxima permitida{{duration_message}}. Ahora se va a guardar automáticamente.",
+      "durationMessage": " de {{duration}}",
+      "button": "Aceptar"
+    }
+  },
+  "participantTileFocus": {
+    "containerLabel": "Opciones para {{name}}",
+    "toolbarHint": "{{shortcut}}: acceder directamente a los atajos.",
+    "pin": {
+      "enable": "Fijar",
+      "disable": "Cancelar la fijación"
+    },
+    "effects": "Fondos y efectos",
+    "muteParticipant": "Silenciar el micrófono de {{name}}",
+    "fullScreen": "Pantalla completa"
+  },
+  "shortcutsPanel": {
+    "title": "Atajos de teclado",
+    "categories": {
+      "navigation": "Navegación",
+      "media": "Multimedia",
+      "interaction": "Interacción"
+    },
+    "actions": {
+      "open-shortcuts": "Abrir la ayuda de atajos",
+      "focus-toolbar": "Poner el foco en la barra de herramientas inferior",
+      "toggle-microphone": "Activar o desactivar el micrófono",
+      "toggle-camera": "Activar o desactivar la cámara",
+      "push-to-talk": "Pulsar para hablar (mantener para reactivar)",
+      "reaction": "Panel de reacciones",
+      "fullscreen": "Cambiar a pantalla completa",
+      "recording": "Mostrar u ocultar el panel de grabación",
+      "raise-hand": "Levantar o bajar la mano",
+      "toggle-chat": "Mostrar/Ocultar el chat",
+      "toggle-participants": "Mostrar/Ocultar los participantes",
+      "open-shortcuts-settings": "Abrir los ajustes de los atajos"
+    },
+    "sr": {
+      "control": "Control",
+      "command": "Comando",
+      "alt": "Alt",
+      "option": "Opción",
+      "shift": "Mayúsculas",
+      "plus": "más",
+      "hold": "Mantener {{key}}",
+      "noShortcut": "Ningún atajo"
+    },
+    "visual": {
+      "hold": "Mantener {{key}}"
+    }
+  },
+  "fullScreenWarning": {
+    "message": "Para evitar el efecto de bucle infinito, no compartas toda tu pantalla. Comparte mejor una pestaña u otra ventana.",
+    "stop": "Detener la presentación",
+    "ignore": "Ignorar"
+  },
+  "participantTile": {
+    "screenShare": "Pantalla de {{name}}"
+  }
+}

--- a/src/frontend/src/locales/es/sdk.json
+++ b/src/frontend/src/locales/es/sdk.json
@@ -1,0 +1,18 @@
+{
+  "createMeeting": {
+    "createButton": "Crear un enlace de Visio",
+    "joinButton": "Unirse con Visio",
+    "copyLinkTooltip": "Copiar el enlace",
+    "resetLabel": "Restablecer",
+    "participantLimit": "Hasta 150 participantes.",
+    "popupBlocked": "Se ha bloqueado la ventana emergente. Permite las ventanas emergentes para este sitio.",
+    "settingsTooltip": "Configuración de la reunión"
+  },
+  "roomSettings": {
+    "title": "Configuración de la reunión",
+    "description": "Configura la reunión {{roomSlug}}.",
+    "notAllowed": "No tienes permisos para modificar la configuración de esta reunión.",
+    "error": "No se ha podido cargar la configuración de la reunión.",
+    "closeButton": "Cerrar"
+  }
+}

--- a/src/frontend/src/locales/es/settings.json
+++ b/src/frontend/src/locales/es/settings.json
@@ -1,0 +1,189 @@
+{
+  "account": {
+    "currentlyLoggedAs": "Actualmente has iniciado sesión como <0>{{user}}</0>",
+    "heading": "Cuenta",
+    "youAreNotLoggedIn": "No has iniciado sesión.",
+    "nameLabel": "Tu nombre",
+    "authentication": "Autenticación",
+    "nameError": "Tu nombre no puede estar vacío"
+  },
+  "preferences": {
+    "title": "Preferencias",
+    "idleDisconnectModal": {
+      "label": "Salir de las llamadas sin ningún otro participante",
+      "description": "Te saca de una llamada al cabo de unos minutos si ningún otro participante se une"
+    },
+    "autoMuteLargeRoom": {
+      "label": "Silenciar automáticamente mi micrófono",
+      "description": "Silencia automáticamente tu micrófono cuando te unes a una reunión numerosa."
+    }
+  },
+  "audio": {
+    "microphone": {
+      "heading": "Micrófono",
+      "label": "Selecciona tu entrada de audio",
+      "disabled": "Micrófono desactivado"
+    },
+    "noiseReduction": {
+      "label": "Reducción de ruido",
+      "heading": "Reducción de ruido",
+      "ariaLabel": {
+        "enable": "Activar la reducción de ruido",
+        "disable": "Desactivar la reducción de ruido"
+      }
+    },
+    "speakers": {
+      "heading": "Altavoces",
+      "label": "Selecciona tu salida de audio",
+      "test": "Probar",
+      "ongoingTest": "Probando el sonido…",
+      "safariWarning": "La selección del altavoz todavía no está disponible en Safari debido a limitaciones del navegador."
+    },
+    "permissionsRequired": "Permisos necesarios"
+  },
+  "video": {
+    "camera": {
+      "heading": "Cámara",
+      "label": "Selecciona tu entrada de vídeo",
+      "disabled": "Cámara desactivada",
+      "previewAriaLabel": {
+        "enabled": "Vista previa de vídeo activada",
+        "disabled": "Vista previa de vídeo desactivada"
+      }
+    },
+    "resolution": {
+      "heading": "Resolución",
+      "publish": {
+        "label": "Selecciona tu resolución de envío (máx.)",
+        "items": {
+          "high": "Alta definición",
+          "medium": "Definición estándar",
+          "low": "Baja definición"
+        }
+      },
+      "subscribe": {
+        "label": "Selecciona tu resolución de recepción (máx.)",
+        "items": {
+          "high": "Alta definición (automática)",
+          "medium": "Definición estándar",
+          "low": "Baja definición"
+        }
+      }
+    },
+    "permissionsRequired": "Permisos necesarios"
+  },
+  "transcription": {
+    "heading": "Transcripción",
+    "language": {
+      "label": "Idioma de la reunión",
+      "options": {
+        "french": "Francés (fr)",
+        "english": "Inglés (en)",
+        "dutch": "Neerlandés (nl)",
+        "german": "Alemán (de)",
+        "auto": "Automático"
+      }
+    }
+  },
+  "notifications": {
+    "heading": "Notificaciones sonoras",
+    "label": "la notificación sonora para",
+    "actions": {
+      "disable": "Desactivar",
+      "enable": "Activar"
+    },
+    "items": {
+      "participantJoined": {
+        "label": "Un nuevo participante"
+      },
+      "handRaised": {
+        "label": "Una mano levantada"
+      },
+      "messageReceived": {
+        "label": "Un mensaje recibido"
+      }
+    }
+  },
+  "shortcuts": {
+    "listLabel": "Lista de atajos de teclado",
+    "columnAction": "Acción",
+    "columnShortcut": "Atajo"
+  },
+  "dialog": {
+    "heading": "Configuración"
+  },
+  "language": {
+    "heading": "Idioma",
+    "label": "Idioma de la aplicación"
+  },
+  "settingsButtonLabel": "Configuración",
+  "accessibility": {
+    "announceReactions": {
+      "label": "Vocalizar las reacciones"
+    },
+    "font": {
+      "label": "Fuente de la interfaz",
+      "description": "Personaliza la fuente utilizada en la interfaz para mejorar tu comodidad de lectura.",
+      "options": {
+        "default": "Predeterminada",
+        "lexend": "Lexend (legibilidad mejorada)",
+        "atkinson-hyperlegible": "Atkinson Hyperlegible (baja visión)",
+        "opendyslexic": "OpenDyslexic (dislexia)"
+      }
+    },
+    "captions": {
+      "heading": "Subtítulos",
+      "textSize": {
+        "label": "Tamaño del texto de los subtítulos",
+        "options": {
+          "small": "Pequeño",
+          "medium": "Mediano",
+          "large": "Grande"
+        }
+      },
+      "fontColor": {
+        "label": "Color del texto",
+        "options": {
+          "default": "Predeterminado",
+          "white": "Blanco",
+          "black": "Negro",
+          "blue": "Azul",
+          "green": "Verde",
+          "red": "Rojo",
+          "yellow": "Amarillo",
+          "cyan": "Cian",
+          "magenta": "Magenta"
+        }
+      },
+      "backgroundColor": {
+        "label": "Color de fondo",
+        "options": {
+          "default": "Predeterminado",
+          "white": "Blanco",
+          "black": "Negro",
+          "blue": "Azul",
+          "green": "Verde",
+          "red": "Rojo",
+          "yellow": "Amarillo",
+          "cyan": "Cian",
+          "magenta": "Magenta"
+        }
+      }
+    }
+  },
+  "tabs": {
+    "account": "Perfil",
+    "audio": "Audio",
+    "video": "Vídeo",
+    "general": "General",
+    "notifications": "Notificaciones",
+    "accessibility": "Accesibilidad",
+    "transcription": "Transcripción",
+    "shortcuts": "Atajos",
+    "rooms": "Reuniones"
+  },
+  "roomDefaults": {
+    "heading": "Configuración predeterminada de las reuniones",
+    "description": "Elige la configuración que se aplica de forma predeterminada a las nuevas reuniones que crees. Siempre podrás modificarla para cada reunión desde la configuración de administración."
+  }
+}

--- a/src/frontend/src/locales/es/settings.json
+++ b/src/frontend/src/locales/es/settings.json
@@ -21,7 +21,7 @@
   "audio": {
     "microphone": {
       "heading": "Micrófono",
-      "label": "Selecciona tu entrada de audio",
+      "label": "Dispositivo de entrada de audio",
       "disabled": "Micrófono desactivado"
     },
     "noiseReduction": {
@@ -34,7 +34,7 @@
     },
     "speakers": {
       "heading": "Altavoces",
-      "label": "Selecciona tu salida de audio",
+      "label": "Dispositivo de salida de audio",
       "test": "Probar",
       "ongoingTest": "Probando el sonido…",
       "safariWarning": "La selección del altavoz todavía no está disponible en Safari debido a limitaciones del navegador."
@@ -44,7 +44,7 @@
   "video": {
     "camera": {
       "heading": "Cámara",
-      "label": "Selecciona tu entrada de vídeo",
+      "label": "Dispositivo de entrada de vídeo",
       "disabled": "Cámara desactivada",
       "previewAriaLabel": {
         "enabled": "Vista previa de vídeo activada",
@@ -183,7 +183,7 @@
     "rooms": "Reuniones"
   },
   "roomDefaults": {
-    "heading": "Configuración predeterminada de las reuniones",
-    "description": "Elige la configuración que se aplica de forma predeterminada a las nuevas reuniones que crees. Siempre podrás modificarla para cada reunión desde la configuración de administración."
+    "heading": "Ajustes predeterminados de las reuniones",
+    "description": "Elige la configuración que se aplica de forma predeterminada a las nuevas reuniones que crees. Siempre podrás modificarla para cada reunión desde el menu de configuración."
   }
 }

--- a/src/frontend/src/locales/es/termsOfService.json
+++ b/src/frontend/src/locales/es/termsOfService.json
@@ -106,7 +106,7 @@
           "paragraphs": [
             "La DINUM presta el soporte de primer nivel a los usuarios y usuarias, exclusivamente sobre los aspectos técnicos de la aplicación.",
             "Se puede contactar con este soporte mediante el formulario de contacto en línea.",
-            "El objetivo de respuesta a las solicitudes es de dos días laborables desde el envío del correo electrónico; este plazo puede variar según la complejidad y el número de solicitudes que deban tramitarse."
+            "El objetivo de respuesta a las solicitudes es de dos días laborales desde el envío del correo electrónico; este plazo puede variar según la complejidad y el número de solicitudes que deban tramitarse."
           ]
         },
         "section4": {

--- a/src/frontend/src/locales/es/termsOfService.json
+++ b/src/frontend/src/locales/es/termsOfService.json
@@ -1,0 +1,130 @@
+{
+  "title": "Condiciones de uso de Visio",
+  "articles": {
+    "article1": {
+      "title": "1. Ámbito de aplicación",
+      "content": "Este documento define las condiciones de uso de Visio (en adelante, «Visio» o «la aplicación»), una aplicación de videoconferencia diseñada especialmente para las administraciones del Estado y los organismos bajo su tutela."
+    },
+    "article2": {
+      "title": "2. Objeto de la aplicación",
+      "content": "Visio permite favorecer la cooperación de los equipos de las administraciones del Estado y de los organismos bajo su tutela, así como el trabajo a distancia, y facilitar la organización de reuniones, conferencias o formaciones.",
+      "paragraphs": [
+        "Visio está desarrollada y operada por la Dirección Interministerial de lo Digital (DINUM).",
+        "La DINUM pone la aplicación a disposición de las administraciones del Estado y de los organismos bajo su tutela, destinada a sus empleados, colaboradores y proveedores invitados.",
+        "Todo uso de Visio debe respetar estas condiciones de uso y, en su caso, la doctrina de empleo de la administración de adscripción."
+      ]
+    },
+    "article3": {
+      "title": "3. Definiciones",
+      "paragraphs": [
+        "Visio es el producto cuyo uso se describe en estas condiciones y que se presenta en la siguiente página: https://visio.numerique.gouv.fr.",
+        "Los usuarios y usuarias de Visio son toda persona que utilice Visio con fines de comunicación por videoconferencia, ya sean empleados, colaboradores o proveedores de las administraciones de adscripción. La administración de adscripción es la administración del Estado y los organismos bajo su tutela que pone Visio a disposición de sus empleados, colaboradores o proveedores.",
+        "Los organizadores y organizadoras de sala son usuarios y usuarias responsables de una sala de videoconferencia tras haber iniciado sesión mediante ProConnect.",
+        "La administración de adscripción es la administración perteneciente al sistema de información y comunicación del Estado que pone Visio a disposición de sus empleados, colaboradores o proveedores."
+      ]
+    },
+    "article4": {
+      "title": "4. Acceso al servicio",
+      "definition": "Visio se pone a disposición de los usuarios y usuarias por parte de su administración de adscripción. Los organizadores y organizadoras pueden después transmitir un enlace que permite acceder a la sala a cualquier persona, bajo su responsabilidad."
+    },
+    "article5": {
+      "title": "5. Funcionalidades",
+      "sections": {
+        "section1": {
+          "title": "5.1. Funcionalidades abiertas a los organizadores y organizadoras",
+          "content": "Visio ofrece a los empleados de las administraciones del Estado y de los organismos bajo su tutela la posibilidad de crear una sala de videoconferencia desde un puesto de trabajo estándar, vinculado a su cuenta ProConnect.",
+          "paragraph1": "A continuación puede compartir el enlace de la reunión con otras personas, usuarios y usuarias, formen parte o no de la administración.",
+          "paragraph2": "A tal efecto, cada organizador u organizadora de sala puede:",
+          "capabilities": [
+            "Proteger el acceso a la sala mediante una sala de espera;",
+            "Autorizar la entrada de cada usuario y usuaria en la sala;",
+            "Silenciar los micrófonos y las cámaras de los usuarios y usuarias;",
+            "Expulsar a un usuario o usuaria de la sala;",
+            "Utilizar la herramienta de transcripción de la reunión tras haber obtenido la conformidad de los usuarios y usuarias, bajo su responsabilidad."
+          ],
+          "paragraph3": "Los empleados deben dirigirse a su administración de adscripción para asegurarse del marco de uso dentro de Visio, en particular en lo que respecta a las reuniones sujetas a obligaciones reforzadas de confidencialidad.",
+          "paragraph4": "Los organizadores y organizadoras pueden utilizar la herramienta de transcripción automática desde el menú de configuración de la sala. Corresponde a los organizadores y organizadoras asegurarse de la conformidad de los usuarios y usuarias que participan en la reunión transcrita. El idioma de transcripción puede modificarse desde el mismo menú. Al final de la reunión, se transmite al organizador u organizadora un enlace para acceder a la transcripción conservada en la herramienta denominada Docs, operada por la DINUM."
+        },
+        "section2": {
+          "title": "5.2. Funcionalidades abiertas a los usuarios y usuarias",
+          "content": "Visio permite a todo usuario y usuaria, sea o no empleado público, participar en cualquier sala de Visio a la que le invite un organizador u organizadora y disfrutar de las funcionalidades.",
+          "paragraph": "A tal efecto, cada usuario y usuaria puede:",
+          "capabilities": [
+            "facilitar una identidad mostrada al entrar en la sala;",
+            "comunicarse a distancia por audio o vídeo;",
+            "compartir su pantalla;",
+            "intercambiar mensajes durante la sesión de forma pública con todos los usuarios y usuarias de la misma;",
+            "acceder a información técnica sobre la sala y a funcionalidades de accesibilidad;",
+            "activar o desactivar su cámara o su micrófono en cualquier momento;",
+            "proteger la intimidad de su entorno en caso de activar la cámara, seleccionando y activando un fondo de pantalla antes de entrar en la sala o incluso durante la videoconferencia."
+          ]
+        }
+      }
+    },
+    "article6": {
+      "title": "6. Compromisos y responsabilidades de los usuarios y usuarias",
+      "sections": {
+        "section1": {
+          "title": "6.1 Usos conformes",
+          "paragraphs": [
+            "Visio se pone a disposición para facilitar los intercambios profesionales entre los empleados de las administraciones del Estado y sus organismos bajo tutela y los colaboradores externos a la administración.",
+            "El usuario o la usuaria es responsable de las imágenes y los sonidos que hace accesibles en la sala de videoconferencia. Esta responsabilidad se aplica tanto a lo que la cámara o el micrófono pueden difundir como a lo que su terminal puede hacer accesible a terceros. A tal fin, el usuario o la usuaria procura utilizar la aplicación en un entorno profesional y no difundir a terceros ninguna información cubierta por la obligación de discreción profesional (por ejemplo: uso de filtro de privacidad, de auriculares, etc.).",
+            "El usuario o la usuaria es responsable de los datos o contenidos que introduce en el servicio de mensajería de la sala de videoconferencia. Procura introducir únicamente mensajes apropiados."
+          ]
+        },
+        "section2": {
+          "title": "6.2 Usos prohibidos",
+          "paragraphs": [
+            "El usuario o la usuaria se compromete a no introducir en el servicio de mensajería de la sala de Visio ni hacer accesibles mediante imagen o sonido contenidos o información contrarios a las disposiciones legales y reglamentarias vigentes."
+          ]
+        }
+      }
+    },
+    "article7": {
+      "title": "7. Compromisos y responsabilidades de la DINUM",
+      "sections": {
+        "section1": {
+          "title": "7.1. Seguridad de la aplicación",
+          "paragraphs": [
+            "La DINUM se compromete a la protección de Visio, en particular adoptando todas las medidas necesarias para garantizar la seguridad y la confidencialidad de los intercambios.",
+            "La aplicación está homologada en las condiciones previstas por el decreto n.º 2010-112 modificado."
+          ]
+        },
+        "section2": {
+          "title": "7.2. Acceso a la aplicación",
+          "paragraphs": [
+            "La DINUM se compromete a proporcionar los medios necesarios y razonables para garantizar un acceso continuo a la aplicación.",
+            "El horario de apertura de la aplicación es 24 horas al día, 7 días a la semana, salvo en los periodos de indisponibilidad por mantenimiento.",
+            "La DINUM persigue un objetivo de disponibilidad anual de la aplicación del 99,5 %, sin contar las indisponibilidades planificadas. En caso de incidencia o mantenimiento, aspira a un plazo de restablecimiento de 72 horas en horas no laborables.",
+            "En el marco de un mantenimiento del entorno de ejecución de la aplicación, la DINUM se reserva el derecho de suspender temporalmente el funcionamiento de la aplicación. En la medida de lo posible, informa a los usuarios con un mínimo de 48 horas de antelación. En caso de urgencia, esta suspensión puede producirse sin previo aviso.",
+            "Estas interrupciones excepcionales pueden ser necesarias, por ejemplo, para operaciones de gestión de datos, de puesta en producción o de cambios de arquitectura.",
+            "La indisponibilidad de la aplicación no da derecho a compensación alguna de ninguna naturaleza."
+          ]
+        },
+        "section3": {
+          "title": "7.3. Gestión del soporte",
+          "paragraphs": [
+            "La DINUM presta el soporte de primer nivel a los usuarios y usuarias, exclusivamente sobre los aspectos técnicos de la aplicación.",
+            "Se puede contactar con este soporte mediante el formulario de contacto en línea.",
+            "El objetivo de respuesta a las solicitudes es de dos días laborables desde el envío del correo electrónico; este plazo puede variar según la complejidad y el número de solicitudes que deban tramitarse."
+          ]
+        },
+        "section4": {
+          "title": "7.4. Control del uso de la aplicación",
+          "paragraphs": [
+            "La DINUM se reserva el derecho de suspender o eliminar la cuenta de un usuario o usuaria que haya incumplido estas condiciones de uso, sin perjuicio de las eventuales acciones de responsabilidad penal y civil que pudieran emprenderse contra la persona afectada. Los elementos podrían transmitirse a la administración de adscripción del usuario o la usuaria, al ser esta responsable de la puesta a disposición de la aplicación.",
+            "La suspensión o revocación de una o varias cuentas no da lugar a compensación alguna de ningún tipo."
+          ]
+        },
+        "section5": {
+          "title": "7.5. Código abierto y licencias",
+          "content": "El código fuente del servicio es libre y está disponible aquí: https://github.com/suitenumerique/meet. Los contenidos propuestos por la DINUM están bajo Licencia Abierta 2.0, a excepción de los logotipos y de las representaciones iconográficas y fotográficas, que pueden regirse por sus propias licencias."
+        }
+      }
+    },
+    "article8": {
+      "title": "8. Evolución de las condiciones de uso",
+      "content": "Los términos de estas condiciones de uso pueden modificarse o completarse en cualquier momento, sin previo aviso, en función de las modificaciones introducidas en el servicio, de la evolución de la legislación o por cualquier otro motivo que se considere necesario.\nEstas modificaciones y actualizaciones se imponen al usuario o la usuaria, que debe, en consecuencia, consultar regularmente esta sección para comprobar las condiciones vigentes."
+    }
+  }
+}

--- a/src/frontend/src/utils/languages.ts
+++ b/src/frontend/src/utils/languages.ts
@@ -1,13 +1,14 @@
 // Map frontend language codes to backend language codes
 
-export type BackendLanguage = 'en-us' | 'fr-fr' | 'nl-nl' | 'de-de'
-export type FrontendLanguage = 'en' | 'fr' | 'nl' | 'de'
+export type BackendLanguage = 'en-us' | 'fr-fr' | 'nl-nl' | 'de-de' | 'es-es'
+export type FrontendLanguage = 'en' | 'fr' | 'nl' | 'de' | 'es'
 
 const frontendToBackendMap: Record<FrontendLanguage, BackendLanguage> = {
   en: 'en-us',
   fr: 'fr-fr',
   nl: 'nl-nl',
   de: 'de-de',
+  es: 'es-es',
 }
 
 export const convertToBackendLanguage = (


### PR DESCRIPTION
Related to #1115 

I've started working on this, having like a IA generated transalation based and I was going to start doing a first verification of the result but then I realized everything seems to be handled on Crowdin directly ? so even if this gets merged It will be overwrited with whatever we have on spanish side on that platform ?

@lebaudantoine maybe I can help there also as a external collaborator or let me know if this is not a priority at the moment :)

thanks

<img width="1150" height="623" alt="image" src="https://github.com/user-attachments/assets/867a136a-50f0-4efb-82b8-5870f271aff1" />
