### PR TITLE
✨(frontend) track processors bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to
 - 🔊(backend) log request duration in Gunicorn workers
 - 📈(frontend) track missing lobby participant on accept/reject
 - ✨(backend) sort waiting participants by their arrival time
+- ✨(frontend) add a dev-only benchmark harness for livekit track processors
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,21 @@ LINT_SUMMARY        = echo 'lint:ruff-format started…' && $(LINT_RUFF_FORMAT) 
 # -- Frontend
 PATH_FRONT          = ./src/frontend
 
+# -- Frontend / processor benchmark
+# Chrome launched with the GPU off, for the dev-only processor benchmark.
+# Override the binary with e.g. `make run-frontend-nogpu CHROME=chromium`.
+CHROME_MACOS        = /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+CHROME              = $(shell test -x "$(CHROME_MACOS)" && echo "$(CHROME_MACOS)" \
+  || command -v google-chrome || command -v chromium || command -v chromium-browser)
+# Overridable, because VITE_PORT is not always 3000 (see compose.yml and the
+# helm values): `make run-frontend-nogpu BENCH_PORT=8080`.
+BENCH_PORT         ?= 3000
+BENCH_URL          ?= http://localhost:$(BENCH_PORT)/processor-bench
+# A throwaway profile is mandatory, not cosmetic: if Chrome is already running
+# with the default profile, a second launch just opens a tab in the existing
+# process and --disable-gpu is silently ignored.
+BENCH_NOGPU_PROFILE = $(shell printf '%s' "$${TMPDIR:-/tmp}")/meet-bench-nogpu
+
 # ==============================================================================
 # RULES
 
@@ -192,10 +207,34 @@ frontend-format: ## run the frontend format
 	cd $(PATH_FRONT) && npm run format
 .PHONY: frontend-format
 
+frontend-test: ## run the frontend unit tests
+	cd $(PATH_FRONT) && npm run test
+.PHONY: frontend-test
+
 run-frontend-development: ## run the frontend in development mode
 	@$(COMPOSE) stop frontend
 	cd $(PATH_FRONT) && npm run dev
 .PHONY: run-frontend-development
+
+run-frontend-nogpu: ## open the processor benchmark in Chrome with the GPU disabled
+	@test -n "$(CHROME)" || { \
+		echo "$(BOLD)Chrome not found.$(RESET) Pass one, e.g. make run-frontend-nogpu CHROME=chromium"; \
+		exit 1; \
+	}
+	@curl -sSf -o /dev/null http://localhost:$(BENCH_PORT)/ || { \
+		echo "$(BOLD)No dev server on port $(BENCH_PORT).$(RESET) Start it first: make run-frontend-development"; \
+		exit 1; \
+	}
+	@echo "$(GREEN)Launching Chrome with --disable-gpu$(RESET)"
+	@echo "Throwaway profile at $(BENCH_NOGPU_PROFILE) — you will be asked for camera access again."
+	@echo "The benchmark's specs panel should report software rendering; if it does not, the flag did not take."
+	@"$(CHROME)" \
+		--disable-gpu \
+		--user-data-dir="$(BENCH_NOGPU_PROFILE)" \
+		--no-first-run \
+		--no-default-browser-check \
+		"$(BENCH_URL)"
+.PHONY: run-frontend-nogpu
 
 # -- Backend
 

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -64,7 +64,8 @@
         "typescript-eslint": "8.60.1",
         "vite": "8.0.14",
         "vite-plugin-static-copy": "4.1.1",
-        "vite-plugin-svgr": "5.2.0"
+        "vite-plugin-svgr": "5.2.0",
+        "vitest": "3.2.7"
       }
     },
     "node_modules/@adobe/react-spectrum": {
@@ -547,6 +548,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1118,6 +1561,26 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -2136,6 +2599,395 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@spectrum-icons/ui": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/@spectrum-icons/ui/-/ui-3.7.1.tgz",
@@ -2506,6 +3358,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dom-mediacapture-record": {
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
@@ -2531,9 +3401,9 @@
       "peer": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2784,6 +3654,94 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -3149,6 +4107,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -4130,6 +5098,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4145,6 +5130,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -4629,6 +5624,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5030,6 +6035,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5084,6 +6096,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escalade": {
@@ -5530,6 +6584,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -8218,6 +9282,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -8927,6 +9998,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -9720,6 +10801,52 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rollup-plugin-visualizer": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
@@ -10134,6 +11261,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -10208,6 +11342,13 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10217,6 +11358,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -10420,6 +11568,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10524,6 +11692,20 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10570,6 +11752,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -11245,6 +12457,135 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-plugin-static-copy": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-4.1.1.tgz",
@@ -11608,6 +12949,222 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -11798,6 +13355,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "i18n:extract": "npx i18next -c i18next-parser.config.json",
     "format": "prettier --write ./src",
-    "check": "prettier --check ./src"
+    "check": "prettier --check ./src",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fontsource-variable/atkinson-hyperlegible-next": "5.3.0",
@@ -71,6 +72,7 @@
     "typescript-eslint": "8.60.1",
     "vite": "8.0.14",
     "vite-plugin-static-copy": "4.1.1",
-    "vite-plugin-svgr": "5.2.0"
+    "vite-plugin-svgr": "5.2.0",
+    "vitest": "3.2.7"
   }
 }

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { Switch, Route } from 'wouter'
 import { I18nProvider } from 'react-aria-components'
 import { Layout } from './layout/Layout'
 import { NotFoundScreen } from './components/NotFoundScreen'
-import { routes } from './routes'
+import { devRoutes, routes } from './routes'
 import './i18n/init'
 import { queryClient } from '@/api/queryClient'
 import { AppInitialization } from '@/components/AppInitialization'
