### PR TITLE
✨(frontend) add 1080p sending resolution option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(frontend) add 1080p sending resolution option #1660
+
 ### Fixed
 
 - 🐛(frontend) keep the sending resolution picked while the camera is off #1667

--- a/docker/dinum-frontend/Dockerfile
+++ b/docker/dinum-frontend/Dockerfile
@@ -65,6 +65,7 @@ RUN apk update && apk upgrade  \
     musl \
     musl-utils \
     zlib>=1.3.2-r0 \
+    libexpat>=2.8.4-r0 \
     && apk del curl
 
 USER nginx

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -53,6 +53,7 @@ RUN apk update && apk upgrade  \
     musl \
     musl-utils \
     zlib>=1.3.2-r0 \
+    libexpat>=2.8.4-r0 \
     && apk del curl
 
 USER nginx

--- a/src/frontend/src/features/settings/components/tabs/VideoTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/VideoTab.tsx
@@ -18,6 +18,7 @@ import {
   saveVideoPublishResolution,
   saveVideoSubscribeQuality,
   userChoicesStore,
+  VIDEO_RESOLUTIONS,
   VideoResolution,
 } from '@/stores/userChoices'
 import { RowWrapper } from './layout/RowWrapper'
@@ -70,7 +71,7 @@ export const VideoTab = ({ id }: VideoTabProps) => {
         isDisabled: true,
       }
 
