### PR TITLE
⬆️(docker) pin LiveKit server to v1.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - ✨(frontend) add 1080p sending resolution option #1660
 - ✨(backend) add Traefik support via configurable media-auth url header #1649
 
+### Changed
+
+- ⬆️(dev) pin LiveKit server to v1.13.6
+
 ### Fixed
 
 - 🐛(frontend) keep the sending resolution picked while the camera is off #1667

--- a/compose.yml
+++ b/compose.yml
@@ -207,7 +207,7 @@ services:
       - kc_postgresql
 
   livekit:
-    image: livekit/livekit-server
+    image: livekit/livekit-server:v1.13.6
     entrypoint: /livekit-server --dev --bind 0.0.0.0 --config ./config.yaml
     ports:
       - "7880:7880"

--- a/docker/livekit/Dockerfile
+++ b/docker/livekit/Dockerfile
@@ -1,4 +1,4 @@
-FROM livekit/livekit-server:v1.9.4
+FROM livekit/livekit-server:v1.13.6
 
 # We inject the nip.io certificate manually because the livekit chart doesn't support volume mounting
 COPY rootCA.pem /etc/ssl/certs/


### PR DESCRIPTION
The compose stack referenced livekit/livekit-server without a tag, which resolved to :latest. Docker doesn't re-resolve a mutable tag it already holds locally, so images earlier than v1.12.0 crashed on startup:

    could not parse config: yaml: unmarshal errors:
      line 20: field allow_restricted_peer_cidrs not found in
      type config.TURNConfig

LiveKit parses its config in strict mode, and allow_restricted_peer_cidrs only exists since v1.12.0. The TURN block added in bd81c994 therefore carried an minimum version which was not reflected.

The Tilt/Helm stack builds its own image from docker/livekit/Dockerfile to inject the mkcert root CA, and that was still based on v1.9.4. Bump it to the same version so both dev stacks run the same server.