@@ -31,6 +31,13 @@ function App() {
             <Switch>
               {Object.entries(routes).map(([, route], i) => (
                 <Route key={i} path={route.path} component={route.Component} />
+              ))}
+              {devRoutes.map((route) => (
+                <Route
+                  key={route.path}
+                  path={route.path}
+                  component={route.Component}
+                />
               ))}
               <Route component={NotFoundScreen} />
             </Switch>

--- a/src/frontend/src/features/rooms/livekit/processors/bench/ProcessorBenchPage.tsx
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/ProcessorBenchPage.tsx
@@ -1,0 +1,589 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { VideoPresets } from 'livekit-client'
+import { css } from '@/styled-system/css'
+import { BENCH_CONTENDERS } from './contenders'
+import { BenchAbortError, runBenchmark } from './ProcessorBenchmark'
+import { SUPPORTS_LONG_TASKS, SUPPORTS_RVFC } from './collectors'
+import {
+  collectSystemSpecs,
+  describeGpu,
+  type SystemSpecs,
+} from './systemSpecs'
+import {
+  DEFAULT_BENCH_OPTIONS,
+  type BenchPhase,
+  type BenchProgress,
+  type BenchReport,
+  type ContenderResult,
+  type GpuUsage,
+} from './types'
+
+// The same ladder the product publishes (see VideoTab / VideoDeviceControl),
+// rather than a second hardcoded copy of it.
+const RESOLUTION_KEYS = ['h360', 'h720', 'h1080'] as const
+type ResolutionKey = (typeof RESOLUTION_KEYS)[number]
+
+const resolutionOf = (key: ResolutionKey) => VideoPresets[key]
+const resolutionLabel = (key: ResolutionKey) =>
+  `${VideoPresets[key].width}x${VideoPresets[key].height}`
+
+type Range = { min: number; max: number }
+
+const MEASURE_SECONDS: Range = { min: 3, max: 120 }
+const PASSES: Range = { min: 1, max: 6 }
+
+/**
+ * The `min` and `max` attributes only bite on a form submit, and these
+ * controls have no form: cleared, the field parses as 0 and the run produces
+ * a report with no measurement in it. Null here means the field is unusable,
+ * and the Run button stays disabled until it is not.
+ */
+const numberInRange = (raw: string, range: Range): number | null => {
+  const value = Number(raw)
+  if (raw.trim() === '' || !Number.isInteger(value)) return null
+  return value >= range.min && value <= range.max ? value : null
+}
+
+const styles = {
+  page: css({
+    padding: '1.5rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1.25rem',
+    maxWidth: '1200px',
+    marginX: 'auto',
+  }),
+  row: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '1rem',
+    alignItems: 'flex-end',
+  }),
+  field: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.25rem',
+    fontSize: '0.875rem',
+  }),
+  contenders: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.375rem',
+  }),
+  previews: css({
+    display: 'flex',
+    gap: '1rem',
+    flexWrap: 'wrap',
+  }),
+  // Reserves the slot while the harness swaps its video element in and out.
+  videoSlot: css({
+    width: '320px',
+    maxWidth: '100%',
+    aspectRatio: '16 / 9',
+    background: '#111',
+    borderRadius: '4px',
+  }),
+  video: css({
+    width: '100%',
+    height: '100%',
+    borderRadius: '4px',
+    objectFit: 'contain',
+  }),
+  tableWrap: css({
+    overflowX: 'auto',
+  }),
+  table: css({
+    borderCollapse: 'collapse',
+    fontSize: '0.8125rem',
+    width: '100%',
+    '& th, & td': {
+      border: '1px solid #ddd',
+      padding: '0.375rem 0.5rem',
+      textAlign: 'right',
+      whiteSpace: 'nowrap',
+    },
+    '& th:first-child, & td:first-child': {
+      textAlign: 'left',
+    },
+  }),
+  note: css({
+    fontSize: '0.8125rem',
+    color: '#666',
+  }),
+  specs: css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+    gap: '0.25rem 1.5rem',
+    fontSize: '0.8125rem',
+    border: '1px solid #ddd',
+    borderRadius: '4px',
+    padding: '0.75rem 1rem',
+  }),
+  specRow: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: '1rem',
+  }),
+  specKey: css({
+    color: '#666',
+  }),
+  specValue: css({
+    fontFamily: 'monospace',
+    textAlign: 'right',
+    wordBreak: 'break-word',
+  }),
+  badge: css({
+    display: 'inline-block',
+    padding: '0.125rem 0.5rem',
+    borderRadius: '999px',
+    fontSize: '0.75rem',
+    border: '1px solid currentColor',
+  }),
+  error: css({
+    fontSize: '0.8125rem',
+    color: '#b3261e',
+  }),
+  button: css({
+    padding: '0.5rem 1rem',
+    borderRadius: '4px',
+    border: '1px solid #666',
+    cursor: 'pointer',
+    _disabled: { opacity: 0.5, cursor: 'not-allowed' },
+  }),
+}
+
+const fmt = (value: number | null | undefined, digits = 1): string =>
+  typeof value === 'number' && Number.isFinite(value)
+    ? value.toFixed(digits)
+    : '—'
+
+const fmtMb = (bytes: number | null | undefined): string =>
+  typeof bytes === 'number' ? `${(bytes / 1024 / 1024).toFixed(1)} MB` : '—'
+
+const PHASE_VERBS: Partial<Record<BenchPhase, string>> = {
+  starting: 'Initialising',
+  warmup: 'Warming up',
+  measuring: 'Measuring',
+}
+
+const describeProgress = (progress: BenchProgress): string => {
+  const verb = PHASE_VERBS[progress.phase]
+  if (verb) {
+    return `${verb} ${progress.contenderLabel} (pass ${(progress.pass ?? 0) + 1})`
+  }
+  if (progress.phase === 'cooldown') {
+    return `Cooling down after ${progress.contenderLabel}`
+  }
+  return progress.phase === 'done' ? 'Done' : 'Idle'
+}
+
+const describeGpuUsage = (gpu: GpuUsage): string => {
+  if (gpu.rendersOnGpu === null) return 'no canvas observed'
+  const contexts = gpu.contextTypes.join(', ')
+  return gpu.rendersOnGpu ? `GPU (${contexts})` : `CPU (${contexts})`
+}
+
+const RESULT_COLUMNS: Array<{
+  header: string
+  cell: (result: ContenderResult) => string
+}> = [
+  { header: 'Processor', cell: (r) => r.label },
+  { header: 'Rendering', cell: (r) => describeGpuUsage(r.gpu) },
+  {
+    header: 'Inference (requested)',
+    cell: (r) => r.inferenceDelegate ?? 'n/a',
+  },
+  { header: 'FPS', cell: (r) => fmt(r.averaged.fps) },
+  { header: 'Frame p95 (ms)', cell: (r) => fmt(r.averaged.frameP95Ms) },
+  { header: 'rAF p50 (ms)', cell: (r) => fmt(r.averaged.rafP50Ms) },
+  { header: 'rAF p95 (ms)', cell: (r) => fmt(r.averaged.rafP95Ms) },
+  { header: 'Blocking (ms)', cell: (r) => fmt(r.averaged.blockingMs, 0) },
+  { header: 'Long tasks', cell: (r) => fmt(r.averaged.longTaskCount, 0) },
+  { header: 'Busy %', cell: (r) => fmt(r.averaged.longTaskSharePct) },
+  { header: 'Startup cold (ms)', cell: (r) => fmt(r.coldStartupMs, 0) },
+  { header: 'Startup warm (ms)', cell: (r) => fmt(r.warmStartupMs, 0) },
+  { header: 'Heap peak (max)', cell: (r) => fmtMb(r.heapPeakBytes) },
+]
+
+const SpecRow = ({ label, value }: { label: string; value: string }) => (
+  <div className={styles.specRow}>
+    <span className={styles.specKey}>{label}</span>
+    <span className={styles.specValue}>{value}</span>
+  </div>
+)
+
+const or = (value: string | number | null | undefined): string =>
+  value === null || value === undefined || value === '' ? '—' : String(value)
+
+const SpecsPanel = ({ specs }: { specs: SystemSpecs }) => {
+  let power = '—'
+
+  if (specs.battery) {
+    const status = specs.battery.charging ? 'charging' : 'on battery'
+    power = `${status} (${specs.battery.levelPct}%)`
+  }
+
+  return (
+    <div className={styles.specs}>
+      <SpecRow
+        label="Platform"
+        value={`${or(specs.platform)} ${or(specs.platformVersion)}`}
+      />
+
+      <SpecRow
+        label="Architecture"
+        value={`${or(specs.architecture)} ${or(specs.bitness)}`}
+      />
+
+      <SpecRow label="Browser" value={or(specs.browserVersion)} />
+      <SpecRow label="Logical cores" value={or(specs.logicalCores)} />
+
+      <SpecRow
+        label="Device memory"
+        value={specs.deviceMemoryGb ? `${specs.deviceMemoryGb} GB` : '—'}
+      />
+
+      <SpecRow label="GPU" value={describeGpu(specs.gpu)} />
+      <SpecRow label="GPU vendor" value={or(specs.gpu.webglVendor)} />
+
+      <SpecRow
+        label="WebGL2"
+        value={specs.gpu.webgl2Available ? 'available' : 'unavailable'}
+      />
+
+      <SpecRow
+        label="WebGPU"
+        value={
+          specs.gpu.webgpuAvailable
+            ? or(
+                specs.gpu.webgpuDescription ||
+                  specs.gpu.webgpuDevice ||
+                  specs.gpu.webgpuVendor
+              )
+            : 'unavailable'
+        }
+      />
+
+      <SpecRow
+        label="Screen"
+        value={`${specs.screen.width}x${specs.screen.height} @${specs.screen.devicePixelRatio}x`}
+      />
+
+      <SpecRow label="Power" value={power} />
+
+      <SpecRow label="Timezone" value={or(specs.timezone)} />
+    </div>
+  )
+}
+
+const ProcessorBenchPage = () => {
+  const sourceContainerRef = useRef<HTMLDivElement>(null)
+  const outputContainerRef = useRef<HTMLDivElement>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const [selected, setSelected] = useState<string[]>(
+    BENCH_CONTENDERS.slice(0, 2).map((contender) => contender.id)
+  )
+  const [resolution, setResolution] = useState<ResolutionKey>('h720')
+  const [measureSecondsInput, setMeasureSecondsInput] = useState('15')
+  const [passesInput, setPassesInput] = useState('2')
+
+  const measureSeconds = numberInRange(measureSecondsInput, MEASURE_SECONDS)
+  const passes = numberInRange(passesInput, PASSES)
+
+  const [running, setRunning] = useState(false)
+  const [progress, setProgress] = useState<BenchProgress>({ phase: 'idle' })
+  const [report, setReport] = useState<BenchReport | null>(null)
+  const [failure, setFailure] = useState<string | null>(null)
+  const [specs, setSpecs] = useState<SystemSpecs | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    collectSystemSpecs().then((collected) => {
+      if (!cancelled) setSpecs(collected)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const estimatedSeconds = useMemo(() => {
+    if (measureSeconds === null || passes === null) return null
+    const perRun =
+      DEFAULT_BENCH_OPTIONS.warmupMs / 1000 +
+      measureSeconds +
+      DEFAULT_BENCH_OPTIONS.cooldownMs / 1000
+    return Math.round(perRun * selected.length * passes)
+  }, [measureSeconds, passes, selected.length])
+
+  const toggle = (id: string) =>
+    setSelected((current) =>
+      current.includes(id)
+        ? current.filter((item) => item !== id)
+        : [...current, id]
+    )
+
+  const start = useCallback(async () => {
+    const sourceContainer = sourceContainerRef.current
+    const outputContainer = outputContainerRef.current
+    if (!sourceContainer || !outputContainer) return
+    if (measureSeconds === null || passes === null) return
+
+    const chosen = BENCH_CONTENDERS.filter((contender) =>
+      selected.includes(contender.id)
+    )
+    const size = resolutionOf(resolution)
+
+    const controller = new AbortController()
+    abortRef.current = controller
+    setRunning(true)
+    setFailure(null)
+    setReport(null)
+
+    try {
+      const result = await runBenchmark(
+        chosen,
+        {
+          ...DEFAULT_BENCH_OPTIONS,
+          width: size.width,
+          height: size.height,
+          measureMs: measureSeconds * 1000,
+          passes,
+        },
+        {
+          sourceContainer,
+          outputContainer,
+          videoClassName: styles.video,
+        },
+        setProgress,
+        controller.signal
+      )
+      setReport(result)
+    } catch (error) {
+      if (error instanceof BenchAbortError) {
+        setProgress({ phase: 'idle' })
+      } else {
+        setFailure(error instanceof Error ? error.message : String(error))
+      }
+    } finally {
+      setRunning(false)
+      abortRef.current = null
+    }
+  }, [measureSeconds, passes, resolution, selected])
+
+  const stop = () => abortRef.current?.abort()
+
+  return (
+    <div className={styles.page}>
+      <div>
+        <h1>Track processor benchmark</h1>
+        <p className={styles.note}>
+          Measures any livekit <code>TrackProcessor</code> under an identical
+          protocol: one camera track, warm up, measure, tear down, repeated with
+          the running order reversed. Dev-only page.
+        </p>
+      </div>
+
+      {specs && (
+        <>
+          <div className={styles.row}>
+            <strong>This machine</strong>
+            {specs.gpu.softwareRendered && (
+              <span className={styles.badge}>
+                GPU disabled — software rendering
+              </span>
+            )}
+          </div>
+          <SpecsPanel specs={specs} />
+        </>
+      )}
+
+      {!SUPPORTS_RVFC && (
+        <p className={styles.error}>
+          This browser has no requestVideoFrameCallback, so frame pacing cannot
+          be measured. FPS falls back to decoded-frame counts and jitter is
+          unavailable.
+        </p>
+      )}
+      {!SUPPORTS_LONG_TASKS && (
+        <p className={styles.error}>
+          This browser does not report long tasks, so main-thread blocking
+          columns will be empty. Chromium reports them.
+        </p>
+      )}
+
+      <div className={styles.contenders}>
+        <strong>Processors</strong>
+        {BENCH_CONTENDERS.map((contender) => (
+          <label key={contender.id}>
+            <input
+              type="checkbox"
+              checked={selected.includes(contender.id)}
+              disabled={running}
+              onChange={() => toggle(contender.id)}
+            />{' '}
+            {contender.label}{' '}
+            <span className={styles.note}>{contender.description}</span>
+          </label>
+        ))}
+      </div>
+
+      <div className={styles.row}>
+        <label className={styles.field}>
+          <span>Resolution</span>
+          <select
+            value={resolution}
+            disabled={running}
+            onChange={(event) =>
+              setResolution(event.target.value as ResolutionKey)
+            }
+          >
+            {RESOLUTION_KEYS.map((key) => (
+              <option key={key} value={key}>
+                {resolutionLabel(key)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={styles.field}>
+          <span>Measure seconds</span>
+          <input
+            type="number"
+            min={MEASURE_SECONDS.min}
+            max={MEASURE_SECONDS.max}
+            value={measureSecondsInput}
+            disabled={running}
+            aria-invalid={measureSeconds === null}
+            onChange={(event) => setMeasureSecondsInput(event.target.value)}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <span>Passes</span>
+          <input
+            type="number"
+            min={PASSES.min}
+            max={PASSES.max}
+            value={passesInput}
+            disabled={running}
+            aria-invalid={passes === null}
+            onChange={(event) => setPassesInput(event.target.value)}
+          />
+        </label>
+
+        <button
+          type="button"
+          className={styles.button}
+          onClick={start}
+          disabled={
+            running ||
+            selected.length === 0 ||
+            measureSeconds === null ||
+            passes === null
+          }
+        >
+          Run benchmark
+        </button>
+        <button
+          type="button"
+          className={styles.button}
+          onClick={stop}
+          disabled={!running}
+        >
+          Stop
+        </button>
+
+        <span className={styles.note}>
+          {estimatedSeconds === null
+            ? `Measure seconds ${MEASURE_SECONDS.min}–${MEASURE_SECONDS.max}, passes ${PASSES.min}–${PASSES.max}`
+            : `~${estimatedSeconds}s total`}
+        </span>
+      </div>
+
+      <p>
+        <strong>Status:</strong> {describeProgress(progress)}
+      </p>
+      {failure && <p className={styles.error}>{failure}</p>}
+
+      {/*
+        The harness owns these video elements: it creates a fresh pair per run,
+        the way livekit's setProcessor does, so no `loadeddata` state carries
+        from one processor's start-up into the next.
+      */}
+      <div className={styles.previews}>
+        <div>
+          <div className={styles.note}>Camera source</div>
+          <div ref={sourceContainerRef} className={styles.videoSlot} />
+        </div>
+        <div>
+          <div className={styles.note}>Processor output</div>
+          <div ref={outputContainerRef} className={styles.videoSlot} />
+        </div>
+      </div>
+
+      {report && (
+        <>
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  {RESULT_COLUMNS.map((column) => (
+                    <th key={column.header}>{column.header}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {report.results.map((result) => (
+                  <tr key={result.contenderId}>
+                    {RESULT_COLUMNS.map((column) => (
+                      <td key={column.header}>{column.cell(result)}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className={styles.note}>
+            <strong>Rendering</strong> is observed: the canvas context types
+            each processor actually created during its run.{' '}
+            <strong>Inference</strong> is only what the processor asks MediaPipe
+            for — MediaPipe never reports the delegate it settled on and can
+            fall back to CPU silently, so it is not proof. To take the GPU out
+            of the picture entirely, including compositing, run{' '}
+            <code>make run-frontend-nogpu</code>; the panel above will then
+            report software rendering.
+          </p>
+
+          {report.results.map((result) => (
+            <div key={result.contenderId}>
+              {result.notes.map((note) => (
+                <div key={note} className={styles.note}>
+                  {result.label}: {note}
+                </div>
+              ))}
+              {result.errors.map((error) => (
+                <div key={error} className={styles.error}>
+                  {result.label}: {error}
+                </div>
+              ))}
+            </div>
+          ))}
+
+          <button
+            type="button"
+            className={styles.button}
+            onClick={() =>
+              navigator.clipboard.writeText(JSON.stringify(report, null, 2))
+            }
+          >
+            Copy JSON report
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default ProcessorBenchPage

--- a/src/frontend/src/features/rooms/livekit/processors/bench/ProcessorBenchPage.tsx
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/ProcessorBenchPage.tsx
@@ -3,6 +3,7 @@ import { VideoPresets } from 'livekit-client'
 import { css } from '@/styled-system/css'
 import { BENCH_CONTENDERS } from './contenders'
 import { BenchAbortError, runBenchmark } from './ProcessorBenchmark'
+import { MEASURE_SECONDS, PASSES, numberInRange } from './options'
 import { SUPPORTS_LONG_TASKS, SUPPORTS_RVFC } from './collectors'
 import {
   collectSystemSpecs,
@@ -26,23 +27,6 @@ type ResolutionKey = (typeof RESOLUTION_KEYS)[number]
 const resolutionOf = (key: ResolutionKey) => VideoPresets[key]
 const resolutionLabel = (key: ResolutionKey) =>
   `${VideoPresets[key].width}x${VideoPresets[key].height}`
-
-type Range = { min: number; max: number }
-
-const MEASURE_SECONDS: Range = { min: 3, max: 120 }
-const PASSES: Range = { min: 1, max: 6 }
-
-/**
- * The `min` and `max` attributes only bite on a form submit, and these
- * controls have no form: cleared, the field parses as 0 and the run produces
- * a report with no measurement in it. Null here means the field is unusable,
- * and the Run button stays disabled until it is not.
- */
-const numberInRange = (raw: string, range: Range): number | null => {
-  const value = Number(raw)
-  if (raw.trim() === '' || !Number.isInteger(value)) return null
-  return value >= range.min && value <= range.max ? value : null
-}
 
 const styles = {
   page: css({

--- a/src/frontend/src/features/rooms/livekit/processors/bench/ProcessorBenchmark.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/ProcessorBenchmark.ts
@@ -1,0 +1,395 @@
+import { Track } from 'livekit-client'
+import {
+  CanvasContextRecorder,
+  FrameRateCollector,
+  HeapSampler,
+  LongTaskCollector,
+  RafCollector,
+  rendersOnGpu,
+} from './collectors'
+import {
+  BenchAbortError,
+  initThenAttach,
+  raceAbort,
+  throwIfAborted,
+} from './sequencing'
+import { mean } from './stats'
+import { collectSystemSpecs } from './systemSpecs'
+import type {
+  BenchContender,
+  BenchOptions,
+  BenchProgress,
+  BenchReport,
+  ContenderResult,
+  GpuUsage,
+  RunMetrics,
+  VideoTrackProcessor,
+} from './types'
+
+export { BenchAbortError } from './sequencing'
+
+const FIRST_FRAME_TIMEOUT_MS = 20_000
+
+/** Abortable sleep; the abort plumbing itself lives in raceAbort. */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  let timer: ReturnType<typeof setTimeout>
+  const sleep = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, ms)
+  })
+  return raceAbort(sleep, signal).finally(() => clearTimeout(timer))
+}
+
+async function playSilently(video: HTMLVideoElement) {
+  try {
+    await video.play()
+  } catch {
+    // Autoplay of a muted MediaStream is allowed; a rejection here is not fatal.
+  }
+}
+
+export type BenchMounts = {
+  sourceContainer: HTMLElement
+  outputContainer: HTMLElement
+  videoClassName?: string
+}
+
+/**
+ * A fresh element per run, like livekit's setProcessor. Reusing one across
+ * contenders would carry `loadeddata` state from the previous run into the
+ * next processor's start-up.
+ */
+function createVideoElement(
+  container: HTMLElement,
+  className?: string
+): HTMLVideoElement {
+  const video = document.createElement('video')
+  video.muted = true
+  video.playsInline = true
+  if (className) video.className = className
+  container.replaceChildren(video)
+  return video
+}
+
+type RunContext = {
+  sourceTrack: MediaStreamTrack
+  mounts: BenchMounts
+  options: BenchOptions
+  signal?: AbortSignal
+  onProgress: (progress: BenchProgress) => void
+}
+
+async function runSingle(
+  contender: BenchContender,
+  pass: number,
+  ctx: RunContext
+): Promise<RunMetrics> {
+  const { mounts, options, signal, onProgress } = ctx
+  const label = contender.label
+
+  // A fresh clone per run: the modern processor path consumes the track it is
+  // handed, so contenders must never share one.
+  const sourceClone = ctx.sourceTrack.clone()
+  const sourceVideo = createVideoElement(
+    mounts.sourceContainer,
+    mounts.videoClassName
+  )
+  const outputVideo = createVideoElement(
+    mounts.outputContainer,
+    mounts.videoClassName
+  )
+
+  let processor: VideoTrackProcessor | undefined
+  let pendingInit: Promise<void> | undefined
+  let initSettled = false
+
+  /**
+   * Idempotent: destroy() first, then stop whatever track is still live.
+   * The in-house processors expose a canvas.captureStream track their
+   * destroy() never stops, and one left running per pass would be measured
+   * by every pass after it.
+   */
+  const teardownProcessor = async () => {
+    try {
+      await processor?.destroy()
+    } catch {
+      // A processor that fails to tear down must not mask the run's result.
+    }
+    processor?.processedTrack?.stop()
+  }
+
+  const frames = new FrameRateCollector(outputVideo)
+  const raf = new RafCollector()
+  const longTasks = new LongTaskCollector()
+  const heap = new HeapSampler()
+  const contexts = new CanvasContextRecorder()
+
+  const gpuUsage = (): GpuUsage => {
+    const contextTypes = contexts.summarize()
+    return { contextTypes, rendersOnGpu: rendersOnGpu(contextTypes) }
+  }
+
+  const failed = (error: string): RunMetrics => ({
+    pass,
+    measuredMs: 0,
+    framesDelivered: 0,
+    fps: 0,
+    frameIntervals: null,
+    rafIntervals: null,
+    longTasks: longTasks.summarize(0),
+    heap: heap.summarize(),
+    gpu: gpuUsage(),
+    startupMs: null,
+    error,
+  })
+
+  try {
+    onProgress({ phase: 'starting', contenderLabel: label, pass })
+    throwIfAborted(signal)
+
+    // Started before construction: processors create their canvases in the
+    // constructor or in init(), and both count as evidence.
+    contexts.start()
+    processor = contender.create()
+    const initStartedAt = performance.now()
+
+    // Order matters: see initThenAttach.
+    await initThenAttach({
+      init: () => {
+        // Kept so teardown can wait on it: init() exposes no cancellation, so
+        // an abort only stops us waiting, never the processor.
+        pendingInit = processor!.init({
+          kind: Track.Kind.Video,
+          track: sourceClone,
+          element: sourceVideo,
+        })
+        const settled = () => {
+          initSettled = true
+        }
+        pendingInit.then(settled, settled)
+        return raceAbort(pendingInit, signal)
+      },
+      attach: () => {
+        sourceVideo.srcObject = new MediaStream([sourceClone])
+      },
+      play: () => playSilently(sourceVideo),
+    })
+
+    const processedTrack = processor.processedTrack
+    if (!processedTrack) return failed('Processor produced no processedTrack')
+
+    outputVideo.srcObject = new MediaStream([processedTrack])
+    await playSilently(outputVideo)
+
+    frames.start()
+    const firstFrameAt = await raceAbort(
+      frames.waitForFirstFrame(FIRST_FRAME_TIMEOUT_MS),
+      signal
+    )
+    if (firstFrameAt === null) {
+      return failed(
+        `No frame was delivered on the processed track within ${FIRST_FRAME_TIMEOUT_MS / 1000}s`
+      )
+    }
+    const startupMs = firstFrameAt - initStartedAt
+
+    onProgress({ phase: 'warmup', contenderLabel: label, pass })
+    await delay(options.warmupMs, signal)
+
+    // Emitted, then yielded to, so React commits this render *before* the
+    // collectors are armed. Otherwise the harness's own re-render is the
+    // first thing the long-task and rAF collectors observe.
+    onProgress({ phase: 'measuring', contenderLabel: label, pass })
+    await delay(0, signal)
+
+    raf.start()
+    longTasks.start()
+    heap.start()
+    frames.startRecording()
+    const measureStartedAt = performance.now()
+
+    await delay(options.measureMs, signal)
+
+    const measuredMs = performance.now() - measureStartedAt
+    frames.stopRecording()
+    raf.stop()
+    longTasks.stop()
+    heap.stop()
+
+    const frameStats = frames.summarize(measuredMs)
+
+    return {
+      pass,
+      measuredMs,
+      framesDelivered: frameStats.framesDelivered,
+      fps: frameStats.fps,
+      frameIntervals: frameStats.frameIntervals,
+      rafIntervals: raf.summarize(),
+      longTasks: longTasks.summarize(measuredMs),
+      heap: heap.summarize(),
+      gpu: gpuUsage(),
+      startupMs,
+      note: contender.describe?.(processor),
+    }
+  } catch (error) {
+    if (error instanceof BenchAbortError) throw error
+    return failed(
+      error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+    )
+  } finally {
+    frames.stop()
+    raf.stop()
+    longTasks.stop()
+    heap.stop()
+    contexts.stop()
+    await teardownProcessor()
+    // Abort only stops us waiting on init(), never init() itself, so a
+    // stopped run can still be building a worker and a MediaPipe instance
+    // right now. Tear down a second time once it lands, or they outlive it.
+    if (pendingInit && !initSettled) {
+      void pendingInit.then(
+        () => teardownProcessor(),
+        () => teardownProcessor()
+      )
+    }
+    sourceClone.stop()
+    sourceVideo.srcObject = null
+    outputVideo.srcObject = null
+    sourceVideo.remove()
+    outputVideo.remove()
+  }
+}
+
+function usableNumbers(values: Array<number | null | undefined>): number[] {
+  return values.filter((value): value is number => typeof value === 'number')
+}
+
+function averageOf(values: Array<number | null | undefined>): number | null {
+  return mean(usableNumbers(values))
+}
+
+function maxOf(values: Array<number | null | undefined>): number | null {
+  const usable = usableNumbers(values)
+  return usable.length > 0 ? Math.max(...usable) : null
+}
+
+function aggregate(
+  contender: BenchContender,
+  runs: RunMetrics[]
+): ContenderResult {
+  const good = runs.filter((run) => !run.error)
+  const ordered = [...runs].sort((a, b) => a.pass - b.pass)
+  const timed = ordered.filter((run) => run.startupMs !== null)
+
+  return {
+    contenderId: contender.id,
+    label: contender.label,
+    runs: ordered,
+    coldStartupMs: timed[0]?.startupMs ?? null,
+    warmStartupMs: timed[1]?.startupMs ?? null,
+    // The worst pass, not the first: a leak shows up in a later one.
+    heapPeakBytes: maxOf(runs.map((run) => run.heap.peakBytes)),
+    averaged: {
+      fps: averageOf(good.map((run) => run.fps)),
+      frameP95Ms: averageOf(good.map((run) => run.frameIntervals?.p95Ms)),
+      rafP50Ms: averageOf(good.map((run) => run.rafIntervals?.p50Ms)),
+      rafP95Ms: averageOf(good.map((run) => run.rafIntervals?.p95Ms)),
+      blockingMs: averageOf(good.map((run) => run.longTasks.blockingMs)),
+      longTaskCount: averageOf(good.map((run) => run.longTasks.count)),
+      longTaskSharePct: averageOf(good.map((run) => run.longTasks.sharePct)),
+    },
+    notes: [
+      ...new Set(runs.map((run) => run.note).filter((n): n is string => !!n)),
+    ],
+    errors: [
+      ...new Set(runs.map((run) => run.error).filter((e): e is string => !!e)),
+    ],
+    gpu: mergeGpuUsage(runs),
+    inferenceDelegate: contender.inferenceDelegate,
+  }
+}
+
+/** Union across passes: a context seen in any run was genuinely created. */
+function mergeGpuUsage(runs: RunMetrics[]): GpuUsage {
+  const contextTypes = [
+    ...new Set(runs.flatMap((run) => run.gpu.contextTypes)),
+  ].sort((a, b) => a.localeCompare(b))
+  return { contextTypes, rendersOnGpu: rendersOnGpu(contextTypes) }
+}
+
+export async function acquireSourceTrack(
+  options: BenchOptions
+): Promise<MediaStreamTrack> {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    video: {
+      width: { ideal: options.width },
+      height: { ideal: options.height },
+      frameRate: { ideal: options.frameRate },
+    },
+  })
+  const [track] = stream.getVideoTracks()
+  if (!track) throw new Error('getUserMedia returned no video track')
+  return track
+}
+
+/**
+ * Runs every contender against one camera track under an identical protocol.
+ *
+ * Passes alternate direction (forward, then reversed) so that thermal drift
+ * and model-cache warmth do not systematically favour whoever ran first.
+ */
+export async function runBenchmark(
+  contenders: BenchContender[],
+  options: BenchOptions,
+  mounts: BenchMounts,
+  onProgress: (progress: BenchProgress) => void,
+  signal?: AbortSignal
+): Promise<BenchReport> {
+  if (contenders.length === 0)
+    throw new Error('Select at least one processor to benchmark')
+
+  // Independent: a WebGPU adapter request should not sit in front of the
+  // camera warm-up.
+  const [specs, sourceTrack] = await Promise.all([
+    collectSystemSpecs(),
+    acquireSourceTrack(options),
+  ])
+  const sourceSettings = sourceTrack.getSettings()
+  const runsByContender = new Map<string, RunMetrics[]>(
+    contenders.map((contender) => [contender.id, []])
+  )
+
+  try {
+    for (let pass = 0; pass < options.passes; pass++) {
+      const order = pass % 2 === 0 ? contenders : [...contenders].reverse()
+      for (const contender of order) {
+        throwIfAborted(signal)
+        const metrics = await runSingle(contender, pass, {
+          sourceTrack,
+          mounts,
+          options,
+          signal,
+          onProgress,
+        })
+        runsByContender.get(contender.id)!.push(metrics)
+
+        onProgress({ phase: 'cooldown', contenderLabel: contender.label, pass })
+        await delay(options.cooldownMs, signal)
+      }
+    }
+  } finally {
+    sourceTrack.stop()
+  }
+
+  onProgress({ phase: 'done' })
+
+  return {
+    startedAt: new Date().toISOString(),
+    userAgent: navigator.userAgent,
+    specs,
+    options,
+    sourceSettings,
+    results: contenders.map((contender) =>
+      aggregate(contender, runsByContender.get(contender.id)!)
+    ),
+  }
+}

--- a/src/frontend/src/features/rooms/livekit/processors/bench/ProcessorBenchmark.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/ProcessorBenchmark.ts
@@ -13,6 +13,7 @@ import {
   raceAbort,
   throwIfAborted,
 } from './sequencing'
+import { resolveBenchOptions } from './options'
 import { mean } from './stats'
 import { collectSystemSpecs } from './systemSpecs'
 import type {
@@ -347,11 +348,14 @@ export async function runBenchmark(
   if (contenders.length === 0)
     throw new Error('Select at least one processor to benchmark')
 
+  // Every read below uses the resolved options, never the caller's.
+  const resolved = resolveBenchOptions(options)
+
   // Independent: a WebGPU adapter request should not sit in front of the
   // camera warm-up.
   const [specs, sourceTrack] = await Promise.all([
     collectSystemSpecs(),
-    acquireSourceTrack(options),
+    acquireSourceTrack(resolved),
   ])
   const sourceSettings = sourceTrack.getSettings()
   const runsByContender = new Map<string, RunMetrics[]>(
@@ -359,21 +363,21 @@ export async function runBenchmark(
   )
 
   try {
-    for (let pass = 0; pass < options.passes; pass++) {
+    for (let pass = 0; pass < resolved.passes; pass++) {
       const order = pass % 2 === 0 ? contenders : [...contenders].reverse()
       for (const contender of order) {
         throwIfAborted(signal)
         const metrics = await runSingle(contender, pass, {
           sourceTrack,
           mounts,
-          options,
+          options: resolved,
           signal,
           onProgress,
         })
         runsByContender.get(contender.id)!.push(metrics)
 
         onProgress({ phase: 'cooldown', contenderLabel: contender.label, pass })
-        await delay(options.cooldownMs, signal)
+        await delay(resolved.cooldownMs, signal)
       }
     }
   } finally {
@@ -386,7 +390,7 @@ export async function runBenchmark(
     startedAt: new Date().toISOString(),
     userAgent: navigator.userAgent,
     specs,
-    options,
+    options: resolved,
     sourceSettings,
     results: contenders.map((contender) =>
       aggregate(contender, runsByContender.get(contender.id)!)

--- a/src/frontend/src/features/rooms/livekit/processors/bench/README.md
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/README.md
@@ -1,0 +1,131 @@
+# Track processor benchmark
+
+A dev-only harness that measures any livekit `TrackProcessor<Track.Kind>` under an
+identical protocol, so two implementations can be compared on the same machine in
+the same session.
+
+## Running it
+
+```bash
+npm run dev
+```
+
+Open <http://localhost:3000/processor-bench>, tick the processors to compare, press
+**Run benchmark** and grant camera access. The route only exists in dev builds:
+`import.meta.env.DEV` is inlined as `false` for production, so the branch and the
+chunk it imports are dropped from `dist` entirely.
+
+## Protocol
+
+One `getUserMedia` track is acquired and shared by every run, then per processor:
+
+1. clone the source track (the modern processor path consumes the track it is given,
+   so contenders must never share one)
+2. create a fresh `<video>` element, with no source attached yet
+3. `init()` the processor against that bare element
+4. only now attach the cloned track to the element and play it
+5. wait for the first frame on `processedTrack`
+6. warm up
+7. measure for the configured window
+8. `destroy()`, stop the clone, discard the elements, cool down
+
+Steps 2–4 mirror `LocalVideoTrack.setProcessor` and the order is a contract, not a
+detail. Processors such as `BackgroundCustomProcessor` and `FaceLandmarksProcessor`
+finish `init()` by registering `onloadeddata` to start their render loop:
+
+```ts
+if (this.videoElementLoaded) { startTimer() } else { videoElement.onloadeddata = ... }
+```
+
+Attach the source before `init()` and that event has already fired, so the loop never
+starts, the canvas is never drawn to, and the processor emits nothing but black. Reusing
+one element across runs causes the same failure for the second contender onwards, which
+is why each run gets a fresh pair.
+
+Passes alternate direction — forward, then reversed — so thermal drift and model-cache
+warmth do not systematically favour whoever ran first. Steady-state metrics are averaged
+across passes; startup is reported separately as cold (first run, model download included)
+and warm (later runs).
+
+## Metrics
+
+All of them are black-box, observed on the output track and the main thread, which is
+what keeps the harness processor-agnostic.
+
+| Metric              | Meaning                                                                                        | Availability                      |
+| ------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------- |
+| FPS, frame p95      | frames delivered on `processedTrack` and their pacing                                          | needs `requestVideoFrameCallback` |
+| rAF p50 / p95       | an independent animation loop's cadence — a proxy for how janky the rest of the app would feel | everywhere                        |
+| Blocking (ms)       | Total Blocking Time: each long task's excess over 50ms                                         | Chromium                          |
+| Long tasks, Busy %  | count of >50ms tasks, and the share of the window spent in them                                | Chromium                          |
+| Startup cold / warm | `init()` until the first frame leaves the processor                                            | everywhere                        |
+| Heap peak (max)     | sampled `performance.memory`, highest across passes; a leak smell test, not a measurement      | Chromium                          |
+
+GPU time is not measured — there is no portable API for it — and neither are the internals
+of any processor. Compare rows only when their notes agree: a processor that self-tunes at
+startup reports what it settled on via `describe()`.
+
+## Machine specs
+
+Every report captures the machine that produced it, shown in a panel on the page and
+embedded in the JSON: CPU cores, device memory, OS and architecture, browser version,
+GPU vendor and renderer (WebGPU `adapter.info` when available, else the WebGL
+`WEBGL_debug_renderer_info` strings), WebGL2 and WebGPU availability, screen size and
+pixel ratio, timezone, and battery charging state — a laptop on battery throttles hard
+enough to invalidate a comparison against one on mains.
+
+## Did a processor use the GPU?
+
+Two columns, and they are not equally strong:
+
+- **Rendering** is _observed_. `CanvasContextRecorder` patches
+  `HTMLCanvasElement.prototype.getContext` for the duration of each run and records the
+  context types the processor actually created: `webgl`/`webgl2` means it rendered on the
+  GPU, `2d` means it did not. This is real per-run evidence.
+- **Inference (requested)** is _declared_. It is what the contender asks MediaPipe for —
+  `@livekit/track-processors` defaults to `delegate: 'GPU'`, `BackgroundCustomProcessor`
+  hardcodes `'CPU'`, `FaceLandmarksProcessor` hardcodes `'GPU'`. MediaPipe never reports
+  the delegate it settled on and can fall back to CPU silently, so this is a request and
+  is labelled as one. Never read it as proof.
+
+### Running without a GPU at all
+
+Neither column can be changed from inside the page: forcing a delegate would only move
+MediaPipe inference, while WebGL rendering and browser compositing stay hardware
+accelerated. For a genuinely GPU-less run:
+
+```bash
+make run-frontend-development   # in one shell
+make run-frontend-nogpu         # in another
+```
+
+That launches Chrome with `--disable-gpu` against a throwaway profile. The profile is
+mandatory: with the default profile, if Chrome is already running the second launch just
+opens a tab in the existing process and the flag is **silently ignored** — you would get
+an ordinary GPU run that looks like a GPU-less one. The specs panel closes that loop, so
+check it says _software rendering_ before trusting the numbers.
+
+## Adding a processor
+
+One entry in `contenders.ts`:
+
+```ts
+{
+  id: 'my-filter',
+  label: 'My filter',
+  description: 'What it does',
+  create: () => new MyFilterProcessor({ ... }),
+  // optional: what it asks MediaPipe for, omitted if it does no inference
+  inferenceDelegate: 'GPU',
+  // optional, for anything decided at runtime (model picked, GPU vs CPU path)
+  describe: (processor) => `...`,
+}
+```
+
+Nothing else changes: the protocol and the metrics apply to whatever the entry constructs.
+
+## Tests
+
+`stats.ts` and `sequencing.ts` are pure and unit-tested (`npm run test`) — the latter pins the
+init-before-attach ordering and the abort behaviour described above. The collectors and the page
+need a real camera, GPU and compositor, so they are verified by running the page.

--- a/src/frontend/src/features/rooms/livekit/processors/bench/collectors.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/collectors.ts
@@ -1,0 +1,331 @@
+import { computeFps, summarizeIntervals, type SampleSummary } from './stats'
+import type { HeapMetrics, LongTaskMetrics } from './types'
+
+const LONG_TASK_THRESHOLD_MS = 50
+
+/**
+ * Constant for the page's lifetime, so they are resolved once at import
+ * rather than on every render and inside every summarize().
+ */
+export const SUPPORTS_RVFC =
+  typeof HTMLVideoElement !== 'undefined' &&
+  'requestVideoFrameCallback' in HTMLVideoElement.prototype
+
+export const SUPPORTS_LONG_TASKS =
+  typeof PerformanceObserver !== 'undefined' &&
+  (PerformanceObserver.supportedEntryTypes ?? []).includes('longtask')
+
+const GPU_CONTEXT_TYPES = new Set(['webgl', 'webgl2', 'webgpu'])
+
+/** Single definition of what counts as GPU rendering, shared by every caller. */
+export function rendersOnGpu(contextTypes: string[]): boolean | null {
+  if (contextTypes.length === 0) return null
+  return contextTypes.some((type) => GPU_CONTEXT_TYPES.has(type))
+}
+
+/**
+ * Counts frames actually delivered on a processor's output track, by
+ * playing it in a video element and hooking requestVideoFrameCallback.
+ *
+ * Observation starts immediately so the first frame can time startup;
+ * interval recording only starts when `startRecording()` is called, so
+ * warmup never lands in the numbers.
+ */
+export class FrameRateCollector {
+  private readonly timestamps: number[] = []
+  private active = false
+  private recording = false
+  private handle?: number
+  private firstFrameAt: number | null = null
+  private readonly firstFrameWaiters: Array<(at: number) => void> = []
+
+  constructor(private readonly video: HTMLVideoElement) {}
+
+  start() {
+    if (this.active) return
+    this.active = true
+    if (SUPPORTS_RVFC) this.scheduleRvfc()
+  }
+
+  /** Allocated once, not per frame: this runs inside the measured window. */
+  private readonly onFrame = (now: number) => {
+    if (!this.active) return
+    if (this.firstFrameAt === null) {
+      this.firstFrameAt = now
+      this.firstFrameWaiters.splice(0).forEach((resolve) => resolve(now))
+    }
+    if (this.recording) this.timestamps.push(now)
+    this.scheduleRvfc()
+  }
+
+  private scheduleRvfc() {
+    this.handle = this.video.requestVideoFrameCallback(this.onFrame)
+  }
+
+  /** Resolves with the timestamp of the first frame, or null if none arrives in time. */
+  waitForFirstFrame(timeoutMs: number): Promise<number | null> {
+    if (this.firstFrameAt !== null) return Promise.resolve(this.firstFrameAt)
+    if (!SUPPORTS_RVFC) return this.pollForFirstFrame(timeoutMs)
+
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(null), timeoutMs)
+      this.firstFrameWaiters.push((at) => {
+        clearTimeout(timer)
+        resolve(at)
+      })
+    })
+  }
+
+  /** Fallback for browsers without rVFC: wait for the element to have decoded data. */
+  private pollForFirstFrame(timeoutMs: number): Promise<number | null> {
+    const deadline = performance.now() + timeoutMs
+    return new Promise((resolve) => {
+      const check = () => {
+        if (!this.active) return resolve(null)
+        if (this.video.readyState >= 2 && this.video.videoWidth > 0) {
+          this.firstFrameAt = performance.now()
+          return resolve(this.firstFrameAt)
+        }
+        if (performance.now() > deadline) return resolve(null)
+        setTimeout(check, 50)
+      }
+      check()
+    })
+  }
+
+  startRecording() {
+    this.recording = true
+    this.frameCountAtRecordStart = this.decodedFrameCount()
+  }
+
+  stopRecording() {
+    this.recording = false
+    this.frameCountAtRecordStop = this.decodedFrameCount()
+  }
+
+  stop() {
+    this.active = false
+    this.recording = false
+    if (this.handle !== undefined) {
+      this.video.cancelVideoFrameCallback?.(this.handle)
+      this.handle = undefined
+    }
+  }
+
+  private frameCountAtRecordStart: number | null = null
+  private frameCountAtRecordStop: number | null = null
+
+  /** Non-rVFC fallback source of truth for frame counts. */
+  private decodedFrameCount(): number | null {
+    const quality = this.video.getVideoPlaybackQuality?.()
+    return quality ? quality.totalVideoFrames : null
+  }
+
+  summarize(measuredMs: number): {
+    framesDelivered: number
+    fps: number
+    frameIntervals: SampleSummary | null
+  } {
+    if (SUPPORTS_RVFC) {
+      return {
+        framesDelivered: this.timestamps.length,
+        fps: computeFps(this.timestamps.length, measuredMs),
+        frameIntervals: summarizeIntervals(this.timestamps),
+      }
+    }
+
+    const start = this.frameCountAtRecordStart
+    const stop = this.frameCountAtRecordStop
+    const delivered = start !== null && stop !== null ? stop - start : 0
+    return {
+      framesDelivered: delivered,
+      fps: computeFps(delivered, measuredMs),
+      frameIntervals: null,
+    }
+  }
+}
+
+/**
+ * Independent requestAnimationFrame ticker. A processor that saturates the
+ * main thread starves this loop, so its interval spread is a direct proxy
+ * for how janky the rest of the app would feel.
+ */
+export class RafCollector {
+  private readonly timestamps: number[] = []
+  private active = false
+  private handle: number | null = null
+
+  start() {
+    if (this.active) return
+    this.active = true
+    const tick = (now: number) => {
+      if (!this.active) return
+      this.timestamps.push(now)
+      this.handle = requestAnimationFrame(tick)
+    }
+    this.handle = requestAnimationFrame(tick)
+  }
+
+  stop() {
+    this.active = false
+    if (this.handle !== null) {
+      cancelAnimationFrame(this.handle)
+      this.handle = null
+    }
+  }
+
+  summarize(): SampleSummary | null {
+    return summarizeIntervals(this.timestamps)
+  }
+}
+
+/** Long tasks (>50ms) blocking the main thread during the measurement window. */
+export class LongTaskCollector {
+  private observer?: PerformanceObserver
+  private readonly durations: number[] = []
+
+  start() {
+    if (!SUPPORTS_LONG_TASKS) return
+    this.observer = new PerformanceObserver((list) =>
+      this.record(list.getEntries())
+    )
+    this.observer.observe({ entryTypes: ['longtask'] })
+  }
+
+  private record(entries: PerformanceEntryList) {
+    for (const entry of entries) this.durations.push(entry.duration)
+  }
+
+  stop() {
+    if (!this.observer) return
+    // Delivery is batched, so a long task that ended just before the window
+    // closed is still queued. Drain it, or the tail of every run is missing.
+    this.record(this.observer.takeRecords())
+    this.observer.disconnect()
+    this.observer = undefined
+  }
+
+  summarize(measuredMs: number): LongTaskMetrics {
+    // With no observer the durations are empty, so the arithmetic below
+    // already yields zeroes; only `supported` needs stating.
+    const totalMs = this.durations.reduce((sum, d) => sum + d, 0)
+    const blockingMs = this.durations.reduce(
+      (sum, d) => sum + Math.max(0, d - LONG_TASK_THRESHOLD_MS),
+      0
+    )
+    return {
+      supported: SUPPORTS_LONG_TASKS,
+      count: this.durations.length,
+      totalMs,
+      blockingMs,
+      sharePct: measuredMs > 0 ? (totalMs / measuredMs) * 100 : 0,
+    }
+  }
+}
+
+type GetContextHost = {
+  prototype: { getContext: unknown }
+}
+
+/**
+ * Records which canvas context types a processor creates while it runs, which
+ * is the one piece of per-processor GPU evidence that is actually observable:
+ * `webgl`/`webgl2` means it rendered on the GPU, `2d` means it did not.
+ *
+ * MediaPipe offers nothing equivalent — it never reports the delegate it
+ * settled on — so inference is declared by the contender, not measured here.
+ *
+ * Caveat: this is a global patch for the duration of one run, so a canvas
+ * created by anything else in that window is attributed to the processor.
+ * Nothing else on the bench page creates canvases while a run is in flight.
+ */
+export class CanvasContextRecorder {
+  private readonly types = new Set<string>()
+  private readonly restorers: Array<() => void> = []
+
+  start() {
+    this.patch(HTMLCanvasElement as unknown as GetContextHost)
+    if (typeof OffscreenCanvas !== 'undefined') {
+      this.patch(OffscreenCanvas as unknown as GetContextHost)
+    }
+  }
+
+  private patch(host: GetContextHost) {
+    const original = host.prototype.getContext as (
+      ...args: unknown[]
+    ) => unknown
+    const types = this.types
+
+    // Recorded only once the call succeeded: a refused `webgl` request
+    // returns null, and counting it would report GPU rendering that the
+    // processor never got.
+    host.prototype.getContext = function (this: unknown, ...args: unknown[]) {
+      const context = original.apply(this, args)
+      if (context !== null && typeof args[0] === 'string') types.add(args[0])
+      return context
+    }
+
+    this.restorers.push(() => {
+      host.prototype.getContext = original
+    })
+  }
+
+  stop() {
+    this.restorers.splice(0).forEach((restore) => restore())
+  }
+
+  summarize(): string[] {
+    return [...this.types].sort((a, b) => a.localeCompare(b))
+  }
+}
+
+type MemoryCapablePerformance = Performance & {
+  memory?: { usedJSHeapSize: number }
+}
+
+/**
+ * Best-effort JS heap sampling (Chromium only, and at the mercy of GC).
+ * Treat it as a smell test for leaks, not as a precise measurement.
+ */
+export class HeapSampler {
+  private startBytes: number | null = null
+  private peakBytes: number | null = null
+  private endBytes: number | null = null
+  private timer?: ReturnType<typeof setInterval>
+
+  private read(): number | null {
+    const memory = (performance as MemoryCapablePerformance).memory
+    return memory ? memory.usedJSHeapSize : null
+  }
+
+  private observe(bytes: number | null) {
+    if (bytes === null) return
+    if (this.peakBytes === null || bytes > this.peakBytes)
+      this.peakBytes = bytes
+  }
+
+  start() {
+    this.startBytes = this.read()
+    this.peakBytes = this.startBytes
+    if (this.startBytes === null) return
+    this.timer = setInterval(() => this.observe(this.read()), 500)
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer)
+    this.timer = undefined
+    this.endBytes = this.read()
+    // The last periodic sample is up to 500ms old, so growth after it would
+    // otherwise report a peak below the heap the run actually ended on.
+    this.observe(this.endBytes)
+  }
+
+  summarize(): HeapMetrics {
+    return {
+      supported: this.startBytes !== null,
+      startBytes: this.startBytes,
+      peakBytes: this.peakBytes,
+      endBytes: this.endBytes,
+    }
+  }
+}

--- a/src/frontend/src/features/rooms/livekit/processors/bench/contenders.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/contenders.ts
@@ -1,0 +1,79 @@
+import {
+  BackgroundProcessorFactory,
+  ProcessorType,
+} from '@/features/rooms/livekit/components/blur'
+import { BackgroundCustomProcessor } from '@/features/rooms/livekit/components/blur/BackgroundCustomProcessor'
+import { FaceLandmarksProcessor } from '@/features/rooms/livekit/components/blur/FaceLandmarksProcessor'
+import { UnifiedBackgroundTrackProcessor } from '@/features/rooms/livekit/components/blur/UnifiedBackgroundTrackProcessor'
+import type { BenchContender } from './types'
+
+const BLUR_RADIUS = 10
+const VIRTUAL_BACKGROUND_PATH = '/assets/backgrounds/1.jpg'
+
+// Via the factory rather than ProcessorWrapper directly, so @livekit/track-processors
+// stays behind the components/blur boundary.
+const describeWrapperPath = (): string =>
+  BackgroundProcessorFactory.hasModernApiSupport()
+    ? 'MediaStreamTrackProcessor path'
+    : 'canvas.captureStream fallback path'
+
+/**
+ * The processors this harness can measure.
+ *
+ * Anything implementing livekit's TrackProcessor belongs here — background
+ * blur today, an animal-face filter tomorrow. Adding a contender is one
+ * entry; the protocol and the metrics come for free.
+ */
+export const BENCH_CONTENDERS: BenchContender[] = [
+  {
+    id: 'livekit-blur',
+    label: 'LiveKit blur',
+    description: `@livekit/track-processors background blur, radius ${BLUR_RADIUS}`,
+    create: () =>
+      new UnifiedBackgroundTrackProcessor({
+        type: ProcessorType.BLUR,
+        blurRadius: BLUR_RADIUS,
+      }),
+    // track-processors defaults its ImageSegmenter to delegate: 'GPU' and
+    // spreads any segmenterOptions after it; we pass none.
+    inferenceDelegate: 'GPU',
+    describe: describeWrapperPath,
+  },
+  {
+    id: 'livekit-virtual',
+    label: 'LiveKit virtual background',
+    description: '@livekit/track-processors virtual background',
+    create: () =>
+      new UnifiedBackgroundTrackProcessor({
+        type: ProcessorType.VIRTUAL,
+        imagePath: VIRTUAL_BACKGROUND_PATH,
+      }),
+    inferenceDelegate: 'GPU',
+    describe: describeWrapperPath,
+  },
+  {
+    id: 'custom-canvas-blur',
+    label: 'Custom canvas blur (CPU fallback)',
+    description:
+      'In-house Canvas2D blur used where track-processors is unsupported',
+    create: () =>
+      new BackgroundCustomProcessor({
+        type: ProcessorType.BLUR,
+        blurRadius: BLUR_RADIUS,
+      }),
+    // Hardcoded to CPU: it exists for browsers without track-processors.
+    inferenceDelegate: 'CPU',
+  },
+  {
+    id: 'face-landmarks',
+    label: 'Face landmarks filter',
+    description: 'MediaPipe face landmarker drawing glasses overlays',
+    create: () =>
+      new FaceLandmarksProcessor({
+        showGlasses: true,
+        showFrench: false,
+      }),
+    // Hardcoded to GPU in FaceLandmarksProcessor.initFaceLandmarker.
+    inferenceDelegate: 'GPU',
+  },
+]

--- a/src/frontend/src/features/rooms/livekit/processors/bench/options.test.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/options.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+import {
+  MEASURE_SECONDS,
+  PASSES,
+  numberInRange,
+  resolveBenchOptions,
+} from './options'
+import { DEFAULT_BENCH_OPTIONS } from './types'
+
+describe('numberInRange', () => {
+  test('accepts an integer inside the range', () => {
+    expect(numberInRange('15', MEASURE_SECONDS)).toBe(15)
+  })
+
+  test('rejects an empty field rather than reading it as 0', () => {
+    expect(numberInRange('', PASSES)).toBeNull()
+  })
+
+  test('rejects values outside the range', () => {
+    expect(numberInRange('0', PASSES)).toBeNull()
+    expect(numberInRange('7', PASSES)).toBeNull()
+  })
+
+  test('rejects non-integers and unparseable text', () => {
+    expect(numberInRange('2.5', PASSES)).toBeNull()
+    expect(numberInRange('abc', PASSES)).toBeNull()
+  })
+})
+
+describe('resolveBenchOptions', () => {
+  test('leaves options that are already in range untouched', () => {
+    expect(resolveBenchOptions(DEFAULT_BENCH_OPTIONS)).toEqual(
+      DEFAULT_BENCH_OPTIONS
+    )
+  })
+
+  test('clamps a pass count that would run nothing at all', () => {
+    expect(
+      resolveBenchOptions({ ...DEFAULT_BENCH_OPTIONS, passes: 0 }).passes
+    ).toBe(PASSES.min)
+  })
+
+  test('clamps a measurement window that is too short to measure', () => {
+    expect(
+      resolveBenchOptions({ ...DEFAULT_BENCH_OPTIONS, measureMs: 0 }).measureMs
+    ).toBe(MEASURE_SECONDS.min * 1000)
+  })
+
+  test('falls back to the defaults for non-finite input', () => {
+    const resolved = resolveBenchOptions({
+      ...DEFAULT_BENCH_OPTIONS,
+      measureMs: Number.NaN,
+      passes: Number.POSITIVE_INFINITY,
+    })
+    expect(resolved.measureMs).toBe(DEFAULT_BENCH_OPTIONS.measureMs)
+    expect(resolved.passes).toBe(DEFAULT_BENCH_OPTIONS.passes)
+  })
+})

--- a/src/frontend/src/features/rooms/livekit/processors/bench/options.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/options.ts
@@ -1,0 +1,45 @@
+import { DEFAULT_BENCH_OPTIONS, type BenchOptions } from './types'
+
+export type Range = { min: number; max: number }
+
+/** The bounds the page displays, and the ones `runBenchmark` enforces. */
+export const MEASURE_SECONDS: Range = { min: 3, max: 120 }
+export const PASSES: Range = { min: 1, max: 6 }
+
+const MEASURE_MS: Range = {
+  min: MEASURE_SECONDS.min * 1000,
+  max: MEASURE_SECONDS.max * 1000,
+}
+
+/**
+ * A number input's `min`/`max` only bite on a form submit, and these controls
+ * have no form: cleared, the field reads as 0. Null means unusable, and the
+ * Run button stays disabled until it is not.
+ */
+export const numberInRange = (raw: string, range: Range): number | null => {
+  const value = Number(raw)
+  if (raw.trim() === '' || !Number.isInteger(value)) return null
+  return value >= range.min && value <= range.max ? value : null
+}
+
+const clamp = (value: number, range: Range, fallback: number) =>
+  Number.isFinite(value)
+    ? Math.min(Math.max(value, range.min), range.max)
+    : fallback
+
+/**
+ * Clamped, not rejected: `passes: 0` runs no pass and still returns a report,
+ * and a non-finite measureMs is setTimeout(0). The report carries these, so it
+ * states the protocol that actually ran.
+ */
+export const resolveBenchOptions = (options: BenchOptions): BenchOptions => ({
+  ...options,
+  measureMs: clamp(
+    options.measureMs,
+    MEASURE_MS,
+    DEFAULT_BENCH_OPTIONS.measureMs
+  ),
+  passes: Math.round(
+    clamp(options.passes, PASSES, DEFAULT_BENCH_OPTIONS.passes)
+  ),
+})

--- a/src/frontend/src/features/rooms/livekit/processors/bench/sequencing.test.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/sequencing.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from 'vitest'
+import { BenchAbortError, initThenAttach, raceAbort } from './sequencing'
+
+describe('initThenAttach', () => {
+  test('initialises the processor before attaching the source', async () => {
+    // Processors register their `loadeddata` handler at the end of init(),
+    // so attaching the source first means the event fires before anyone is
+    // listening and their render loop never starts. livekit's setProcessor
+    // orders it this way for the same reason.
+    const calls: string[] = []
+
+    await initThenAttach({
+      init: async () => {
+        calls.push('init')
+      },
+      attach: () => {
+        calls.push('attach')
+      },
+      play: async () => {
+        calls.push('play')
+      },
+    })
+
+    expect(calls).toEqual(['init', 'attach', 'play'])
+  })
+
+  test('never attaches the source when init fails', async () => {
+    const attach = vi.fn()
+
+    await expect(
+      initThenAttach({
+        init: async () => {
+          throw new Error('model download failed')
+        },
+        attach,
+        play: async () => {},
+      })
+    ).rejects.toThrow('model download failed')
+
+    expect(attach).not.toHaveBeenCalled()
+  })
+})
+
+describe('raceAbort', () => {
+  test('resolves with the value when the signal never aborts', async () => {
+    const controller = new AbortController()
+
+    await expect(
+      raceAbort(Promise.resolve('done'), controller.signal)
+    ).resolves.toBe('done')
+  })
+
+  test('rejects as soon as the signal aborts, even if the promise never settles', async () => {
+    const controller = new AbortController()
+    const neverSettles = new Promise<string>(() => {})
+
+    const raced = raceAbort(neverSettles, controller.signal)
+    controller.abort()
+
+    await expect(raced).rejects.toBeInstanceOf(BenchAbortError)
+  })
+
+  test('rejects immediately when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      raceAbort(Promise.resolve('done'), controller.signal)
+    ).rejects.toBeInstanceOf(BenchAbortError)
+  })
+
+  test('resolves normally when no signal is supplied', async () => {
+    await expect(raceAbort(Promise.resolve('done'), undefined)).resolves.toBe(
+      'done'
+    )
+  })
+})

--- a/src/frontend/src/features/rooms/livekit/processors/bench/sequencing.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/sequencing.ts
@@ -1,0 +1,65 @@
+export class BenchAbortError extends Error {
+  constructor() {
+    super('Benchmark aborted')
+    this.name = 'BenchAbortError'
+  }
+}
+
+type InitThenAttachSteps = {
+  init: () => Promise<void>
+  attach: () => void
+  play: () => Promise<void>
+}
+
+/**
+ * Drives a processor's start-up in the order livekit's `setProcessor` uses:
+ * `init()` runs against an element that has no source yet, and only then is
+ * the track attached and played.
+ *
+ * The order is a contract, not a detail. Processors finish `init()` by
+ * registering an `onloadeddata` handler to start their render loop; attach
+ * the source first and that event fires before anyone is listening, so the
+ * loop never starts and the processor emits nothing but a black frame.
+ */
+export async function initThenAttach(
+  steps: InitThenAttachSteps
+): Promise<void> {
+  await steps.init()
+  steps.attach()
+  await steps.play()
+}
+
+/**
+ * Rejects as soon as `signal` aborts, whether or not `promise` ever settles.
+ *
+ * Needed because a processor's `init()` exposes no cancellation, so the only
+ * way to stay responsive to Stop is to give up waiting on it.
+ */
+export function raceAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined
+): Promise<T> {
+  if (!signal) return promise
+  if (signal.aborted) return Promise.reject(new BenchAbortError())
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new BenchAbortError())
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      }
+    )
+  })
+}
+
+/** Throws if the run has been aborted; use at phase boundaries. */
+export function throwIfAborted(signal: AbortSignal | undefined) {
+  if (signal?.aborted) throw new BenchAbortError()
+}

--- a/src/frontend/src/features/rooms/livekit/processors/bench/stats.test.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/stats.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest'
+import { computeFps, mean, percentile, summarizeIntervals } from './stats'
+
+describe('percentile', () => {
+  test('returns the only value for a single-element sample', () => {
+    expect(percentile([42], 0.95)).toBe(42)
+  })
+
+  test('returns the median of an odd-sized sample', () => {
+    expect(percentile([5, 1, 3], 0.5)).toBe(3)
+  })
+
+  test('uses nearest-rank so p95 of 20 values is the 19th smallest', () => {
+    const values = Array.from({ length: 20 }, (_, i) => i + 1)
+    expect(percentile(values, 0.95)).toBe(19)
+  })
+
+  test('does not mutate the caller array', () => {
+    const values = [3, 1, 2]
+    percentile(values, 0.5)
+    expect(values).toEqual([3, 1, 2])
+  })
+
+  test('returns null for an empty sample', () => {
+    expect(percentile([], 0.5)).toBeNull()
+  })
+})
+
+describe('mean', () => {
+  test('averages the values', () => {
+    expect(mean([1, 2, 3, 4])).toBe(2.5)
+  })
+
+  test('returns null for an empty sample', () => {
+    expect(mean([])).toBeNull()
+  })
+})
+
+describe('summarizeIntervals', () => {
+  test('summarizes the gaps between timestamps, not the timestamps', () => {
+    const summary = summarizeIntervals([0, 10, 20, 30, 40])
+
+    expect(summary).not.toBeNull()
+    expect(summary!.count).toBe(4)
+    expect(summary!.meanMs).toBe(10)
+    expect(summary!.p50Ms).toBe(10)
+  })
+
+  test('surfaces stalls in the p95 while the p50 stays healthy', () => {
+    // 18 healthy 16ms gaps plus 2 stalls, so the stalls occupy the top 10%
+    // of samples and a nearest-rank p95 lands on one of them.
+    const gaps = [...Array(18).fill(16), 500, 500]
+    const timestamps = gaps.reduce(
+      (acc, gap) => [...acc, acc[acc.length - 1] + gap],
+      [0]
+    )
+
+    const summary = summarizeIntervals(timestamps)!
+
+    expect(summary.count).toBe(20)
+    expect(summary.p50Ms).toBe(16)
+    expect(summary.p95Ms).toBe(500)
+  })
+
+  test('returns null when there are fewer than two timestamps', () => {
+    expect(summarizeIntervals([5])).toBeNull()
+    expect(summarizeIntervals([])).toBeNull()
+  })
+})
+
+describe('computeFps', () => {
+  test('converts a frame count over an elapsed window into frames per second', () => {
+    expect(computeFps(30, 1000)).toBe(30)
+    expect(computeFps(45, 1500)).toBe(30)
+  })
+
+  test('returns 0 rather than dividing by zero on an empty window', () => {
+    expect(computeFps(10, 0)).toBe(0)
+  })
+})

--- a/src/frontend/src/features/rooms/livekit/processors/bench/stats.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/stats.ts
@@ -1,0 +1,55 @@
+export type SampleSummary = {
+  count: number
+  meanMs: number
+  p50Ms: number
+  p95Ms: number
+}
+
+export function mean(values: number[]): number | null {
+  if (values.length === 0) return null
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function percentileOfSorted(sorted: number[], p: number): number {
+  const rank = Math.ceil(p * sorted.length)
+  const index = Math.min(Math.max(rank - 1, 0), sorted.length - 1)
+  return sorted[index]
+}
+
+/**
+ * Nearest-rank percentile: the smallest value at or below which at least
+ * `p` of the sample falls. No interpolation, so every result is a value
+ * that was actually observed.
+ */
+export function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null
+  return percentileOfSorted(
+    [...values].sort((a, b) => a - b),
+    p
+  )
+}
+
+/** Turns a series of monotonic timestamps into a summary of the gaps between them. */
+export function summarizeIntervals(timestamps: number[]): SampleSummary | null {
+  if (timestamps.length < 2) return null
+
+  const intervals: number[] = []
+  for (let i = 1; i < timestamps.length; i++) {
+    intervals.push(timestamps[i] - timestamps[i - 1])
+  }
+
+  // Sorted once and indexed twice: a run can hold a few thousand intervals.
+  const sorted = [...intervals].sort((a, b) => a - b)
+
+  return {
+    count: intervals.length,
+    meanMs: mean(intervals)!,
+    p50Ms: percentileOfSorted(sorted, 0.5),
+    p95Ms: percentileOfSorted(sorted, 0.95),
+  }
+}
+
+export function computeFps(frameCount: number, elapsedMs: number): number {
+  if (elapsedMs <= 0) return 0
+  return (frameCount * 1000) / elapsedMs
+}

--- a/src/frontend/src/features/rooms/livekit/processors/bench/systemSpecs.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/systemSpecs.ts
@@ -1,0 +1,259 @@
+import { SUPPORTS_LONG_TASKS, SUPPORTS_RVFC } from './collectors'
+
+/**
+ * Machine description captured alongside a report, so a pasted result says
+ * which machine produced it. Everything here is best-effort: browsers vary
+ * in what they expose, and several of these are Chromium-only.
+ */
+
+export type GpuInfo = {
+  webgl2Available: boolean
+  webglVendor: string | null
+  webglRenderer: string | null
+  /** Renderer string looks like a software rasteriser (SwiftShader, llvmpipe). */
+  softwareRendered: boolean
+  webgpuAvailable: boolean
+  webgpuVendor: string | null
+  webgpuArchitecture: string | null
+  webgpuDevice: string | null
+  webgpuDescription: string | null
+}
+
+/** What this browser is able to tell the harness, recorded in the report. */
+export type MeasurementCapabilities = {
+  requestVideoFrameCallback: boolean
+  longTasks: boolean
+  jsHeap: boolean
+}
+
+export type SystemSpecs = {
+  collectedAt: string
+  userAgent: string
+  platform: string | null
+  platformVersion: string | null
+  architecture: string | null
+  bitness: string | null
+  model: string | null
+  browserVersion: string | null
+  logicalCores: number | null
+  deviceMemoryGb: number | null
+  gpu: GpuInfo
+  screen: {
+    width: number
+    height: number
+    devicePixelRatio: number
+    colorDepth: number
+  }
+  battery: { charging: boolean; levelPct: number } | null
+  capabilities: MeasurementCapabilities
+  timezone: string | null
+  language: string | null
+}
+
+const SOFTWARE_RENDERER_PATTERN =
+  /swiftshader|swangle|llvmpipe|software|basic render|microsoft basic/i
+
+type UserAgentDataLike = {
+  platform?: string
+  getHighEntropyValues?: (hints: string[]) => Promise<Record<string, string>>
+}
+
+type BatteryLike = { charging: boolean; level: number }
+
+type NavigatorLike = Navigator & {
+  deviceMemory?: number
+  userAgentData?: UserAgentDataLike
+  getBattery?: () => Promise<BatteryLike>
+}
+
+type GpuAdapterLike = {
+  info?: {
+    vendor?: string
+    architecture?: string
+    device?: string
+    description?: string
+  }
+  requestAdapterInfo?: () => Promise<{
+    vendor?: string
+    architecture?: string
+    device?: string
+    description?: string
+  }>
+}
+
+type GpuLike = {
+  requestAdapter?: () => Promise<GpuAdapterLike | null>
+}
+
+function readWebglInfo(): Pick<
+  GpuInfo,
+  'webgl2Available' | 'webglVendor' | 'webglRenderer' | 'softwareRendered'
+> {
+  const empty = {
+    webgl2Available: false,
+    webglVendor: null,
+    webglRenderer: null,
+    softwareRendered: false,
+  }
+  try {
+    const canvas = document.createElement('canvas')
+    const gl2 = canvas.getContext('webgl2')
+    const gl = (gl2 ??
+      canvas.getContext('webgl')) as WebGLRenderingContext | null
+    if (!gl) return empty
+
+    const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+    const vendor = debugInfo
+      ? (gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) as string)
+      : gl.getParameter(gl.VENDOR)
+    const renderer = debugInfo
+      ? (gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) as string)
+      : gl.getParameter(gl.RENDERER)
+
+    // Browsers cap live contexts (~16) and this probe runs more than once
+    // per session, so hand it back rather than waiting for GC.
+    gl.getExtension('WEBGL_lose_context')?.loseContext()
+
+    return {
+      webgl2Available: !!gl2,
+      webglVendor: vendor ?? null,
+      webglRenderer: renderer ?? null,
+      softwareRendered: SOFTWARE_RENDERER_PATTERN.test(String(renderer ?? '')),
+    }
+  } catch {
+    return empty
+  }
+}
+
+async function readWebgpuInfo(): Promise<
+  Pick<
+    GpuInfo,
+    | 'webgpuAvailable'
+    | 'webgpuVendor'
+    | 'webgpuArchitecture'
+    | 'webgpuDevice'
+    | 'webgpuDescription'
+  >
+> {
+  const empty = {
+    webgpuAvailable: false,
+    webgpuVendor: null,
+    webgpuArchitecture: null,
+    webgpuDevice: null,
+    webgpuDescription: null,
+  }
+  try {
+    // Cast through unknown: lib.dom types GPUAdapter without the older
+    // requestAdapterInfo(), which Chrome still uses before adapter.info.
+    const gpu = (navigator as unknown as { gpu?: GpuLike }).gpu
+    if (!gpu?.requestAdapter) return empty
+
+    const adapter = await gpu.requestAdapter()
+    if (!adapter) return empty
+
+    const info = adapter.info ?? (await adapter.requestAdapterInfo?.())
+    return {
+      webgpuAvailable: true,
+      webgpuVendor: info?.vendor ?? null,
+      webgpuArchitecture: info?.architecture ?? null,
+      webgpuDevice: info?.device ?? null,
+      webgpuDescription: info?.description ?? null,
+    }
+  } catch {
+    return empty
+  }
+}
+
+async function readHighEntropyUa(): Promise<{
+  platform: string | null
+  platformVersion: string | null
+  architecture: string | null
+  bitness: string | null
+  model: string | null
+  browserVersion: string | null
+}> {
+  const empty = {
+    platform: null,
+    platformVersion: null,
+    architecture: null,
+    bitness: null,
+    model: null,
+    browserVersion: null,
+  }
+  try {
+    const uaData = (navigator as NavigatorLike).userAgentData
+    if (!uaData?.getHighEntropyValues) {
+      return { ...empty, platform: uaData?.platform ?? null }
+    }
+    const values = await uaData.getHighEntropyValues([
+      'platform',
+      'platformVersion',
+      'architecture',
+      'bitness',
+      'model',
+      'uaFullVersion',
+    ])
+    return {
+      platform: values.platform ?? null,
+      platformVersion: values.platformVersion ?? null,
+      architecture: values.architecture ?? null,
+      bitness: values.bitness ?? null,
+      model: values.model || null,
+      browserVersion: values.uaFullVersion ?? null,
+    }
+  } catch {
+    return empty
+  }
+}
+
+async function readBattery(): Promise<SystemSpecs['battery']> {
+  try {
+    const getBattery = (navigator as NavigatorLike).getBattery
+    if (!getBattery) return null
+    const battery = await getBattery.call(navigator)
+    return {
+      charging: battery.charging,
+      levelPct: Math.round(battery.level * 100),
+    }
+  } catch {
+    return null
+  }
+}
+
+export async function collectSystemSpecs(): Promise<SystemSpecs> {
+  const [ua, webgpu, battery] = await Promise.all([
+    readHighEntropyUa(),
+    readWebgpuInfo(),
+    readBattery(),
+  ])
+
+  return {
+    collectedAt: new Date().toISOString(),
+    userAgent: navigator.userAgent,
+    ...ua,
+    logicalCores: navigator.hardwareConcurrency ?? null,
+    deviceMemoryGb: (navigator as NavigatorLike).deviceMemory ?? null,
+    gpu: { ...readWebglInfo(), ...webgpu },
+    screen: {
+      width: window.screen.width,
+      height: window.screen.height,
+      devicePixelRatio: window.devicePixelRatio,
+      colorDepth: window.screen.colorDepth,
+    },
+    battery,
+    capabilities: {
+      requestVideoFrameCallback: SUPPORTS_RVFC,
+      longTasks: SUPPORTS_LONG_TASKS,
+      jsHeap: 'memory' in performance,
+    },
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? null,
+    language: navigator.language ?? null,
+  }
+}
+
+/** One-line summary of how the machine is rendering, for the results header. */
+export function describeGpu(gpu: GpuInfo): string {
+  if (!gpu.webglRenderer) return 'unknown'
+  if (gpu.softwareRendered) return `software (${gpu.webglRenderer})`
+  return gpu.webglRenderer
+}

--- a/src/frontend/src/features/rooms/livekit/processors/bench/types.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/bench/types.ts
@@ -1,0 +1,156 @@
+import type {
+  Track,
+  TrackProcessor,
+  VideoProcessorOptions,
+} from 'livekit-client'
+import type { SampleSummary } from './stats'
+import type { SystemSpecs } from './systemSpecs'
+
+/**
+ * What a processor asks MediaPipe for. It is a *request*, not a measurement:
+ * MediaPipe never reports the delegate it settled on and can silently fall
+ * back to CPU, so this is only ever labelled as requested.
+ */
+export type InferenceDelegate = 'CPU' | 'GPU' | 'unknown'
+
+/**
+ * Everything the harness needs from a processor. Deliberately the plain
+ * livekit-client interface: the harness must stay usable for background
+ * blur, face filters, or anything else that transforms a video track.
+ */
+export type VideoTrackProcessor = TrackProcessor<
+  Track.Kind.Video,
+  VideoProcessorOptions
+>
+
+export type BenchContender = {
+  id: string
+  label: string
+  description?: string
+  create: () => VideoTrackProcessor
+  /**
+   * The MediaPipe delegate this processor requests, where it is known.
+   * Optional: a contender that does no MediaPipe inference has no answer.
+   */
+  inferenceDelegate?: InferenceDelegate
+  /**
+   * Optional note read after init, for whatever the processor decided at
+   * runtime (model picked, GPU vs CPU path). Surfaced next to the numbers
+   * so two rows are only compared when they are comparable.
+   */
+  describe?: (processor: VideoTrackProcessor) => string | undefined
+}
+
+/** Purely observed. Anything a contender merely declares belongs elsewhere. */
+export type GpuUsage = {
+  /** Canvas context types the processor created during the run. */
+  contextTypes: string[]
+  /** True when a webgl/webgl2/webgpu context was created; null if none were. */
+  rendersOnGpu: boolean | null
+}
+
+export type BenchOptions = {
+  width: number
+  height: number
+  frameRate: number
+  /** Settling time after the first frame, before measurement starts. */
+  warmupMs: number
+  measureMs: number
+  cooldownMs: number
+  /** Passes over the contender list; pass 2+ runs in reverse order. */
+  passes: number
+}
+
+export const DEFAULT_BENCH_OPTIONS: BenchOptions = {
+  width: 1280,
+  height: 720,
+  frameRate: 30,
+  warmupMs: 3000,
+  measureMs: 15000,
+  cooldownMs: 2000,
+  passes: 2,
+}
+
+export type LongTaskMetrics = {
+  supported: boolean
+  count: number
+  /** Raw sum of long-task durations. */
+  totalMs: number
+  /** Total Blocking Time: each long task's excess over the 50ms threshold. */
+  blockingMs: number
+  /** Share of the measurement window spent inside long tasks. */
+  sharePct: number
+}
+
+export type HeapMetrics = {
+  supported: boolean
+  startBytes: number | null
+  peakBytes: number | null
+  endBytes: number | null
+}
+
+export type RunMetrics = {
+  pass: number
+  measuredMs: number
+  framesDelivered: number
+  fps: number
+  /** Null when the browser lacks requestVideoFrameCallback. */
+  frameIntervals: SampleSummary | null
+  rafIntervals: SampleSummary | null
+  longTasks: LongTaskMetrics
+  heap: HeapMetrics
+  gpu: GpuUsage
+  /** init() until the first frame leaves the processor. */
+  startupMs: number | null
+  note?: string
+  error?: string
+}
+
+export type ContenderResult = {
+  contenderId: string
+  label: string
+  runs: RunMetrics[]
+  /** First run: model download and compile included. */
+  coldStartupMs: number | null
+  /** Later runs: assets already cached. */
+  warmStartupMs: number | null
+  /** Highest heap peak across every pass. Null where the browser has no `performance.memory`. */
+  heapPeakBytes: number | null
+  averaged: {
+    fps: number | null
+    frameP95Ms: number | null
+    rafP50Ms: number | null
+    rafP95Ms: number | null
+    blockingMs: number | null
+    longTaskCount: number | null
+    longTaskSharePct: number | null
+  }
+  notes: string[]
+  errors: string[]
+  gpu: GpuUsage
+  /** Declared by the contender, not measured. Absent when it does not apply. */
+  inferenceDelegate?: InferenceDelegate
+}
+
+export type BenchReport = {
+  startedAt: string
+  userAgent: string
+  specs: SystemSpecs
+  options: BenchOptions
+  sourceSettings: MediaTrackSettings | null
+  results: ContenderResult[]
+}
+
+export type BenchPhase =
+  | 'idle'
+  | 'starting'
+  | 'warmup'
+  | 'measuring'
+  | 'cooldown'
+  | 'done'
+
+export type BenchProgress = {
+  phase: BenchPhase
+  contenderLabel?: string
+  pass?: number
+}

--- a/src/frontend/src/routes.ts
+++ b/src/frontend/src/routes.ts
@@ -27,6 +27,26 @@ const ConnectionTestRoute = lazy(
 
 const roomIdRegex = new RegExp(`^[/](?<roomId>${flexibleRoomIdPattern})$`)
 
+/**
+ * Routes that only exist while developing. `import.meta.env.DEV` is inlined
+ * as `false` at build time, so the branch — and the chunk it imports — are
+ * dropped from production bundles entirely.
+ */
+export const devRoutes: Array<{
+  path: string
+  Component: LazyExoticComponent<ComponentType>
+}> = import.meta.env.DEV
+  ? [
+      {
+        path: '/processor-bench',
+        Component: lazy(
+          () =>
+            import('@/features/rooms/livekit/processors/bench/ProcessorBenchPage')
+        ),
+      },
+    ]
+  : []
+
 export const routes: Record<
   | 'home'
   | 'room'

--- a/src/frontend/tsconfig.node.json
+++ b/src/frontend/tsconfig.node.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+// Kept in step with vite.config.ts: a standalone vitest config replaces it
+// rather than extending it, so anything tests rely on has to be repeated here.
+// The `@/` alias mirrors vite.config.ts's `resolve.tsconfigPaths` (which is not
+// in the vite version vitest bundles) and tsconfig.app.json's paths.
+const mediapipeVersion = JSON.parse(
+  readFileSync('./node_modules/@mediapipe/tasks-vision/package.json', 'utf-8')
+).version
+
+export default defineConfig({
+  define: {
+    __MEDIAPIPE_VERSION__: JSON.stringify(mediapipeVersion),
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Purpose

While reviewing #1378 I realized it would be a good idea to have a development tool to compare performance on track processors.

This is not supposed to give absolute results as the bench depends on the machine where it is executed and if said machine have a gpu enabled on the browser etc. But just to give a base line for changes on video processing.

Currently on main we have
- livekit-blur
- livekit-virtual
- custom-canvas-blur
- face-landmarks

The idea if this in considered a good addition would to have `AdvancedMattingProcessor` measured to see how it performs compared to current trackers.

## Results
<img width="2350" height="1912" alt="image" src="https://github.com/user-attachments/assets/fb7b74ae-53da-4fdb-88d0-635ab2405e52" />