-  const handleVideoResolutionChange = async (key: 'h720' | 'h360' | 'h180') => {
+  const handleVideoResolutionChange = async (key: VideoResolution) => {
     saveVideoPublishResolution(key)
     const videoTrack = localParticipant.getTrackPublication(
       Track.Source.Camera
@@ -124,20 +125,13 @@ export const VideoTab = ({ id }: VideoTabProps) => {
   }, [videoDeviceId, videoElement])
 
   const resolutionItems = useMemo(() => {
-    return [
-      {
-        value: 'h720',
-        label: `${t('resolution.publish.items.high')} (720p)`,
-      },
-      {
-        value: 'h360',
-        label: `${t('resolution.publish.items.medium')} (360p)`,
-      },
-      {
-        value: 'h180',
-        label: `${t('resolution.publish.items.low')} (180p)`,
-      },
-    ]
+    const labels: Record<VideoResolution, string> = {
+      h1080: `${t('resolution.publish.items.veryHigh')} (1080p)`,
+      h720: `${t('resolution.publish.items.high')} (720p)`,
+      h360: `${t('resolution.publish.items.medium')} (360p)`,
+      h180: `${t('resolution.publish.items.low')} (180p)`,
+    }
+    return VIDEO_RESOLUTIONS.map((value) => ({ value, label: labels[value] }))
   }, [t])
 
   const videoQualityItems = useMemo(() => {

--- a/src/frontend/src/locales/de/settings.json
+++ b/src/frontend/src/locales/de/settings.json
@@ -56,6 +56,7 @@
       "publish": {
         "label": "Wähle die maximale Auflösung beim Senden",
         "items": {
+          "veryHigh": "Sehr hohe Auflösung",
           "high": "Hohe Auflösung",
           "medium": "Mittlere Auflösung",
           "low": "Niedrige Auflösung"

--- a/src/frontend/src/locales/en/settings.json
+++ b/src/frontend/src/locales/en/settings.json
@@ -56,6 +56,7 @@
       "publish": {
         "label": "Select your sending resolution (max.)",
         "items": {
+          "veryHigh": "Very high definition",
           "high": "High definition",
           "medium": "Standard definition",
           "low": "Low definition"

--- a/src/frontend/src/locales/es/settings.json
+++ b/src/frontend/src/locales/es/settings.json
@@ -56,6 +56,7 @@
       "publish": {
         "label": "Selecciona tu resolución de envío (máx.)",
         "items": {
+          "veryHigh": "Muy alta definición",
           "high": "Alta definición",
           "medium": "Definición estándar",
           "low": "Baja definición"

--- a/src/frontend/src/locales/fr/settings.json
+++ b/src/frontend/src/locales/fr/settings.json
@@ -56,6 +56,7 @@
       "publish": {
         "label": "Sélectionner votre résolution d'envoi (max.)",
         "items": {
+          "veryHigh": "Très haute définition",
           "high": "Haute définition",
           "medium": "Définition standard",
           "low": "Basse définition"

--- a/src/frontend/src/locales/nl/settings.json
+++ b/src/frontend/src/locales/nl/settings.json
@@ -56,6 +56,7 @@
       "publish": {
         "label": "Selecteer uw verzendresolutie (max.)",
         "items": {
+          "veryHigh": "Zeer hoge definitie",
           "high": "Hoge definitie",
           "medium": "Standaarddefinitie",
           "low": "Lage definitie"

--- a/src/frontend/src/stores/userChoices.ts
+++ b/src/frontend/src/stores/userChoices.ts
@@ -10,7 +10,12 @@ import {
 } from '@livekit/components-core'
 import { VideoQuality } from 'livekit-client'
 
-export type VideoResolution = 'h720' | 'h360' | 'h180'
+export const VIDEO_RESOLUTIONS = ['h1080', 'h720', 'h360', 'h180'] as const
+
+export type VideoResolution = (typeof VIDEO_RESOLUTIONS)[number]
+
+const isVideoResolution = (value: unknown): value is VideoResolution =>
+  VIDEO_RESOLUTIONS.includes(value as VideoResolution)
 
 export type LocalUserChoices = Omit<LocalUserChoicesLK, 'username'> & {
   processorConfig?: ProcessorConfig
@@ -21,13 +26,17 @@ export type LocalUserChoices = Omit<LocalUserChoicesLK, 'username'> & {
 }
 
 function getUserChoicesState(): LocalUserChoices {
-  return {
+  const stored: LocalUserChoices = {
     noiseReductionEnabled: false,
     audioOutputDeviceId: 'default', // Use 'default' to match LiveKit's standard device selection behavior
     videoPublishResolution: 'h720',
     videoSubscribeQuality: VideoQuality.HIGH,
     ...loadUserChoices(),
   }
+  if (!isVideoResolution(stored.videoPublishResolution)) {
+    stored.videoPublishResolution = 'h720'
+  }
+  return stored
 }
 
 export const userChoicesStore = proxy<LocalUserChoices>(getUserChoicesState())


### PR DESCRIPTION
## What

Adds a 1080p entry to the sending resolution selector, which stopped at 720p.

## Why

`VideoPresets` already exposes `h1080` (1920×1080), and `videoCaptureDefaults.resolution` already reads whatever the user picked. Publishers on a good uplink simply had no way to use the capacity they had — the selector was the only thing in the way.

The default stays `h720`. Nothing changes unless a user goes and picks the new entry.

## The part that needs a maintainer decision

Being explicit rather than reassuring: 1080p roughly doubles a publisher's uplink, and **an instance operator has no way today to decline it**. This is a per-user choice, and the existing `ApiConfig` flags (`recording.is_enabled`, `telephony.enabled`, `diagnostics.connection_test_enabled`, …) all govern whole features or backend-provided resources — none of them govern client media quality, so there is no obvious precedent to follow.

Whether that warrants a server-side setting is your call, not mine. I would rather ask than change the API contract unasked in a frontend PR. Happy to add one in this PR if you want it.

## Also in here

The option list was easy to get wrong, and adding a fourth entry made that worse, so while in the file:

- resolutions now come from a single `VIDEO_RESOLUTIONS` tuple that `VideoResolution` derives from;
- the selector items are built by mapping over that tuple against a `Record<VideoResolution, string>` of labels, so a resolution cannot be added to one and forgotten in the other — in either direction;
- a persisted value that is not in the tuple falls back to `h720`. `loadUserChoices` spreads localStorage without validating it, so the declared type was a claim rather than a guarantee; an unknown value would have reached `VideoPresets[...]` and indexed it as `undefined`.

## Known limitation, unchanged by this PR

`restartTrack` passes the resolution as an `ideal` constraint, so a camera that cannot reach the selected height degrades silently, with no feedback in the UI. That is already true of 720p on a 480p webcam. 1080p is the first step where the gap is the common case rather than the edge one — worth knowing, though fixing it properly needs `getCapabilities()` and a rework of the selector, which felt out of scope here.

## Measured in production, 2026-09-01

Numbers rather than adjectives, from a real two-participant call on our instance — publisher on a MacBook Pro M1 Pro 16", Chrome 151, over `chrome://webrtc-internals`:

| | |
|---|---|
| `frameWidth` × `frameHeight` | **1920 × 1080** at 30 fps |
| Codec / mode | VP9, `scalabilityMode` **L3T3_KEY** |
| Uplink | **2.6 Mb/s** |
| `qualityLimitationReason` | `none` — 0.085 s of `bandwidth` limitation over **830 s** of call, 0 s of `cpu` |
| Loss | **1 retransmitted packet out of 186,534 sent**, `nackCount` 0 |

The cost is real and worth stating: `encoderImplementation` is **`libvpx`** with `powerEfficientEncoder: false`, i.e. software VP9, at **11.4 ms per frame**. Comfortable on an M1 Pro, plausibly not on a modest laptop — which is an argument for keeping `h720` the default, as this PR does, and possibly for the operator-side setting offered above.

Receiving peer was an iPhone on cellular; it subscribed to the medium layer, as expected for a small tile.

## Translations

`resolution.publish.items.veryHigh` added to all five locales. I understand `fr` is the Crowdin source and the other four are generated, so please treat `en`/`de`/`es`/`nl` as placeholders for your translators to review.

## Testing

`tsc -b`, `eslint --max-warnings 0` and `prettier --check` are clean. Running in production on a self-hosted instance since 2026-07-22.

---

*Contributed on behalf of [ALTERNATECH](https://alternatech.io), a French non-profit hosting a public Meet instance.*

