### PR TITLE
🐛(frontend) fix chat text-area bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 - 🔥(backend) remove the S3 storage-event webhook for recordings
 - ♻️(backend) always finalize recordings using the LiveKit egress_ended webhook
 
+### Fixed
+
+- 🐛(frontend) fix chat text-area bug
+
 ## [1.29.0] - 2026-08-25
 
 ### Added

--- a/src/frontend/src/features/chat/components/ChatTextArea.tsx
+++ b/src/frontend/src/features/chat/components/ChatTextArea.tsx
@@ -21,7 +21,9 @@ const StyledContainer = styled('div', {
 })
 
 export const ChatTextArea = () => {
-  const { isSending, send, textAreaValue } = useSnapshot(chatStore)
+  const { isSending, send, textAreaValue } = useSnapshot(chatStore, {
+    sync: true,
+  })
 
   const { t } = useTranslation('rooms', { keyPrefix: 'controls.chat.input' })
 


### PR DESCRIPTION
## Purpose

Whenever a character was typed, the caret would jump to the end of the textarea.
The bug was due to async behavior from Valtio.

Fixes #1656.

## Steps to reproduce

1. Open chat panel
2. Click textarea
3. Type something
4. Move the cursor anywhere inside the text you've typed
5. Type multiple letters

Expected: ...text being inserted where you've put your cursor.
Actual: one letter being inserted at the right place, all the others at the end of the text area.

(With variants for dead keys – typing `^` then `e` would not output `ê` but `^e`.)