### PR TITLE
✨(frontend) expose publish permissions in MediaStateObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - ✨(agent) support Voxtral realtime as inference engine
 - 🌐(i18n) add Spanish language support
+- ✨(frontend) expose publish permissions on the media state element #1661
 
 ### Changed
 

--- a/src/frontend/src/features/rooms/livekit/components/MediaStateObserver.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/MediaStateObserver.tsx
@@ -1,5 +1,7 @@
 import { useLocalParticipant } from '@livekit/components-react'
+import { TrackSource } from '@livekit/protocol'
 import { useEffect } from 'react'
+import { useCanPublishTrack } from '@/features/rooms/livekit/hooks/useCanPublishTrack'
 
 export const MEDIA_STATE_ELEMENT_ID = 'media-state'
 export const MEDIA_STATE_CHANGED_EVENT = 'media-state-changed'
@@ -7,6 +9,8 @@ export const MEDIA_STATE_CHANGED_EVENT = 'media-state-changed'
 export type MediaStateChangedDetail = {
   microphoneEnabled: boolean
   cameraEnabled: boolean
+  canPublishMicrophone: boolean
+  canPublishCamera: boolean
 }
 
 /**
@@ -16,9 +20,15 @@ export type MediaStateChangedDetail = {
  *
  * const el = document.getElementById('media-state')
  * new MutationObserver(...).observe(el, { attributes: true })
+ *
+ * The publish permissions are exposed alongside the state: an external tool
+ * cannot tell a muted microphone from one it is not allowed to unmute, and
+ * would otherwise offer a control that silently does nothing.
  */
 export const MediaStateObserver = () => {
   const { isMicrophoneEnabled, isCameraEnabled } = useLocalParticipant()
+  const canPublishMicrophone = useCanPublishTrack(TrackSource.MICROPHONE)
+  const canPublishCamera = useCanPublishTrack(TrackSource.CAMERA)
 
   useEffect(() => {
     window.dispatchEvent(
@@ -26,10 +36,17 @@ export const MediaStateObserver = () => {
         detail: {
           microphoneEnabled: isMicrophoneEnabled,
           cameraEnabled: isCameraEnabled,
+          canPublishMicrophone,
+          canPublishCamera,
         },
       })
     )
-  }, [isMicrophoneEnabled, isCameraEnabled])
+  }, [
+    isMicrophoneEnabled,
+    isCameraEnabled,
+    canPublishMicrophone,
+    canPublishCamera,
+  ])
 
   return (
     <div
@@ -37,6 +54,8 @@ export const MediaStateObserver = () => {
       style={{ display: 'none' }}
       data-microphone-enabled={isMicrophoneEnabled ? 'true' : 'false'}
       data-camera-enabled={isCameraEnabled ? 'true' : 'false'}
+      data-can-publish-microphone={canPublishMicrophone ? 'true' : 'false'}
+      data-can-publish-camera={canPublishCamera ? 'true' : 'false'}
     />
   )
 }


### PR DESCRIPTION
## Purpose

`MediaStateObserver` (introduced in 1.25.0) exposes the local participant's
microphone and camera state in the DOM so external tools automating the
frontend can read it and watch for changes with a `MutationObserver`.

It does not expose whether publication is *allowed*. Such a tool therefore
cannot tell a microphone the user muted from one the organiser locked, and
ends up offering a control that silently does nothing — the very failure
mode the component was meant to remove.

The information is readable today from the `disabled` state of the control
button, but that is a rendering detail liable to change without notice, and
its disappearance would make an external tool report "publication allowed"
incorrectly. Hence the request for a stable attribute.

## Proposal

Expose the publish permissions alongside the media state, reusing the
existing `useCanPublishTrack()` hook that already gates the web client's own
controls. This is parity between the web client and any external consumer,
not new data.

- [x] add `canPublishMicrophone` / `canPublishCamera` to `MediaStateChangedDetail`
- [x] emit them in the `media-state-changed` event detail
- [x] add them to the `useEffect` dependencies, so a permission change emits
      the event even when the enabled state does not move — the real case,
      where the organiser revokes publication on an already connected client
- [x] expose `data-can-publish-microphone` / `data-can-publish-camera` on the
      observed element
- [x] document the rationale in the component's header comment

The change is additive: existing consumers reading `data-microphone-enabled`
and `data-camera-enabled` are unaffected.

Verified on a local deployment with two participants, an owner and an
unprivileged member. Toggling publication from the admin panel updates both
attributes independently per source, and emits `media-state-changed` even
when the enabled state does not change.