### PR TITLE
🐛(frontend) keep the sending resolution picked while the camera is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(frontend) keep the sending resolution picked while the camera is off #1667
+
 ## [1.30.0] - 2026-09-01
 
 ### Added

--- a/src/frontend/src/features/rooms/livekit/components/controls/Device/VideoDeviceControl.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Device/VideoDeviceControl.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useTrackToggle, UseTrackToggleProps } from '@livekit/components-react'
 import { Button, Popover } from '@/primitives'
 import { RiArrowUpSLine, RiImageCircleAiFill } from '@remixicon/react'
-import { Track, type VideoCaptureOptions } from 'livekit-client'
+import { Track, type VideoCaptureOptions, VideoPresets } from 'livekit-client'
 
 import { ToggleDevice } from './ToggleDevice'
 import { css } from '@/styled-system/css'
@@ -57,7 +57,8 @@ export const VideoDeviceControl = ({
 }: VideoDeviceControlProps) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'selectDevice' })
 
-  const { videoDeviceId, processorConfig } = useSnapshot(userChoicesStore)
+  const { videoDeviceId, processorConfig, videoPublishResolution } =
+    useSnapshot(userChoicesStore)
 
   const onChange = React.useCallback(
     (enabled: boolean, isUserInitiated: boolean) =>
@@ -97,6 +98,9 @@ export const VideoDeviceControl = ({
 
     await toggle(!trackProps.enabled, {
       processor: processor,
+      ...(videoPublishResolution && {
+        resolution: VideoPresets[videoPublishResolution].resolution,
+      }),
     } as VideoCaptureOptions)
   }
 

--- a/src/frontend/src/features/settings/components/tabs/VideoTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/VideoTab.tsx
@@ -32,7 +32,8 @@ const EMPTY_PROPS = {}
 
 export const VideoTab = ({ id }: VideoTabProps) => {
   const { t } = useTranslation('settings', { keyPrefix: 'video' })
-  const { localParticipant, remoteParticipants } = useRoomContext()
+  const room = useRoomContext()
+  const { localParticipant, remoteParticipants } = room
 
   const {
     videoDeviceId,
@@ -70,19 +71,20 @@ export const VideoTab = ({ id }: VideoTabProps) => {
       }
 
   const handleVideoResolutionChange = async (key: 'h720' | 'h360' | 'h180') => {
-    const videoPublication = localParticipant.getTrackPublication(
+    saveVideoPublishResolution(key)
+    const videoTrack = localParticipant.getTrackPublication(
       Track.Source.Camera
-    )
-    const videoTrack = videoPublication?.track
-    if (videoTrack) {
-      saveVideoPublishResolution(key)
-      await videoTrack.restartTrack({
-        resolution: VideoPresets[key].resolution,
-        deviceId: { exact: videoDeviceId },
-        processor:
-          BackgroundProcessorFactory.fromProcessorConfig(processorConfig),
-      })
+    )?.track
+    if (!videoTrack) {
+      return
     }
+
+    await videoTrack.restartTrack({
+      resolution: VideoPresets[key].resolution,
+      deviceId: { exact: videoDeviceId },
+      processor:
+        BackgroundProcessorFactory.fromProcessorConfig(processorConfig),
+    })
   }
 
   /**


### PR DESCRIPTION
## What

Choosing a sending resolution while the camera is **off** does nothing at all — the choice is neither applied nor persisted — while the selector goes on showing the value that was just picked.

`handleVideoResolutionChange` performs all of its work inside `if (videoTrack)`, `saveVideoPublishResolution` included:

```ts
const videoTrack = videoPublication?.track
if (videoTrack) {
  saveVideoPublishResolution(key)   // ← never runs when the camera is off
  await videoTrack.restartTrack({ … })
}
```

## How it was found

On a self-hosted instance (v1.22.0): a user turned the camera off, set the sending resolution, turned the camera back on — and the publisher kept sending 720p. `chrome://webrtc-internals` confirmed `frameWidth`/`frameHeight` unchanged, and nothing in the UI hinted the choice had been dropped. Setting it again with the camera **on** applied immediately.

## The fix

Two parts, because persisting alone is not enough inside a live session:

1. **Persist first, unconditionally**, then restart the track only if there is one.
2. **Keep `room.options.videoCaptureDefaults.resolution` in step.** `roomOptions` is only read by `new Room(...)`, so a store update never reaches a room that is already built, and `setCameraEnabled` builds its track from the room's capture defaults. Without this, turning the camera back on in the same session still uses the old resolution.

The early return is deliberate: with no live track there is nothing to await, and the defaults above cover the next publish.

## Notes

- No behaviour change when the camera is on.
- Touches the same handler as #1660, but stands alone and applies to the current option set; whichever lands first, the other is a trivial rebase.
- Sent on behalf of [ALTERNATECH](https://alternatech.io), a small French non-profit running a self-hosted instance.