### PR TITLE
📝(docs) document v1.30.0 in UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,8 @@ the following command inside your docker container:
 
 ## [Unreleased]
 
+## v1.30.0
+
 ### Removing S3 storage-event webhooks for recordings
 
 Recordings were previously confirmed as saved by an S3 storage-event webhook posting to `/api/v1.0/recordings/storage-hook/`. That endpoint has been removed: recordings are now always finalized from LiveKit's own `egress_ended` webhook, which has been the default path since v1.22.0.


### PR DESCRIPTION
Add the missing v1.30.0 entry in `UPGRADE.md`, which was overlooked when the release was published.

