### PR TITLE
configure audio to be mono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - ⬆️(frontend) upgrade @tanstack/react-query from 5.101.1 to 5.101.4
 - ⬆️(frontend) upgrade @pandacss/preset-panda from 1.11.3 to 1.12.0
 - ⬆️(frontend) upgrade posthog-js from 1.404.1 to 1.409.5
+- ⚡️(frontend) apply frugal constraint to the active meeting audio track
 
 ## [1.28.0] - 2026-08-24
 

--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -43,6 +43,7 @@ import { useSnapshot } from 'valtio'
 import { userPreferencesStore } from '@/stores/userPreferences'
 import { userStore } from '@/stores/user'
 import { WatchMediaDeviceErrors } from './WatchMediaDeviceErrors'
+import { VOICE_AUDIO_CONSTRAINTS } from '@/features/rooms/livekit/utils/constants'
 
 export const Conference = ({
   roomId,
@@ -115,6 +116,7 @@ export const Conference = ({
       },
       audioCaptureDefaults: {
         deviceId: userConfig.audioDeviceId ?? undefined,
+        ...VOICE_AUDIO_CONSTRAINTS,
       },
       audioOutput: {
         deviceId: userConfig.audioOutputDeviceId ?? undefined,

--- a/src/frontend/src/features/rooms/livekit/hooks/useJoinTracks.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useJoinTracks.ts
@@ -18,6 +18,7 @@ import {
   noteDeviceReady,
   onMediaPermissionError,
 } from '../utils/mediaPermissions'
+import { VOICE_AUDIO_CONSTRAINTS } from '../utils/constants'
 import {
   saveAudioInputDeviceId,
   saveAudioInputEnabled,
@@ -26,16 +27,6 @@ import {
   userChoicesStore,
 } from '@/stores/userChoices'
 import { useSyncTrackDeviceId } from './useSyncTrackDeviceId'
-
-const VOICE_AUDIO_CONSTRAINTS = {
-  noiseSuppression: true,
-  echoCancellation: true,
-  autoGainControl: true,
-  voiceIsolation: false,
-  sampleRate: 48000,
-  channelCount: 1,
-  sampleSize: 16,
-} as const
 
 // Module-level: effect dependencies, must be referentially stable.
 const disableAudio = () => saveAudioInputEnabled(false)

--- a/src/frontend/src/features/rooms/livekit/utils/constants.ts
+++ b/src/frontend/src/features/rooms/livekit/utils/constants.ts
@@ -1,0 +1,9 @@
+export const VOICE_AUDIO_CONSTRAINTS = {
+  noiseSuppression: true,
+  echoCancellation: true,
+  autoGainControl: true,
+  voiceIsolation: false,
+  sampleRate: 48000,
+  channelCount: 1,
+  sampleSize: 16,
+} as const


### PR DESCRIPTION
Goal is to save bandwidth, was introduced on the join track in the BBBA PR