### PR TITLE
🐛(backend) allow all ASCII characters in the user sub field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) allow any printable ASCII characters in user sub field #1673
 - 🐛(frontend) keep the sending resolution picked while the camera is off #1667
 
 ## [1.30.0] - 2026-09-01

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -3,7 +3,11 @@
 import contextlib
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
+from django.core.exceptions import (
+    ImproperlyConfigured,
+    SuspiciousOperation,
+    ValidationError,
+)
 from django.utils.translation import gettext_lazy as _
 
 from lasuite.oidc_login.backends import (
@@ -17,6 +21,7 @@ from core.services.marketing import (
     ContactData,
     get_marketing_service,
 )
+from core.validators import sub_validator
 
 
 class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
@@ -84,6 +89,19 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
 
     def get_existing_user(self, sub, email):
         """Fetch existing user by sub or email."""
+
+        sub = str(sub)
+
+        try:
+            sub_validator(sub)
+        except ValidationError as err:
+            raise SuspiciousOperation(
+                "User info contained an invalid sub claim"
+            ) from err
+
+        if len(sub) > 255:
+            raise SuspiciousOperation("User info contained an invalid sub claim")
+
         try:
             return User.objects.get(sub=sub)
         except User.DoesNotExist:

--- a/src/backend/core/migrations/0001_initial.py
+++ b/src/backend/core/migrations/0001_initial.py
@@ -8,6 +8,8 @@ import uuid
 from django.conf import settings
 from django.db import migrations, models
 
+import core.validators
+
 
 class Migration(migrations.Migration):
 
@@ -41,7 +43,7 @@ class Migration(migrations.Migration):
                 ('id', models.UUIDField(default=uuid.uuid4, editable=False, help_text='primary key for the record as UUID', primary_key=True, serialize=False, verbose_name='id')),
                 ('created_at', models.DateTimeField(auto_now_add=True, help_text='date and time at which a record was created', verbose_name='created on')),
                 ('updated_at', models.DateTimeField(auto_now=True, help_text='date and time at which a record was last updated', verbose_name='updated on')),
-                ('sub', models.CharField(blank=True, help_text='Optional for pending users; required upon account activation. 255 characters or fewer. Letters, numbers, and @/./+/-/_ characters only.', max_length=255, null=True, unique=True, validators=[django.core.validators.RegexValidator(message='Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/_ characters.', regex='^[\\w.@+-]+\\Z')], verbose_name='sub')),
+                ('sub', models.CharField(blank=True, help_text='Optional for pending users; required upon account activation. 255 characters or fewer. Printable ASCII characters only.', max_length=255, null=True, unique=True, validators=[core.validators.sub_validator], verbose_name='sub')),
                 ('email', models.EmailField(blank=True, max_length=254, null=True, verbose_name='identity email address')),
                 ('admin_email', models.EmailField(blank=True, max_length=254, null=True, unique=True, verbose_name='admin email address')),
                 ('language', models.CharField(choices=settings.LANGUAGES, default=settings.LANGUAGE_CODE, help_text='The language in which the user wants to see the interface.', max_length=10, verbose_name='language')),

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -27,6 +27,7 @@ from timezone_field import TimeZoneField
 
 from . import fields, utils
 from .recording.enums import FileExtension
+from .validators import sub_validator
 
 logger = getLogger(__name__)
 
@@ -145,19 +146,11 @@ class BaseModel(models.Model):
 class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
     """User model to work with OIDC only authentication."""
 
-    sub_validator = validators.RegexValidator(
-        regex=r"^[\w.@+-]+\Z",
-        message=_(
-            "Enter a valid sub. This value may contain only letters, "
-            "numbers, and @/./+/-/_ characters."
-        ),
-    )
-
     sub = models.CharField(
         _("sub"),
         help_text=_(
             "Optional for pending users; required upon account activation. "
-            "255 characters or fewer. Letters, numbers, and @/./+/-/_ characters only."
+            "255 characters or fewer. Printable ASCII characters only."
         ),
         max_length=255,
         unique=True,

--- a/src/backend/core/tests/authentication/test_backends.py
+++ b/src/backend/core/tests/authentication/test_backends.py
@@ -40,6 +40,111 @@ def test_authentication_getter_existing_user(monkeypatch):
     assert user == db_user
 
 
+@pytest.mark.parametrize(
+    "sub",
+    [
+        # NUL (U+0000) passes str.isascii() but PostgreSQL text fields
+        # cannot store or compare it (DataError)
+        "auth0|abc\x00def",
+        # lone surrogates cannot be encoded to UTF-8 for the DB lookup
+        # (UnicodeEncodeError), which runs before any model validation
+        "bad\ud800sub",
+        # plainly invalid subs would otherwise escape as ValidationError
+        # on user creation, which mozilla-django-oidc does not catch
+        "\u00e9milie",
+        "a" * 256,
+        # ASCII control characters are rejected by policy
+        "tab\tsub",
+        "del\x7fsub",
+    ],
+)
+def test_authentication_getter_invalid_sub_rejected_cleanly(monkeypatch, sub):
+    """
+    Subs that can never be persisted should be rejected with
+    SuspiciousOperation (turned into a clean authentication failure by
+    mozilla-django-oidc) instead of leaking DataError, UnicodeEncodeError
+    or ValidationError as a server error.
+    """
+    klass = OIDCAuthenticationBackend()
+
+    def get_userinfo_mocked(*args):
+        return {"sub": sub, "email": "john@example.com"}
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    with pytest.raises(
+        SuspiciousOperation,
+        match="User info contained an invalid sub claim",
+    ):
+        klass.get_or_create_user(access_token="test-token", id_token=None, payload=None)
+
+    assert models.User.objects.exists() is False
+
+
+def test_authentication_getter_numeric_sub(monkeypatch):
+    """
+    Some providers serialize the sub as a JSON number. It should keep working
+    (CharField coerces it to a string on save) and must not crash the early
+    sub checks in get_existing_user.
+    """
+    klass = OIDCAuthenticationBackend()
+
+    def get_userinfo_mocked(*args):
+        return {"sub": 12345, "email": "john@example.com"}
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    user = klass.get_or_create_user(
+        access_token="test-token", id_token=None, payload=None
+    )
+
+    assert user.sub == "12345"
+    assert models.User.objects.count() == 1
+
+
+def test_authentication_getter_new_user_auth0_pipe_sub(monkeypatch):
+    """
+    A first login with an Auth0-style sub containing a pipe ("provider|user-id")
+    should create the user instead of raising a ValidationError.
+    Regression test for https://github.com/suitenumerique/meet/issues/[XXX].
+    """
+    klass = OIDCAuthenticationBackend()
+
+    def get_userinfo_mocked(*args):
+        return {"sub": "auth0|644c0bc8f1874ef6d339fb34", "email": "john@example.com"}
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    user = klass.get_or_create_user(
+        access_token="test-token", id_token=None, payload=None
+    )
+
+    assert user.sub == "auth0|644c0bc8f1874ef6d339fb34"
+    assert user.email == "john@example.com"
+    assert models.User.objects.count() == 1
+
+
+def test_authentication_getter_existing_user_auth0_pipe_sub(monkeypatch):
+    """
+    A returning user with an Auth0-style pipe sub should be matched by sub,
+    not duplicated or rejected.
+    """
+    klass = OIDCAuthenticationBackend()
+    db_user = UserFactory(sub="auth0|644c0bc8f1874ef6d339fb34")
+
+    def get_userinfo_mocked(*args):
+        return {"sub": db_user.sub}
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    user = klass.get_or_create_user(
+        access_token="test-token", id_token=None, payload=None
+    )
+
+    assert user == db_user
+    assert models.User.objects.count() == 1
+
+
 def test_authentication_getter_new_user_no_email(monkeypatch):
     """
     If no user matches, a user should be created.

--- a/src/backend/core/tests/test_models_users.py
+++ b/src/backend/core/tests/test_models_users.py
@@ -26,6 +26,64 @@ def test_models_users_id_unique():
         factories.UserFactory(id=user.id)
 
 
+@pytest.mark.parametrize(
+    "sub,is_valid",
+    [
+        # cases from suitenumerique/docs PR #1295 (same validator)
+        ("valid_sub.@+-:=/", True),
+        ("invalid süb", False),
+        (12345, True),
+        # Auth0 emits "provider|user-id" subject identifiers
+        ("auth0|644c0bc8f1874ef6d339fb34", True),
+        ("google-oauth2|103547991597142817347", True),
+        # Keycloak-style UUID
+        ("f:550e8400-e29b-41d4-a716-446655440000:jdoe", True),
+        # base64/URN-style identifiers
+        ("dGVzdC1zdWItdmFsdWU=", True),
+        ("urn:example:user/42", True),
+        # legacy format still accepted
+        ("user@example.com", True),
+        # space (U+0020) is printable ASCII and remains allowed
+        ("sub with space", True),
+        # non-ASCII values are rejected
+        ("émilie", False),
+        # ASCII control characters (U+0000-U+001F, U+007F) are rejected:
+        # NUL passes isascii() but cannot be stored in PostgreSQL text
+        # fields, and the others invite log injection and interop issues
+        ("nul\x00sub", False),
+        ("\x00", False),
+        ("tab\tsub", False),
+        ("newline\nsub", False),
+        ("del\x7fsub", False),
+    ],
+)
+def test_models_users_sub_validator(sub, is_valid):
+    """
+    The "sub" field should accept any ASCII string as required by
+    OpenID Connect Core 1.0 §2 and RFC 7519 §4.1.2, and reject non-ASCII values.
+    """
+    user = factories.UserFactory()
+    user.sub = sub
+    if is_valid:
+        user.full_clean()
+    else:
+        with pytest.raises(
+            ValidationError,
+            match="Enter a valid sub. This value should be printable ASCII only.",
+        ):
+            user.full_clean()
+
+
+def test_models_users_sub_max_length():
+    """The "sub" field should enforce the 255 ASCII characters limit of OIDC Core 1.0 §2."""
+    user = factories.UserFactory(sub="a" * 255)
+    assert user.sub == "a" * 255
+
+    user.sub = "a" * 256
+    with pytest.raises(ValidationError, match="at most 255 characters"):
+        user.full_clean()
+
+
 def test_models_users_send_mail_main_existing():
     """The "email_user' method should send mail to the user's email address."""
     user = factories.UserFactory()

--- a/src/backend/core/validators.py
+++ b/src/backend/core/validators.py
@@ -1,0 +1,23 @@
+"""Custom validators for the core app."""
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+
+def sub_validator(value):
+    """Validate that the sub is printable ASCII only.
+
+    OpenID Connect Core 1.0 (section 2) allows any ASCII (RFC 20) string of
+    at most 255 characters, so no character whitelist is applied: providers
+    legitimately emit "|" (Auth0), ":" (Keycloak), "=", "/", etc. As a
+    deliberate hardening beyond the spec, ASCII control characters
+    (U+0000-U+001F and U+007F) are rejected: no known provider emits them,
+    NUL cannot be stored in PostgreSQL text fields, and the others invite
+    log-injection and interoperability issues. For str values,
+    ``isprintable()`` is false exactly for those control characters, while
+    space (U+0020) remains allowed.
+    """
+    if not value.isascii() or not value.isprintable():
+        raise ValidationError(
+            _("Enter a valid sub. This value should be printable ASCII only.")
+        )

--- a/src/backend/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/backend/locale/de_DE/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-02 10:47+0000\n"
+"POT-Creation-Date: 2026-09-02 22:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,11 +51,11 @@ msgstr ""
 msgid "File preview"
 msgstr ""
 
-#: core/admin.py:300 core/admin.py:443
+#: core/admin.py:300 core/admin.py:450
 msgid "No owner"
 msgstr "Kein Eigentümer"
 
-#: core/admin.py:303 core/admin.py:446
+#: core/admin.py:303 core/admin.py:453
 msgid "Multiple owners"
 msgstr "Mehrere Eigentümer"
 
@@ -98,11 +98,11 @@ msgstr "%(count)s Aufnahme(n) erfolgreich als ‚Fehler beim Stoppen‘ markiert
 msgid "Skipped %(count)s recording(s) with an ineligible status."
 msgstr "%(count)s abgelaufene Aufnahme(n) übersprungen."
 
-#: core/admin.py:510
+#: core/admin.py:517
 msgid "No scopes"
 msgstr "Keine Scopes"
 
-#: core/admin.py:512
+#: core/admin.py:519
 msgid "Scopes"
 msgstr "Scopes"
 
@@ -110,185 +110,201 @@ msgstr "Scopes"
 msgid "Creator is me"
 msgstr "Ersteller bin ich"
 
-#: core/api/serializers.py:89
+#: core/api/serializers.py:108
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Sie müssen Administrator oder Eigentümer eines Raums sein, um Zugriffe "
 "hinzuzufügen."
 
-#: core/api/serializers.py:534
+#: core/api/serializers.py:560
 msgid "This file extension is not allowed."
 msgstr "Diese Dateiendung ist nicht erlaubt."
 
-#: core/api/viewsets.py:1222
+#: core/api/viewsets.py:1268
 msgid "You have reached the maximum number of files for this type."
 msgstr "Sie haben die maximale Anzahl an Dateien dieses Typs erreicht."
 
-#: core/models.py:37
+#: core/models.py:38
 msgid "Member"
 msgstr "Mitglied"
 
-#: core/models.py:38
+#: core/models.py:39
 msgid "Administrator"
 msgstr "Administrator"
 
-#: core/models.py:39
+#: core/models.py:40
 msgid "Owner"
 msgstr "Eigentümer"
 
-#: core/models.py:55
+#: core/models.py:56
 msgid "Initiated"
 msgstr "Gestartet"
 
-#: core/models.py:56
+#: core/models.py:57
 msgid "Active"
 msgstr "Aktiv"
 
-#: core/models.py:57
+#: core/models.py:58
 msgid "Stopped"
 msgstr "Beendet"
 
-#: core/models.py:58
+#: core/models.py:59
 msgid "Saved"
 msgstr "Gespeichert"
 
-#: core/models.py:59
+#: core/models.py:60
 msgid "Aborted"
 msgstr "Abgebrochen"
 
-#: core/models.py:60
+#: core/models.py:61
 msgid "Failed to Start"
 msgstr "Start fehlgeschlagen"
 
-#: core/models.py:61
+#: core/models.py:62
 msgid "Failed to Stop"
 msgstr "Stopp fehlgeschlagen"
 
-#: core/models.py:62
+#: core/models.py:63
 msgid "Notification succeeded"
 msgstr "Benachrichtigung erfolgreich"
 
-#: core/models.py:65
+#: core/models.py:66
 msgid "External process successful"
 msgstr "Externer Prozess erfolgreich"
 
-#: core/models.py:67
+#: core/models.py:68
 msgid "External process failed"
 msgstr "Externer Prozess fehlgeschlagen"
 
-#: core/models.py:96
+#: core/models.py:97
 msgid "SCREEN_RECORDING"
 msgstr "BILDSCHIRMAUFZEICHNUNG"
 
-#: core/models.py:97
+#: core/models.py:98
 msgid "TRANSCRIPT"
 msgstr "TRANSKRIPT"
 
-#: core/models.py:103
+#: core/models.py:104
 msgid "Public Access"
 msgstr "Öffentlicher Zugriff"
 
-#: core/models.py:104
+#: core/models.py:105
 msgid "Trusted Access"
 msgstr "Vertrauenswürdiger Zugriff"
 
-#: core/models.py:105
+#: core/models.py:106
 msgid "Restricted Access"
 msgstr "Eingeschränkter Zugriff"
 
-#: core/models.py:117
+#: core/models.py:118
 msgid "id"
 msgstr "ID"
 
-#: core/models.py:118
+#: core/models.py:119
 msgid "primary key for the record as UUID"
 msgstr "Primärschlüssel des Eintrags als UUID"
 
-#: core/models.py:124
+#: core/models.py:125
 msgid "created on"
 msgstr "erstellt am"
 
-#: core/models.py:125
+#: core/models.py:126
 msgid "date and time at which a record was created"
 msgstr "Datum und Uhrzeit der Erstellung eines Eintrags"
 
-#: core/models.py:130
+#: core/models.py:131
 msgid "updated on"
 msgstr "aktualisiert am"
 
-#: core/models.py:131
+#: core/models.py:132
 msgid "date and time at which a record was last updated"
 msgstr "Datum und Uhrzeit der letzten Aktualisierung eines Eintrags"
 
-#: core/models.py:151
-msgid ""
-"Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
-"_ characters."
-msgstr ""
-"Geben Sie einen gültigen Sub ein. Dieser Wert darf nur Buchstaben, Zahlen "
-"und die Zeichen @/./+/-/_ enthalten."
-
-#: core/models.py:157
+#: core/models.py:150
 msgid "sub"
 msgstr "Sub"
 
-#: core/models.py:159
+#: core/models.py:152
 msgid ""
 "Optional for pending users; required upon account activation. 255 characters "
-"or fewer. Letters, numbers, and @/./+/-/_ characters only."
+"or fewer. Printable ASCII characters only."
 msgstr ""
 "Optional für ausstehende Benutzer; erforderlich nach Kontoaktivierung. "
-"Maximal 255 Zeichen. Nur Buchstaben, Zahlen und @/./+/-/_ Zeichen erlaubt."
+"Maximal 255 Zeichen. Nur druckbare ASCII-Zeichen erlaubt."
 
-#: core/models.py:168
+#: core/validators.py:22
+msgid "Enter a valid sub. This value should be printable ASCII only."
+msgstr "Geben Sie einen gültigen sub ein. Dieser Wert darf nur druckbare ASCII-Zeichen enthalten."
+
+#: core/models.py:161
 msgid "identity email address"
 msgstr "Identitäts-E-Mail-Adresse"
 
-#: core/models.py:173
+#: core/models.py:166
 msgid "admin email address"
 msgstr "Administrator-E-Mail-Adresse"
 
-#: core/models.py:175
+#: core/models.py:168
 msgid "full name"
 msgstr "Vollständiger Name"
 
-#: core/models.py:177
+#: core/models.py:170
 msgid "short name"
 msgstr "Kurzname"
 
-#: core/models.py:183
+#: core/models.py:176
 msgid "language"
 msgstr "Sprache"
 
-#: core/models.py:184
+#: core/models.py:177
 msgid "The language in which the user wants to see the interface."
 msgstr "Die Sprache, in der der Benutzer die Oberfläche sehen möchte."
 
-#: core/models.py:190
+#: core/models.py:183
 msgid "The timezone in which the user wants to see times."
 msgstr "Die Zeitzone, in der der Benutzer die Zeiten sehen möchte."
 
-#: core/models.py:193
+#: core/models.py:190
+msgid "default room access level"
+msgstr ""
+
+#: core/models.py:192
+msgid ""
+"Access level applied by default to new rooms created by this user. When "
+"empty, the instance default is used."
+msgstr ""
+
+#: core/models.py:199
+#, fuzzy
+#| msgid "Visio room configuration"
+msgid "default room configuration"
+msgstr "Visio-Raumkonfiguration"
+
+#: core/models.py:201
+msgid "Configurations applied by default to new rooms created by this user."
+msgstr ""
+
+#: core/models.py:205
 msgid "device"
 msgstr "Gerät"
 
-#: core/models.py:195
+#: core/models.py:207
 msgid "Whether the user is a device or a real user."
 msgstr "Ob es sich um ein Gerät oder einen echten Benutzer handelt."
 
-#: core/models.py:198
+#: core/models.py:210
 msgid "staff status"
 msgstr "Mitarbeiterstatus"
 
-#: core/models.py:200
+#: core/models.py:212
 msgid "Whether the user can log into this admin site."
 msgstr "Ob der Benutzer sich bei dieser Admin-Seite anmelden kann."
 
-#: core/models.py:203
+#: core/models.py:215
 msgid "active"
 msgstr "aktiv"
 
-#: core/models.py:206
+#: core/models.py:218
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
@@ -296,66 +312,66 @@ msgstr ""
 "Ob dieser Benutzer als aktiv behandelt werden soll. Deaktivieren Sie dies "
 "anstelle des Löschens des Kontos."
 
-#: core/models.py:219
+#: core/models.py:231
 msgid "user"
 msgstr "Benutzer"
 
-#: core/models.py:220
+#: core/models.py:232
 msgid "users"
 msgstr "Benutzer"
 
-#: core/models.py:286
+#: core/models.py:298
 msgid "Resource"
 msgstr "Ressource"
 
-#: core/models.py:287
+#: core/models.py:299
 msgid "Resources"
 msgstr "Ressourcen"
 
-#: core/models.py:345
+#: core/models.py:357
 msgid "Resource access"
 msgstr "Ressourcenzugriff"
 
-#: core/models.py:346
+#: core/models.py:358
 msgid "Resource accesses"
 msgstr "Ressourcenzugriffe"
 
-#: core/models.py:352
+#: core/models.py:364
 msgid "Resource access with this User and Resource already exists."
 msgstr ""
 "Ein Ressourcenzugriff mit diesem Benutzer und dieser Ressource existiert "
 "bereits."
 
-#: core/models.py:409
+#: core/models.py:421
 msgid "Visio room configuration"
 msgstr "Visio-Raumkonfiguration"
 
-#: core/models.py:410
+#: core/models.py:422
 msgid "Values for Visio parameters to configure the room."
 msgstr "Werte für Visio-Parameter zur Konfiguration des Raums."
 
-#: core/models.py:417
+#: core/models.py:429
 msgid "Room PIN code"
 msgstr "PIN-Code für den Raum"
 
-#: core/models.py:418
+#: core/models.py:430
 msgid "Unique n-digit code that identifies this room in telephony mode."
 msgstr ""
 "Eindeutiger n-stelliger Code, der diesen Raum im Telephonmodus identifiziert."
 
-#: core/models.py:424 core/models.py:578
+#: core/models.py:436 core/models.py:597
 msgid "Room"
 msgstr "Raum"
 
-#: core/models.py:425
+#: core/models.py:437
 msgid "Rooms"
 msgstr "Räume"
 
-#: core/models.py:589
+#: core/models.py:608
 msgid "Worker ID"
 msgstr "Worker-ID"
 
-#: core/models.py:591
+#: core/models.py:610
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
@@ -364,153 +380,153 @@ msgstr ""
 "erhalten, auch wenn der Worker stoppt, was ein einfaches Nachverfolgen "
 "ermöglicht."
 
-#: core/models.py:599
+#: core/models.py:618
 msgid "Recording mode"
 msgstr "Aufzeichnungsmodus"
 
-#: core/models.py:600
+#: core/models.py:619
 msgid "Defines the mode of recording being called."
 msgstr "Definiert den aufgerufenen Aufzeichnungsmodus."
 
-#: core/models.py:605 core/models.py:606
+#: core/models.py:624 core/models.py:625
 msgid "Recording options"
 msgstr "Aufnahmeoptionen"
 
-#: core/models.py:613
+#: core/models.py:632
 msgid "External Process ID"
 msgstr "External Process ID"
 
-#: core/models.py:614
+#: core/models.py:633
 msgid "ID of the external process associated with the recording."
 msgstr "ID des externen Prozesses, der mit der Aufzeichnung verknüpft ist"
 
-#: core/models.py:620
+#: core/models.py:639
 msgid "Recording"
 msgstr "Aufzeichnung"
 
-#: core/models.py:621
+#: core/models.py:640
 msgid "Recordings"
 msgstr "Aufzeichnungen"
 
-#: core/models.py:731
+#: core/models.py:750
 msgid "Recording/user relation"
 msgstr "Beziehung Aufzeichnung/Benutzer"
 
-#: core/models.py:732
+#: core/models.py:751
 msgid "Recording/user relations"
 msgstr "Beziehungen Aufzeichnung/Benutzer"
 
-#: core/models.py:738
+#: core/models.py:757
 msgid "This user is already in this recording."
 msgstr "Dieser Benutzer ist bereits Teil dieser Aufzeichnung."
 
-#: core/models.py:744
+#: core/models.py:763
 msgid "This team is already in this recording."
 msgstr "Dieses Team ist bereits Teil dieser Aufzeichnung."
 
-#: core/models.py:750
+#: core/models.py:769
 msgid "Either user or team must be set, not both."
 msgstr "Entweder Benutzer oder Team muss festgelegt werden, nicht beides."
 
-#: core/models.py:767
+#: core/models.py:786
 msgid "Create rooms"
 msgstr "Räume erstellen"
 
-#: core/models.py:768
+#: core/models.py:787
 msgid "List rooms"
 msgstr "Räume auflisten"
 
-#: core/models.py:769
+#: core/models.py:788
 msgid "Retrieve room details"
 msgstr "Raumdetails abrufen"
 
-#: core/models.py:770
+#: core/models.py:789
 msgid "Update rooms"
 msgstr "Räume aktualisieren"
 
-#: core/models.py:771
+#: core/models.py:790
 msgid "Delete rooms"
 msgstr "Räume löschen"
 
-#: core/models.py:784
+#: core/models.py:803
 msgid "Application name"
 msgstr "Anwendungsname"
 
-#: core/models.py:785
+#: core/models.py:804
 msgid "Descriptive name for this application."
 msgstr "Beschreibender Name für diese Anwendung."
 
-#: core/models.py:795
+#: core/models.py:814
 msgid "Hashed on Save. Copy it now if this is a new secret."
 msgstr ""
 "Beim Speichern gehasht. Jetzt kopieren, wenn dies ein neues Geheimnis ist."
 
-#: core/models.py:806
+#: core/models.py:825
 msgid "Application"
 msgstr "Anwendung"
 
-#: core/models.py:807
+#: core/models.py:826
 msgid "Applications"
 msgstr "Anwendungen"
 
-#: core/models.py:830
+#: core/models.py:849
 msgid "Enter a valid domain"
 msgstr "Geben Sie eine gültige Domain ein"
 
-#: core/models.py:833
+#: core/models.py:852
 msgid "Domain"
 msgstr "Domain"
 
-#: core/models.py:834
+#: core/models.py:853
 msgid "Email domain this application can act on behalf of."
 msgstr "E-Mail-Domain, im Namen der diese Anwendung handeln kann."
 
-#: core/models.py:846
+#: core/models.py:865
 msgid "Application domain"
 msgstr "Anwendungsdomain"
 
-#: core/models.py:847
+#: core/models.py:866
 msgid "Application domains"
 msgstr "Anwendungsdomains"
 
-#: core/models.py:865
+#: core/models.py:884
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: core/models.py:866
+#: core/models.py:885
 msgid "Analyzing"
 msgstr ""
 
-#: core/models.py:873
+#: core/models.py:892
 msgid "Ready"
 msgstr "Bereit"
 
-#: core/models.py:879
+#: core/models.py:898
 msgid "Background image"
 msgstr "Hintergrundbild"
 
-#: core/models.py:891
+#: core/models.py:910
 msgid "title"
 msgstr "Titel"
 
-#: core/models.py:915
+#: core/models.py:934
 msgid "Malware detection info when the analysis status is unsafe."
 msgstr ""
 "Informationen zur Malware-Erkennung, wenn der Analyse-Status unsicher ist."
 
-#: core/models.py:920
+#: core/models.py:939
 msgid "File"
 msgstr "Datei"
 
-#: core/models.py:921
+#: core/models.py:940
 msgid "Files"
 msgstr "Dateien"
 
-#: core/models.py:1041
+#: core/models.py:1060
 msgid "This file is already hard deleted."
 msgstr "Diese Datei wurde bereits endgültig gelöscht."
 
-#: core/models.py:1051
+#: core/models.py:1070
 #, fuzzy
 #| msgid "To hard delete a file, it must first be soft deleted."
 msgid "To hard delete a file, it must first be soft deleted."
@@ -518,15 +534,15 @@ msgstr ""
 "Um eine Datei endgültig zu löschen, muss sie zuvor weich gelöscht worden "
 "sein."
 
-#: core/recording/event/notification.py:123
+#: core/recording/event/notification.py:124
 msgid "Your recording is ready"
 msgstr "Ihre Aufzeichnung ist bereit"
 
-#: core/recording/event/notification.py:194
+#: core/recording/event/notification.py:195
 msgid "Transcription"
 msgstr "Transkription"
 
-#: core/recording/event/notification.py:204
+#: core/recording/event/notification.py:206
 #, python-brace-format
 msgid "Meeting \"{room}\" on {room_recording_date} at {room_recording_time}"
 msgstr ""
@@ -537,25 +553,25 @@ msgstr ""
 msgid "Video call in progress: {sender.email} is waiting for you to connect"
 msgstr "Videoanruf läuft: {sender.email} wartet auf Ihre Teilnahme"
 
-#: core/templates/mail/html/invitation.html:159
-#: core/templates/mail/html/screen_recording.html:159
-#: core/templates/mail/text/invitation.txt:3
-#: core/templates/mail/text/screen_recording.txt:3
+#: core/templates/mail/html/invitation.html:151
+#: core/templates/mail/html/screen_recording.html:151
+#: core/templates/mail/text/invitation.txt:4
+#: core/templates/mail/text/screen_recording.txt:4
 msgid "Logo email"
 msgstr "Logo-E-Mail"
 
-#: core/templates/mail/html/invitation.html:189
-#: core/templates/mail/text/invitation.txt:5
+#: core/templates/mail/html/invitation.html:181
+#: core/templates/mail/text/invitation.txt:6
 msgid "invites you to join an ongoing video call"
 msgstr "lädt Sie zu einem laufenden Videoanruf ein"
 
-#: core/templates/mail/html/invitation.html:200
-#: core/templates/mail/text/invitation.txt:7
+#: core/templates/mail/html/invitation.html:192
+#: core/templates/mail/text/invitation.txt:8
 msgid "JOIN THE CALL"
 msgstr "AM ANRUF TEILNEHMEN"
 
-#: core/templates/mail/html/invitation.html:227
-#: core/templates/mail/text/invitation.txt:13
+#: core/templates/mail/html/invitation.html:219
+#: core/templates/mail/text/invitation.txt:14
 msgid ""
 "If you can't click the button, copy and paste the URL into your browser to "
 "join the call."
@@ -563,41 +579,47 @@ msgstr ""
 "Wenn Sie den Button nicht anklicken können, kopieren Sie die URL und fügen "
 "Sie sie in Ihren Browser ein, um am Anruf teilzunehmen."
 
-#: core/templates/mail/html/invitation.html:235
-#: core/templates/mail/text/invitation.txt:15
+#: core/templates/mail/html/invitation.html:227
+#: core/templates/mail/text/invitation.txt:16
 msgid "Tips for a better experience:"
 msgstr "Tipps für ein besseres Erlebnis:"
 
-#: core/templates/mail/html/invitation.html:237
-#: core/templates/mail/text/invitation.txt:17
+#: core/templates/mail/html/invitation.html:229
+#: core/templates/mail/text/invitation.txt:18
 msgid "Use Chrome or Firefox for better call quality"
 msgstr "Verwenden Sie Chrome oder Firefox für eine bessere Anrufqualität"
 
-#: core/templates/mail/html/invitation.html:238
-#: core/templates/mail/text/invitation.txt:18
+#: core/templates/mail/html/invitation.html:230
+#: core/templates/mail/text/invitation.txt:19
 msgid "Test your microphone and camera before joining"
 msgstr "Testen Sie Ihr Mikrofon und Ihre Kamera vor dem Beitritt"
 
-#: core/templates/mail/html/invitation.html:239
-#: core/templates/mail/text/invitation.txt:19
+#: core/templates/mail/html/invitation.html:231
+#: core/templates/mail/text/invitation.txt:20
 msgid "Make sure you have a stable internet connection"
 msgstr "Stellen Sie sicher, dass Sie eine stabile Internetverbindung haben"
 
-#: core/templates/mail/html/invitation.html:248
-#: core/templates/mail/html/screen_recording.html:245
-#: core/templates/mail/text/invitation.txt:21
-#: core/templates/mail/text/screen_recording.txt:23
+#: core/templates/mail/html/invitation.html:240
+#: core/templates/mail/html/screen_recording.html:237
+#: core/templates/mail/text/invitation.txt:22
+#: core/templates/mail/text/screen_recording.txt:24
 #, python-format
 msgid " Thank you for using %(brandname)s. "
 msgstr " Vielen Dank für die Nutzung von %(brandname)s. "
 
-#: core/templates/mail/html/screen_recording.html:188
-#: core/templates/mail/text/screen_recording.txt:6
+#: core/templates/mail/html/invitation.html:271
+#, python-format
+msgid ""
+"This mail has been sent to %(email)s by <a href=\"%(href)s\">%(name)s</a>"
+msgstr ""
+
+#: core/templates/mail/html/screen_recording.html:180
+#: core/templates/mail/text/screen_recording.txt:7
 msgid "Your recording is ready!"
 msgstr "Ihre Aufzeichnung ist fertig!"
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid ""
 " Your recording of \"%(room_name)s\" on %(recording_date)s at "
@@ -606,14 +628,14 @@ msgstr ""
 " Ihre Aufzeichnung von \"%(room_name)s\" am %(recording_date)s um "
 "%(recording_time)s steht nun zum Herunterladen bereit. "
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid " The recording will expire in %(days)s days. "
 msgstr " Die Aufzeichnung wird in %(days)s Tagen ablaufen. "
 
-#: core/templates/mail/html/screen_recording.html:200
-#: core/templates/mail/text/screen_recording.txt:9
+#: core/templates/mail/html/screen_recording.html:192
+#: core/templates/mail/text/screen_recording.txt:10
 msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
@@ -621,33 +643,33 @@ msgstr ""
 " Die Freigabe der Aufzeichnung per Link ist noch nicht verfügbar. Nur "
 "Organisatoren können sie herunterladen. "
 
-#: core/templates/mail/html/screen_recording.html:206
-#: core/templates/mail/text/screen_recording.txt:11
+#: core/templates/mail/html/screen_recording.html:198
+#: core/templates/mail/text/screen_recording.txt:12
 msgid "To keep this recording permanently:"
 msgstr "So speichern Sie diese Aufzeichnung dauerhaft:"
 
-#: core/templates/mail/html/screen_recording.html:208
+#: core/templates/mail/html/screen_recording.html:200
 #, python-format
 msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 msgstr "Klicken Sie auf den Link „<a href=\"%(link)s\">Öffnen</a>\" unten "
 
-#: core/templates/mail/html/screen_recording.html:209
-#: core/templates/mail/text/screen_recording.txt:14
+#: core/templates/mail/html/screen_recording.html:201
+#: core/templates/mail/text/screen_recording.txt:15
 msgid "Use the \"Download\" button in the interface "
 msgstr "Verwenden Sie den Button „Herunterladen“ in der Oberfläche "
 
-#: core/templates/mail/html/screen_recording.html:210
-#: core/templates/mail/text/screen_recording.txt:15
+#: core/templates/mail/html/screen_recording.html:202
+#: core/templates/mail/text/screen_recording.txt:16
 msgid "Save the file to your preferred location"
 msgstr "Speichern Sie die Datei an einem gewünschten Ort"
 
-#: core/templates/mail/html/screen_recording.html:221
-#: core/templates/mail/text/screen_recording.txt:17
+#: core/templates/mail/html/screen_recording.html:213
+#: core/templates/mail/text/screen_recording.txt:18
 msgid "Open"
 msgstr "Öffnen"
 
-#: core/templates/mail/html/screen_recording.html:230
-#: core/templates/mail/text/screen_recording.txt:19
+#: core/templates/mail/html/screen_recording.html:222
+#: core/templates/mail/text/screen_recording.txt:20
 #, python-format
 msgid ""
 " If you have any questions or need assistance, please contact our support "
@@ -656,28 +678,33 @@ msgstr ""
 " Wenn Sie Fragen haben oder Unterstützung benötigen, wenden Sie sich bitte "
 "an unser Support-Team unter %(support_email)s. "
 
-#: core/templates/mail/text/screen_recording.txt:13
+#: core/templates/mail/text/invitation.txt:24
+#, python-format
+msgid "This mail has been sent to %(email)s by %(name)s [%(href)s]"
+msgstr ""
+
+#: core/templates/mail/text/screen_recording.txt:14
 #, fuzzy, python-format
 #| msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 msgid "Click the \"Open [%(link)s]\" link below "
 msgstr "Klicken Sie auf den Link „<a href=\"%(link)s\">Öffnen</a>\" unten "
 
-#: meet/settings.py:228
+#: meet/settings.py:238
 msgid "English"
 msgstr "Englisch"
 
-#: meet/settings.py:229
+#: meet/settings.py:239
 msgid "French"
 msgstr "Französisch"
 
-#: meet/settings.py:230
+#: meet/settings.py:240
 msgid "Dutch"
 msgstr "Niederländisch"
 
-#: meet/settings.py:231
+#: meet/settings.py:241
 msgid "German"
 msgstr "Deutsch"
 
-#: meet/settings.py:233
+#: meet/settings.py:242
 msgid "Spanish"
 msgstr "Spanisch"

--- a/src/backend/locale/en_US/LC_MESSAGES/django.po
+++ b/src/backend/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-02 10:47+0000\n"
+"POT-Creation-Date: 2026-09-02 22:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,11 +51,11 @@ msgstr ""
 msgid "File preview"
 msgstr ""
 
-#: core/admin.py:300 core/admin.py:443
+#: core/admin.py:300 core/admin.py:450
 msgid "No owner"
 msgstr "No owner"
 
-#: core/admin.py:303 core/admin.py:446
+#: core/admin.py:303 core/admin.py:453
 msgid "Multiple owners"
 msgstr "Multiple owners"
 
@@ -98,11 +98,11 @@ msgstr "%(count)s recording(s) successfully marked as 'Failed to Stop'."
 msgid "Skipped %(count)s recording(s) with an ineligible status."
 msgstr "Skipped %(count)s expired recording(s)."
 
-#: core/admin.py:510
+#: core/admin.py:517
 msgid "No scopes"
 msgstr "No scopes"
 
-#: core/admin.py:512
+#: core/admin.py:519
 msgid "Scopes"
 msgstr "Scopes"
 
@@ -110,183 +110,199 @@ msgstr "Scopes"
 msgid "Creator is me"
 msgstr "Creator is me"
 
-#: core/api/serializers.py:89
+#: core/api/serializers.py:108
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr "You must be administrator or owner of a room to add accesses to it."
 
-#: core/api/serializers.py:534
+#: core/api/serializers.py:560
 msgid "This file extension is not allowed."
 msgstr "This file extension is not allowed."
 
-#: core/api/viewsets.py:1222
+#: core/api/viewsets.py:1268
 msgid "You have reached the maximum number of files for this type."
 msgstr "You have reached the maximum number of files for this type."
 
-#: core/models.py:37
+#: core/models.py:38
 msgid "Member"
 msgstr "Member"
 
-#: core/models.py:38
+#: core/models.py:39
 msgid "Administrator"
 msgstr "Administrator"
 
-#: core/models.py:39
+#: core/models.py:40
 msgid "Owner"
 msgstr "Owner"
 
-#: core/models.py:55
+#: core/models.py:56
 msgid "Initiated"
 msgstr "Initiated"
 
-#: core/models.py:56
+#: core/models.py:57
 msgid "Active"
 msgstr "Active"
 
-#: core/models.py:57
+#: core/models.py:58
 msgid "Stopped"
 msgstr "Stopped"
 
-#: core/models.py:58
+#: core/models.py:59
 msgid "Saved"
 msgstr "Saved"
 
-#: core/models.py:59
+#: core/models.py:60
 msgid "Aborted"
 msgstr "Aborted"
 
-#: core/models.py:60
+#: core/models.py:61
 msgid "Failed to Start"
 msgstr "Failed to Start"
 
-#: core/models.py:61
+#: core/models.py:62
 msgid "Failed to Stop"
 msgstr "Failed to Stop"
 
-#: core/models.py:62
+#: core/models.py:63
 msgid "Notification succeeded"
 msgstr "Notification succeeded"
 
-#: core/models.py:65
+#: core/models.py:66
 msgid "External process successful"
 msgstr "External process successful"
 
-#: core/models.py:67
+#: core/models.py:68
 msgid "External process failed"
 msgstr "External process failed"
 
-#: core/models.py:96
+#: core/models.py:97
 msgid "SCREEN_RECORDING"
 msgstr "SCREEN_RECORDING"
 
-#: core/models.py:97
+#: core/models.py:98
 msgid "TRANSCRIPT"
 msgstr "TRANSCRIPT"
 
-#: core/models.py:103
+#: core/models.py:104
 msgid "Public Access"
 msgstr "Public Access"
 
-#: core/models.py:104
+#: core/models.py:105
 msgid "Trusted Access"
 msgstr "Trusted Access"
 
-#: core/models.py:105
+#: core/models.py:106
 msgid "Restricted Access"
 msgstr "Restricted Access"
 
-#: core/models.py:117
+#: core/models.py:118
 msgid "id"
 msgstr "id"
 
-#: core/models.py:118
+#: core/models.py:119
 msgid "primary key for the record as UUID"
 msgstr "primary key for the record as UUID"
 
-#: core/models.py:124
+#: core/models.py:125
 msgid "created on"
 msgstr "created on"
 
-#: core/models.py:125
+#: core/models.py:126
 msgid "date and time at which a record was created"
 msgstr "date and time at which a record was created"
 
-#: core/models.py:130
+#: core/models.py:131
 msgid "updated on"
 msgstr "updated on"
 
-#: core/models.py:131
+#: core/models.py:132
 msgid "date and time at which a record was last updated"
 msgstr "date and time at which a record was last updated"
 
-#: core/models.py:151
-msgid ""
-"Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
-"_ characters."
-msgstr ""
-"Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
-"_ characters."
-
-#: core/models.py:157
+#: core/models.py:150
 msgid "sub"
 msgstr "sub"
 
-#: core/models.py:159
+#: core/models.py:152
 msgid ""
 "Optional for pending users; required upon account activation. 255 characters "
-"or fewer. Letters, numbers, and @/./+/-/_ characters only."
+"or fewer. Printable ASCII characters only."
 msgstr ""
-"Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_ "
-"characters only."
+"Optional for pending users; required upon account activation. 255 characters "
+"or fewer. Printable ASCII characters only."
 
-#: core/models.py:168
+#: core/validators.py:22
+msgid "Enter a valid sub. This value should be printable ASCII only."
+msgstr "Enter a valid sub. This value should be printable ASCII only."
+
+#: core/models.py:161
 msgid "identity email address"
 msgstr "identity email address"
 
-#: core/models.py:173
+#: core/models.py:166
 msgid "admin email address"
 msgstr "admin email address"
 
-#: core/models.py:175
+#: core/models.py:168
 msgid "full name"
 msgstr "full name"
 
-#: core/models.py:177
+#: core/models.py:170
 msgid "short name"
 msgstr "short name"
 
-#: core/models.py:183
+#: core/models.py:176
 msgid "language"
 msgstr "language"
 
-#: core/models.py:184
+#: core/models.py:177
 msgid "The language in which the user wants to see the interface."
 msgstr "The language in which the user wants to see the interface."
 
-#: core/models.py:190
+#: core/models.py:183
 msgid "The timezone in which the user wants to see times."
 msgstr "The timezone in which the user wants to see times."
 
-#: core/models.py:193
+#: core/models.py:190
+msgid "default room access level"
+msgstr ""
+
+#: core/models.py:192
+msgid ""
+"Access level applied by default to new rooms created by this user. When "
+"empty, the instance default is used."
+msgstr ""
+
+#: core/models.py:199
+#, fuzzy
+#| msgid "Visio room configuration"
+msgid "default room configuration"
+msgstr "Visio room configuration"
+
+#: core/models.py:201
+msgid "Configurations applied by default to new rooms created by this user."
+msgstr ""
+
+#: core/models.py:205
 msgid "device"
 msgstr "device"
 
-#: core/models.py:195
+#: core/models.py:207
 msgid "Whether the user is a device or a real user."
 msgstr "Whether the user is a device or a real user."
 
-#: core/models.py:198
+#: core/models.py:210
 msgid "staff status"
 msgstr "staff status"
 
-#: core/models.py:200
+#: core/models.py:212
 msgid "Whether the user can log into this admin site."
 msgstr "Whether the user can log into this admin site."
 
-#: core/models.py:203
+#: core/models.py:215
 msgid "active"
 msgstr "active"
 
-#: core/models.py:206
+#: core/models.py:218
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
@@ -294,63 +310,63 @@ msgstr ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
 
-#: core/models.py:219
+#: core/models.py:231
 msgid "user"
 msgstr "user"
 
-#: core/models.py:220
+#: core/models.py:232
 msgid "users"
 msgstr "users"
 
-#: core/models.py:286
+#: core/models.py:298
 msgid "Resource"
 msgstr "Resource"
 
-#: core/models.py:287
+#: core/models.py:299
 msgid "Resources"
 msgstr "Resources"
 
-#: core/models.py:345
+#: core/models.py:357
 msgid "Resource access"
 msgstr "Resource access"
 
-#: core/models.py:346
+#: core/models.py:358
 msgid "Resource accesses"
 msgstr "Resource accesses"
 
-#: core/models.py:352
+#: core/models.py:364
 msgid "Resource access with this User and Resource already exists."
 msgstr "Resource access with this User and Resource already exists."
 
-#: core/models.py:409
+#: core/models.py:421
 msgid "Visio room configuration"
 msgstr "Visio room configuration"
 
-#: core/models.py:410
+#: core/models.py:422
 msgid "Values for Visio parameters to configure the room."
 msgstr "Values for Visio parameters to configure the room."
 
-#: core/models.py:417
+#: core/models.py:429
 msgid "Room PIN code"
 msgstr "Room PIN code"
 
-#: core/models.py:418
+#: core/models.py:430
 msgid "Unique n-digit code that identifies this room in telephony mode."
 msgstr "Unique n-digit code that identifies this room in telephony mode."
 
-#: core/models.py:424 core/models.py:578
+#: core/models.py:436 core/models.py:597
 msgid "Room"
 msgstr "Room"
 
-#: core/models.py:425
+#: core/models.py:437
 msgid "Rooms"
 msgstr "Rooms"
 
-#: core/models.py:589
+#: core/models.py:608
 msgid "Worker ID"
 msgstr "Worker ID"
 
-#: core/models.py:591
+#: core/models.py:610
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
@@ -358,171 +374,171 @@ msgstr ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
 
-#: core/models.py:599
+#: core/models.py:618
 msgid "Recording mode"
 msgstr "Recording mode"
 
-#: core/models.py:600
+#: core/models.py:619
 msgid "Defines the mode of recording being called."
 msgstr "Defines the mode of recording being called."
 
-#: core/models.py:605 core/models.py:606
+#: core/models.py:624 core/models.py:625
 msgid "Recording options"
 msgstr "Recording options"
 
-#: core/models.py:613
+#: core/models.py:632
 msgid "External Process ID"
 msgstr "External Process ID"
 
-#: core/models.py:614
+#: core/models.py:633
 msgid "ID of the external process associated with the recording."
 msgstr "ID of the external process associated with the recording."
 
-#: core/models.py:620
+#: core/models.py:639
 msgid "Recording"
 msgstr "Recording"
 
-#: core/models.py:621
+#: core/models.py:640
 msgid "Recordings"
 msgstr "Recordings"
 
-#: core/models.py:731
+#: core/models.py:750
 msgid "Recording/user relation"
 msgstr "Recording/user relation"
 
-#: core/models.py:732
+#: core/models.py:751
 msgid "Recording/user relations"
 msgstr "Recording/user relations"
 
-#: core/models.py:738
+#: core/models.py:757
 msgid "This user is already in this recording."
 msgstr "This user is already in this recording."
 
-#: core/models.py:744
+#: core/models.py:763
 msgid "This team is already in this recording."
 msgstr "This team is already in this recording."
 
-#: core/models.py:750
+#: core/models.py:769
 msgid "Either user or team must be set, not both."
 msgstr "Either user or team must be set, not both."
 
-#: core/models.py:767
+#: core/models.py:786
 #, fuzzy
 #| msgid "created on"
 msgid "Create rooms"
 msgstr "Create rooms"
 
-#: core/models.py:768
+#: core/models.py:787
 msgid "List rooms"
 msgstr "List rooms"
 
-#: core/models.py:769
+#: core/models.py:788
 msgid "Retrieve room details"
 msgstr "Retrieve room details"
 
-#: core/models.py:770
+#: core/models.py:789
 #, fuzzy
 #| msgid "updated on"
 msgid "Update rooms"
 msgstr "Update rooms"
 
-#: core/models.py:771
+#: core/models.py:790
 msgid "Delete rooms"
 msgstr "Delete rooms"
 
-#: core/models.py:784
+#: core/models.py:803
 msgid "Application name"
 msgstr "Application name"
 
-#: core/models.py:785
+#: core/models.py:804
 msgid "Descriptive name for this application."
 msgstr "Descriptive name for this application."
 
-#: core/models.py:795
+#: core/models.py:814
 msgid "Hashed on Save. Copy it now if this is a new secret."
 msgstr "Hashed on Save. Copy it now if this is a new secret."
 
-#: core/models.py:806
+#: core/models.py:825
 msgid "Application"
 msgstr "Application"
 
-#: core/models.py:807
+#: core/models.py:826
 msgid "Applications"
 msgstr "Applications"
 
-#: core/models.py:830
+#: core/models.py:849
 msgid "Enter a valid domain"
 msgstr "Enter a valid domain"
 
-#: core/models.py:833
+#: core/models.py:852
 msgid "Domain"
 msgstr "Domain"
 
-#: core/models.py:834
+#: core/models.py:853
 msgid "Email domain this application can act on behalf of."
 msgstr "Email domain this application can act on behalf of."
 
-#: core/models.py:846
+#: core/models.py:865
 msgid "Application domain"
 msgstr "Application domain"
 
-#: core/models.py:847
+#: core/models.py:866
 msgid "Application domains"
 msgstr "Application domains"
 
-#: core/models.py:865
+#: core/models.py:884
 #, fuzzy
 #| msgid "Recording"
 msgid "Pending"
 msgstr "Pending"
 
-#: core/models.py:866
+#: core/models.py:885
 msgid "Analyzing"
 msgstr ""
 
-#: core/models.py:873
+#: core/models.py:892
 msgid "Ready"
 msgstr "Ready"
 
-#: core/models.py:879
+#: core/models.py:898
 msgid "Background image"
 msgstr "Background image"
 
-#: core/models.py:891
+#: core/models.py:910
 msgid "title"
 msgstr "title"
 
-#: core/models.py:915
+#: core/models.py:934
 msgid "Malware detection info when the analysis status is unsafe."
 msgstr "Malware detection info when the analysis status is unsafe."
 
-#: core/models.py:920
+#: core/models.py:939
 msgid "File"
 msgstr "File"
 
-#: core/models.py:921
+#: core/models.py:940
 msgid "Files"
 msgstr "Files"
 
-#: core/models.py:1041
+#: core/models.py:1060
 #, fuzzy
 #| msgid "This user is already in this recording."
 msgid "This file is already hard deleted."
 msgstr "This file is already hard deleted."
 
-#: core/models.py:1051
+#: core/models.py:1070
 msgid "To hard delete a file, it must first be soft deleted."
 msgstr "To hard delete a file, it must first be soft deleted."
 
-#: core/recording/event/notification.py:123
+#: core/recording/event/notification.py:124
 msgid "Your recording is ready"
 msgstr "Your recording is ready"
 
-#: core/recording/event/notification.py:194
+#: core/recording/event/notification.py:195
 msgid "Transcription"
 msgstr "Transcription"
 
-#: core/recording/event/notification.py:204
+#: core/recording/event/notification.py:206
 #, python-brace-format
 msgid "Meeting \"{room}\" on {room_recording_date} at {room_recording_time}"
 msgstr "Meeting \"{room}\" on {room_recording_date} at {room_recording_time}"
@@ -532,25 +548,25 @@ msgstr "Meeting \"{room}\" on {room_recording_date} at {room_recording_time}"
 msgid "Video call in progress: {sender.email} is waiting for you to connect"
 msgstr "Video call in progress: {sender.email} is waiting for you to connect"
 
-#: core/templates/mail/html/invitation.html:159
-#: core/templates/mail/html/screen_recording.html:159
-#: core/templates/mail/text/invitation.txt:3
-#: core/templates/mail/text/screen_recording.txt:3
+#: core/templates/mail/html/invitation.html:151
+#: core/templates/mail/html/screen_recording.html:151
+#: core/templates/mail/text/invitation.txt:4
+#: core/templates/mail/text/screen_recording.txt:4
 msgid "Logo email"
 msgstr "Logo email"
 
-#: core/templates/mail/html/invitation.html:189
-#: core/templates/mail/text/invitation.txt:5
+#: core/templates/mail/html/invitation.html:181
+#: core/templates/mail/text/invitation.txt:6
 msgid "invites you to join an ongoing video call"
 msgstr "invites you to join an ongoing video call"
 
-#: core/templates/mail/html/invitation.html:200
-#: core/templates/mail/text/invitation.txt:7
+#: core/templates/mail/html/invitation.html:192
+#: core/templates/mail/text/invitation.txt:8
 msgid "JOIN THE CALL"
 msgstr "JOIN THE CALL"
 
-#: core/templates/mail/html/invitation.html:227
-#: core/templates/mail/text/invitation.txt:13
+#: core/templates/mail/html/invitation.html:219
+#: core/templates/mail/text/invitation.txt:14
 msgid ""
 "If you can't click the button, copy and paste the URL into your browser to "
 "join the call."
@@ -558,41 +574,47 @@ msgstr ""
 "If you can't click the button, copy and paste the URL into your browser to "
 "join the call."
 
-#: core/templates/mail/html/invitation.html:235
-#: core/templates/mail/text/invitation.txt:15
+#: core/templates/mail/html/invitation.html:227
+#: core/templates/mail/text/invitation.txt:16
 msgid "Tips for a better experience:"
 msgstr "Tips for a better experience:"
 
-#: core/templates/mail/html/invitation.html:237
-#: core/templates/mail/text/invitation.txt:17
+#: core/templates/mail/html/invitation.html:229
+#: core/templates/mail/text/invitation.txt:18
 msgid "Use Chrome or Firefox for better call quality"
 msgstr "Use Chrome or Firefox for better call quality"
 
-#: core/templates/mail/html/invitation.html:238
-#: core/templates/mail/text/invitation.txt:18
+#: core/templates/mail/html/invitation.html:230
+#: core/templates/mail/text/invitation.txt:19
 msgid "Test your microphone and camera before joining"
 msgstr "Test your microphone and camera before joining"
 
-#: core/templates/mail/html/invitation.html:239
-#: core/templates/mail/text/invitation.txt:19
+#: core/templates/mail/html/invitation.html:231
+#: core/templates/mail/text/invitation.txt:20
 msgid "Make sure you have a stable internet connection"
 msgstr "Make sure you have a stable internet connection"
 
-#: core/templates/mail/html/invitation.html:248
-#: core/templates/mail/html/screen_recording.html:245
-#: core/templates/mail/text/invitation.txt:21
-#: core/templates/mail/text/screen_recording.txt:23
+#: core/templates/mail/html/invitation.html:240
+#: core/templates/mail/html/screen_recording.html:237
+#: core/templates/mail/text/invitation.txt:22
+#: core/templates/mail/text/screen_recording.txt:24
 #, python-format
 msgid " Thank you for using %(brandname)s. "
 msgstr " Thank you for using %(brandname)s. "
 
-#: core/templates/mail/html/screen_recording.html:188
-#: core/templates/mail/text/screen_recording.txt:6
+#: core/templates/mail/html/invitation.html:271
+#, python-format
+msgid ""
+"This mail has been sent to %(email)s by <a href=\"%(href)s\">%(name)s</a>"
+msgstr ""
+
+#: core/templates/mail/html/screen_recording.html:180
+#: core/templates/mail/text/screen_recording.txt:7
 msgid "Your recording is ready!"
 msgstr "Your recording is ready!"
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid ""
 " Your recording of \"%(room_name)s\" on %(recording_date)s at "
@@ -601,14 +623,14 @@ msgstr ""
 " Your recording of \"%(room_name)s\" on %(recording_date)s at "
 "%(recording_time)s is now ready to download. "
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid " The recording will expire in %(days)s days. "
 msgstr " The recording will expire in %(days)s days. "
 
-#: core/templates/mail/html/screen_recording.html:200
-#: core/templates/mail/text/screen_recording.txt:9
+#: core/templates/mail/html/screen_recording.html:192
+#: core/templates/mail/text/screen_recording.txt:10
 msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
@@ -616,33 +638,33 @@ msgstr ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
 
-#: core/templates/mail/html/screen_recording.html:206
-#: core/templates/mail/text/screen_recording.txt:11
+#: core/templates/mail/html/screen_recording.html:198
+#: core/templates/mail/text/screen_recording.txt:12
 msgid "To keep this recording permanently:"
 msgstr "To keep this recording permanently:"
 
-#: core/templates/mail/html/screen_recording.html:208
+#: core/templates/mail/html/screen_recording.html:200
 #, python-format
 msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 msgstr "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 
-#: core/templates/mail/html/screen_recording.html:209
-#: core/templates/mail/text/screen_recording.txt:14
+#: core/templates/mail/html/screen_recording.html:201
+#: core/templates/mail/text/screen_recording.txt:15
 msgid "Use the \"Download\" button in the interface "
 msgstr "Use the \"Download\" button in the interface "
 
-#: core/templates/mail/html/screen_recording.html:210
-#: core/templates/mail/text/screen_recording.txt:15
+#: core/templates/mail/html/screen_recording.html:202
+#: core/templates/mail/text/screen_recording.txt:16
 msgid "Save the file to your preferred location"
 msgstr "Save the file to your preferred location"
 
-#: core/templates/mail/html/screen_recording.html:221
-#: core/templates/mail/text/screen_recording.txt:17
+#: core/templates/mail/html/screen_recording.html:213
+#: core/templates/mail/text/screen_recording.txt:18
 msgid "Open"
 msgstr "Open"
 
-#: core/templates/mail/html/screen_recording.html:230
-#: core/templates/mail/text/screen_recording.txt:19
+#: core/templates/mail/html/screen_recording.html:222
+#: core/templates/mail/text/screen_recording.txt:20
 #, python-format
 msgid ""
 " If you have any questions or need assistance, please contact our support "
@@ -651,28 +673,33 @@ msgstr ""
 " If you have any questions or need assistance, please contact our support "
 "team at %(support_email)s. "
 
-#: core/templates/mail/text/screen_recording.txt:13
+#: core/templates/mail/text/invitation.txt:24
+#, python-format
+msgid "This mail has been sent to %(email)s by %(name)s [%(href)s]"
+msgstr ""
+
+#: core/templates/mail/text/screen_recording.txt:14
 #, fuzzy, python-format
 #| msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 msgid "Click the \"Open [%(link)s]\" link below "
 msgstr "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 
-#: meet/settings.py:228
+#: meet/settings.py:238
 msgid "English"
 msgstr "English"
 
-#: meet/settings.py:229
+#: meet/settings.py:239
 msgid "French"
 msgstr "French"
 
-#: meet/settings.py:230
+#: meet/settings.py:240
 msgid "Dutch"
 msgstr "Dutch"
 
-#: meet/settings.py:231
+#: meet/settings.py:241
 msgid "German"
 msgstr "German"
 
-#: meet/settings.py:233
+#: meet/settings.py:242
 msgid "Spanish"
 msgstr "Spanish"

--- a/src/backend/locale/es_ES/LC_MESSAGES/django.po
+++ b/src/backend/locale/es_ES/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-02 10:47+0000\n"
+"POT-Creation-Date: 2026-09-02 22:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,20 +41,20 @@ msgstr "Eliminar Salas"
 msgid "Derived info"
 msgstr ""
 
-#: core/admin.py:237
 # 'Marcas de tiempo' is a bad translation for spanish
+#: core/admin.py:237
 msgid "Timestamps"
-msgstr "" 
+msgstr ""
 
 #: core/admin.py:240
 msgid "File preview"
 msgstr "Vista previa"
 
-#: core/admin.py:300 core/admin.py:443
+#: core/admin.py:300 core/admin.py:450
 msgid "No owner"
 msgstr "Sin propietario"
 
-#: core/admin.py:303 core/admin.py:446
+#: core/admin.py:303 core/admin.py:453
 msgid "Multiple owners"
 msgstr "Varios propietarios"
 
@@ -89,18 +89,19 @@ msgstr "Marcar las grabaciones seleccionadas como «Error al detener»"
 #: core/admin.py:386
 #, python-format
 msgid "%(count)s recording(s) successfully marked as 'Failed to Stop'."
-msgstr "%(count)s grabación(es) marcada(s) correctamente como «Error al detener»."
+msgstr ""
+"%(count)s grabación(es) marcada(s) correctamente como «Error al detener»."
 
 #: core/admin.py:394
 #, python-format
 msgid "Skipped %(count)s recording(s) with an ineligible status."
 msgstr "Se han omitido %(count)s grabación(es) con un estado no elegible."
 
-#: core/admin.py:510
+#: core/admin.py:517
 msgid "No scopes"
 msgstr ""
 
-#: core/admin.py:512
+#: core/admin.py:519
 msgid "Scopes"
 msgstr "Ámbitos"
 
@@ -108,545 +109,599 @@ msgstr "Ámbitos"
 msgid "Creator is me"
 msgstr "Yo soy el creador"
 
-#: core/api/serializers.py:89
+#: core/api/serializers.py:108
 msgid "You must be administrator or owner of a room to add accesses to it."
-msgstr "Debes ser administrador o propietario de una reunión para añadirle accesos."
+msgstr ""
+"Debes ser administrador o propietario de una reunión para añadirle accesos."
 
-#: core/api/serializers.py:534
+#: core/api/serializers.py:560
 msgid "This file extension is not allowed."
 msgstr "Esta extensión de archivo no está permitida."
 
-#: core/api/viewsets.py:1222
+#: core/api/viewsets.py:1268
 msgid "You have reached the maximum number of files for this type."
 msgstr "Has alcanzado el número máximo de archivos de este tipo."
 
-#: core/models.py:37
+#: core/models.py:38
 msgid "Member"
 msgstr "Miembro"
 
-#: core/models.py:38
+#: core/models.py:39
 msgid "Administrator"
 msgstr "Administrador"
 
-#: core/models.py:39
+#: core/models.py:40
 msgid "Owner"
 msgstr "Propietario"
 
-#: core/models.py:55
 # To check here and following lines for gender agreement (Masculine/Feminine)
+#: core/models.py:56
 msgid "Initiated"
 msgstr "Iniciada"
 
-#: core/models.py:56
+#: core/models.py:57
 msgid "Active"
 msgstr "Activa"
 
-#: core/models.py:57
+#: core/models.py:58
 msgid "Stopped"
 msgstr "Detenida"
 
-#: core/models.py:58
+#: core/models.py:59
 msgid "Saved"
 msgstr "Guardada"
 
-#: core/models.py:59
+#: core/models.py:60
 msgid "Aborted"
 msgstr "Cancelada"
 
-#: core/models.py:60
+#: core/models.py:61
 msgid "Failed to Start"
 msgstr "Error al iniciar"
 
-#: core/models.py:61
+#: core/models.py:62
 msgid "Failed to Stop"
 msgstr "Error al detener"
 
-#: core/models.py:62
+#: core/models.py:63
 msgid "Notification succeeded"
 msgstr "Notificado correctamente"
 
-#: core/models.py:65
+#: core/models.py:66
 msgid "External process successful"
 msgstr "Proceso externo finalizado correctamente"
 
-#: core/models.py:67
+#: core/models.py:68
 msgid "External process failed"
 msgstr "Error en el Proceso externo"
 
-#: core/models.py:96
+#: core/models.py:97
 msgid "SCREEN_RECORDING"
 msgstr "GRABACIÓN_DE_PANTALLA"
 
-#: core/models.py:97
+#: core/models.py:98
 msgid "TRANSCRIPT"
 msgstr "TRANSCRIPCIÓN"
 
-#: core/models.py:103
+#: core/models.py:104
 msgid "Public Access"
 msgstr "Acceso público"
 
-#: core/models.py:104
+#: core/models.py:105
 msgid "Trusted Access"
 msgstr "Acceso usuarios autorizados"
 
-#: core/models.py:105
+#: core/models.py:106
 msgid "Restricted Access"
 msgstr "Acceso restringido"
 
-#: core/models.py:117
+#: core/models.py:118
 msgid "id"
 msgstr "id"
 
-#: core/models.py:118
+#: core/models.py:119
 msgid "primary key for the record as UUID"
 msgstr "clave primaria del registro en forma de UUID"
 
-#: core/models.py:124
+#: core/models.py:125
 msgid "created on"
 msgstr "creado el"
 
-#: core/models.py:125
+#: core/models.py:126
 msgid "date and time at which a record was created"
 msgstr "fecha y hora en que se creó un registro"
 
-#: core/models.py:130
+#: core/models.py:131
 msgid "updated on"
 msgstr "actualizado el"
 
-#: core/models.py:131
+#: core/models.py:132
 msgid "date and time at which a record was last updated"
 msgstr "fecha y hora de la última actualización de un registro"
 
-#: core/models.py:151
-msgid ""
-"Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
-"_ characters."
-msgstr "Introduce un sub válido. Este valor solo puede contener letras, números y los caracteres @/./+/-/_."
-
-#: core/models.py:157
+#: core/models.py:150
 msgid "sub"
 msgstr "sub"
 
-#: core/models.py:159
+#: core/models.py:152
 msgid ""
 "Optional for pending users; required upon account activation. 255 characters "
-"or fewer. Letters, numbers, and @/./+/-/_ characters only."
-msgstr "Opcional para los usuarios pendientes; obligatorio al activar la cuenta. 255 caracteres como máximo. Solo letras, números y los caracteres @/./+/-/_."
+"or fewer. Printable ASCII characters only."
+msgstr ""
+"Opcional para los usuarios pendientes; obligatorio al activar la cuenta. "
+"255 caracteres como máximo. Solo caracteres ASCII imprimibles."
 
-#: core/models.py:168
+#: core/validators.py:22
+msgid "Enter a valid sub. This value should be printable ASCII only."
+msgstr "Introduzca un sub válido. Este valor solo debe contener caracteres ASCII imprimibles."
+
+#: core/models.py:161
 msgid "identity email address"
 msgstr "dirección de correo electrónico"
 
-#: core/models.py:173
+#: core/models.py:166
 msgid "admin email address"
 msgstr "dirección de correo electrónico de administrador"
 
-#: core/models.py:175
+#: core/models.py:168
 msgid "full name"
 msgstr "nombre completo"
 
-#: core/models.py:177
+#: core/models.py:170
 msgid "short name"
 msgstr "nombre corto"
 
-#: core/models.py:183
+#: core/models.py:176
 msgid "language"
 msgstr "idioma"
 
-#: core/models.py:184
+#: core/models.py:177
 msgid "The language in which the user wants to see the interface."
 msgstr "El idioma preferido de interfaz."
 
-#: core/models.py:190
+#: core/models.py:183
 msgid "The timezone in which the user wants to see times."
 msgstr "La zona horaria en la que el usuario quiere ver las horas."
 
-#: core/models.py:193
+#: core/models.py:190
+msgid "default room access level"
+msgstr ""
+
+#: core/models.py:192
+msgid ""
+"Access level applied by default to new rooms created by this user. When "
+"empty, the instance default is used."
+msgstr ""
+
+#: core/models.py:199
+#, fuzzy
+#| msgid "Visio room configuration"
+msgid "default room configuration"
+msgstr "Configuración de la videoconferencia"
+
+#: core/models.py:201
+msgid "Configurations applied by default to new rooms created by this user."
+msgstr ""
+
+#: core/models.py:205
 msgid "device"
 msgstr "dispositivo"
 
-#: core/models.py:195
+#: core/models.py:207
 msgid "Whether the user is a device or a real user."
 msgstr "Si el usuario es un dispositivo o un usuario real."
 
-#: core/models.py:198
+#: core/models.py:210
 msgid "staff status"
 msgstr "estado del personal"
 
-#: core/models.py:200
+#: core/models.py:212
 msgid "Whether the user can log into this admin site."
 msgstr "Si el usuario puede acceder a este sitio de administración."
 
-#: core/models.py:203
+#: core/models.py:215
 msgid "active"
 msgstr "activo"
 
-#: core/models.py:206
+#: core/models.py:218
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
-msgstr "Si este usuario debe considerarse activo. Desmarca esta opción en lugar de eliminar cuentas."
+msgstr ""
+"Si este usuario debe considerarse activo. Desmarca esta opción en lugar de "
+"eliminar cuentas."
 
-#: core/models.py:219
+#: core/models.py:231
 msgid "user"
 msgstr "usuario"
 
-#: core/models.py:220
+#: core/models.py:232
 msgid "users"
 msgstr "usuarios"
 
-#: core/models.py:286
+#: core/models.py:298
 msgid "Resource"
 msgstr "Recurso"
 
-#: core/models.py:287
+#: core/models.py:299
 msgid "Resources"
 msgstr "Recursos"
 
-#: core/models.py:345
+#: core/models.py:357
 msgid "Resource access"
 msgstr "Acceso a recursos"
 
-#: core/models.py:346
+#: core/models.py:358
 msgid "Resource accesses"
 msgstr "Accesos a recursos"
 
-#: core/models.py:352
+#: core/models.py:364
 msgid "Resource access with this User and Resource already exists."
 msgstr "Ya existe un acceso al recurso con este usuario y este recurso."
 
-#: core/models.py:409
+#: core/models.py:421
 msgid "Visio room configuration"
 msgstr "Configuración de la videoconferencia"
 
-#: core/models.py:410
+#: core/models.py:422
 msgid "Values for Visio parameters to configure the room."
-msgstr "Valores de los parámetros de videoconferencia para configurar la reunión."
+msgstr ""
+"Valores de los parámetros de videoconferencia para configurar la reunión."
 
-#: core/models.py:417
+#: core/models.py:429
 msgid "Room PIN code"
 msgstr "Código PIN de la reunión"
 
-#: core/models.py:418
+#: core/models.py:430
 msgid "Unique n-digit code that identifies this room in telephony mode."
-msgstr "Código único de n dígitos que identifica esta reunión en modo telefónico."
+msgstr ""
+"Código único de n dígitos que identifica esta reunión en modo telefónico."
 
-#: core/models.py:424 core/models.py:578
+#: core/models.py:436 core/models.py:597
 msgid "Room"
 msgstr "Reunión"
 
-#: core/models.py:425
+#: core/models.py:437
 msgid "Rooms"
 msgstr "Reuniones"
 
-#: core/models.py:589
+#: core/models.py:608
 msgid "Worker ID"
 msgstr "ID del worker"
 
-#: core/models.py:591
+#: core/models.py:610
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
-msgstr "Introduce un identificador para la grabación del worker. Este identificador se conserva incluso cuando el worker se detiene, lo que permite un seguimiento sencillo."
+msgstr ""
+"Introduce un identificador para la grabación del worker. Este identificador "
+"se conserva incluso cuando el worker se detiene, lo que permite un "
+"seguimiento sencillo."
 
-#: core/models.py:599
+#: core/models.py:618
 msgid "Recording mode"
 msgstr "Modo de grabación"
 
-#: core/models.py:600
+#: core/models.py:619
 msgid "Defines the mode of recording being called."
 msgstr "Define el modo de grabación a utilizar."
 
-#: core/models.py:605 core/models.py:606
+#: core/models.py:624 core/models.py:625
 msgid "Recording options"
 msgstr "Opciones de grabación"
 
-#: core/models.py:613
+#: core/models.py:632
 msgid "External Process ID"
 msgstr "ID del proceso externo"
 
-#: core/models.py:614
+#: core/models.py:633
 msgid "ID of the external process associated with the recording."
 msgstr "ID del proceso externo asociado a la grabación."
 
-#: core/models.py:620
+#: core/models.py:639
 msgid "Recording"
 msgstr "Grabación"
 
-#: core/models.py:621
+#: core/models.py:640
 msgid "Recordings"
 msgstr "Grabaciones"
 
-#: core/models.py:731
+#: core/models.py:750
 msgid "Recording/user relation"
 msgstr "Relación grabación/usuario"
 
-#: core/models.py:732
+#: core/models.py:751
 msgid "Recording/user relations"
 msgstr "Relaciones grabación/usuario"
 
-#: core/models.py:738
+#: core/models.py:757
 msgid "This user is already in this recording."
 msgstr "Este usuario ya está en esta grabación."
 
-#: core/models.py:744
+#: core/models.py:763
 msgid "This team is already in this recording."
 msgstr "Este equipo ya está en esta grabación."
 
-#: core/models.py:750
+#: core/models.py:769
 msgid "Either user or team must be set, not both."
 msgstr "Debe definirse el usuario o el equipo, pero no ambos."
 
-#: core/models.py:767
+#: core/models.py:786
 msgid "Create rooms"
 msgstr "Crear reunión"
 
-#: core/models.py:768
+#: core/models.py:787
 msgid "List rooms"
 msgstr "Listar reuniones"
 
-#: core/models.py:769
+#: core/models.py:788
 msgid "Retrieve room details"
 msgstr "Ver los detalles de una reunión"
 
-#: core/models.py:770
+#: core/models.py:789
 msgid "Update rooms"
 msgstr "Actualizar las reuniones"
 
-#: core/models.py:771
+#: core/models.py:790
 msgid "Delete rooms"
 msgstr "Eliminar las reuniones"
 
-#: core/models.py:784
+#: core/models.py:803
 msgid "Application name"
 msgstr "Nombre de la aplicación"
 
-#: core/models.py:785
+#: core/models.py:804
 msgid "Descriptive name for this application."
 msgstr "Nombre descriptivo de esta aplicación."
 
-#: core/models.py:795
+#: core/models.py:814
 msgid "Hashed on Save. Copy it now if this is a new secret."
 msgstr "Se cifra al guardar. Cópialo ahora si se trata de un secreto nuevo."
 
-#: core/models.py:806
+#: core/models.py:825
 msgid "Application"
 msgstr "Aplicación"
 
-#: core/models.py:807
+#: core/models.py:826
 msgid "Applications"
 msgstr "Aplicaciones"
 
-#: core/models.py:830
+#: core/models.py:849
 msgid "Enter a valid domain"
 msgstr "Introduce un dominio válido"
 
-#: core/models.py:833
+#: core/models.py:852
 msgid "Domain"
 msgstr "Dominio"
 
-#: core/models.py:834
+#: core/models.py:853
 msgid "Email domain this application can act on behalf of."
-msgstr "Dominio de correo electrónico en cuyo nombre puede actuar esta aplicación."
+msgstr ""
+"Dominio de correo electrónico en cuyo nombre puede actuar esta aplicación."
 
-#: core/models.py:846
+#: core/models.py:865
 msgid "Application domain"
 msgstr "Dominio de aplicación"
 
-#: core/models.py:847
+#: core/models.py:866
 msgid "Application domains"
 msgstr "Dominios de aplicación"
 
-#: core/models.py:865
+#: core/models.py:884
 msgid "Pending"
 msgstr "Pendiente"
 
-#: core/models.py:866
+#: core/models.py:885
 msgid "Analyzing"
 msgstr "Analizando"
 
-#: core/models.py:873
+#: core/models.py:892
 msgid "Ready"
 msgstr "Listo"
 
-#: core/models.py:879
+#: core/models.py:898
 msgid "Background image"
 msgstr "Imagen de fondo"
 
-#: core/models.py:891
+#: core/models.py:910
 msgid "title"
 msgstr "título"
 
-#: core/models.py:915
+#: core/models.py:934
 msgid "Malware detection info when the analysis status is unsafe."
-msgstr "Información sobre la detección de malware cuando el estado del análisis no es seguro."
+msgstr ""
+"Información sobre la detección de malware cuando el estado del análisis no "
+"es seguro."
 
-#: core/models.py:920
+#: core/models.py:939
 msgid "File"
 msgstr "Archivo"
 
-#: core/models.py:921
+#: core/models.py:940
 msgid "Files"
 msgstr "Archivos"
 
-#: core/models.py:1041
+#: core/models.py:1060
 msgid "This file is already hard deleted."
 msgstr "Este archivo ya se ha eliminado definitivamente."
 
-#: core/models.py:1051
+#: core/models.py:1070
 msgid "To hard delete a file, it must first be soft deleted."
-msgstr "Para eliminar definitivamente un archivo, primero debe haberse marcado como eliminado."
+msgstr ""
+"Para eliminar definitivamente un archivo, primero debe haberse marcado como "
+"eliminado."
 
-#: core/recording/event/notification.py:123
+#: core/recording/event/notification.py:124
 msgid "Your recording is ready"
 msgstr "Tu grabación está lista"
 
-#: core/recording/event/notification.py:194
+#: core/recording/event/notification.py:195
 msgid "Transcription"
 msgstr "Transcripción"
 
-#: core/recording/event/notification.py:204
+#: core/recording/event/notification.py:206
 #, python-brace-format
 msgid "Meeting \"{room}\" on {room_recording_date} at {room_recording_time}"
-msgstr "Reunión \"{room}\" del {room_recording_date} a las {room_recording_time}"
+msgstr ""
+"Reunión \"{room}\" del {room_recording_date} a las {room_recording_time}"
 
 #: core/services/invitation.py:44
 #, python-brace-format
 msgid "Video call in progress: {sender.email} is waiting for you to connect"
 msgstr "Videollamada en curso: {sender.email} está esperando a que te conectes"
 
-#: core/templates/mail/html/invitation.html:159
-#: core/templates/mail/html/screen_recording.html:159
-#: core/templates/mail/text/invitation.txt:3
-#: core/templates/mail/text/screen_recording.txt:3
+#: core/templates/mail/html/invitation.html:151
+#: core/templates/mail/html/screen_recording.html:151
+#: core/templates/mail/text/invitation.txt:4
+#: core/templates/mail/text/screen_recording.txt:4
 msgid "Logo email"
 msgstr "Logotipo del correo"
 
-#: core/templates/mail/html/invitation.html:189
-#: core/templates/mail/text/invitation.txt:5
+#: core/templates/mail/html/invitation.html:181
+#: core/templates/mail/text/invitation.txt:6
 msgid "invites you to join an ongoing video call"
 msgstr "te invita a unirte a una videollamada en curso"
 
-#: core/templates/mail/html/invitation.html:200
-#: core/templates/mail/text/invitation.txt:7
+#: core/templates/mail/html/invitation.html:192
+#: core/templates/mail/text/invitation.txt:8
 msgid "JOIN THE CALL"
 msgstr "UNIRSE A LA LLAMADA"
 
-#: core/templates/mail/html/invitation.html:227
-#: core/templates/mail/text/invitation.txt:13
+#: core/templates/mail/html/invitation.html:219
+#: core/templates/mail/text/invitation.txt:14
 msgid ""
 "If you can't click the button, copy and paste the URL into your browser to "
 "join the call."
-msgstr "Si no puedes hacer clic en el botón, copia y pega la URL en tu navegador para unirte a la llamada."
+msgstr ""
+"Si no puedes hacer clic en el botón, copia y pega la URL en tu navegador "
+"para unirte a la llamada."
 
-#: core/templates/mail/html/invitation.html:235
-#: core/templates/mail/text/invitation.txt:15
+#: core/templates/mail/html/invitation.html:227
+#: core/templates/mail/text/invitation.txt:16
 msgid "Tips for a better experience:"
 msgstr "Consejos para una mejor experiencia:"
 
-#: core/templates/mail/html/invitation.html:237
-#: core/templates/mail/text/invitation.txt:17
+#: core/templates/mail/html/invitation.html:229
+#: core/templates/mail/text/invitation.txt:18
 msgid "Use Chrome or Firefox for better call quality"
 msgstr "Usa Chrome o Firefox para una mejor calidad de llamada"
 
-#: core/templates/mail/html/invitation.html:238
-#: core/templates/mail/text/invitation.txt:18
+#: core/templates/mail/html/invitation.html:230
+#: core/templates/mail/text/invitation.txt:19
 msgid "Test your microphone and camera before joining"
 msgstr "Prueba tu micrófono y tu cámara antes de unirte"
 
-#: core/templates/mail/html/invitation.html:239
-#: core/templates/mail/text/invitation.txt:19
+#: core/templates/mail/html/invitation.html:231
+#: core/templates/mail/text/invitation.txt:20
 msgid "Make sure you have a stable internet connection"
 msgstr "Asegúrate de tener una conexión a internet estable"
 
-#: core/templates/mail/html/invitation.html:248
-#: core/templates/mail/html/screen_recording.html:245
-#: core/templates/mail/text/invitation.txt:21
-#: core/templates/mail/text/screen_recording.txt:23
+#: core/templates/mail/html/invitation.html:240
+#: core/templates/mail/html/screen_recording.html:237
+#: core/templates/mail/text/invitation.txt:22
+#: core/templates/mail/text/screen_recording.txt:24
 #, python-format
 msgid " Thank you for using %(brandname)s. "
 msgstr " Gracias por usar %(brandname)s. "
 
-#: core/templates/mail/html/screen_recording.html:188
-#: core/templates/mail/text/screen_recording.txt:6
+#: core/templates/mail/html/invitation.html:271
+#, python-format
+msgid ""
+"This mail has been sent to %(email)s by <a href=\"%(href)s\">%(name)s</a>"
+msgstr ""
+
+#: core/templates/mail/html/screen_recording.html:180
+#: core/templates/mail/text/screen_recording.txt:7
 msgid "Your recording is ready!"
 msgstr "¡Tu grabación está lista!"
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid ""
 " Your recording of \"%(room_name)s\" on %(recording_date)s at "
 "%(recording_time)s is now ready to download. "
-msgstr " Tu grabación de \"%(room_name)s\" del %(recording_date)s a las %(recording_time)s ya está lista para descargar. "
+msgstr ""
+" Tu grabación de \"%(room_name)s\" del %(recording_date)s a las "
+"%(recording_time)s ya está lista para descargar. "
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid " The recording will expire in %(days)s days. "
 msgstr " La grabación caducará dentro de %(days)s días. "
 
-#: core/templates/mail/html/screen_recording.html:200
-#: core/templates/mail/text/screen_recording.txt:9
+#: core/templates/mail/html/screen_recording.html:192
+#: core/templates/mail/text/screen_recording.txt:10
 msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
-msgstr " Compartir la grabación mediante un enlace todavía no está disponible. Solo los organizadores pueden descargarla. "
+msgstr ""
+" Compartir la grabación mediante un enlace todavía no está disponible. Solo "
+"los organizadores pueden descargarla. "
 
-#: core/templates/mail/html/screen_recording.html:206
-#: core/templates/mail/text/screen_recording.txt:11
+#: core/templates/mail/html/screen_recording.html:198
+#: core/templates/mail/text/screen_recording.txt:12
 msgid "To keep this recording permanently:"
 msgstr "Para conservar esta grabación de forma permanente:"
 
-#: core/templates/mail/html/screen_recording.html:208
+#: core/templates/mail/html/screen_recording.html:200
 #, python-format
 msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
-msgstr "Haz clic en el enlace \"<a href=\"%(link)s\">Abrir</a>\" que aparece abajo "
+msgstr ""
+"Haz clic en el enlace \"<a href=\"%(link)s\">Abrir</a>\" que aparece abajo "
 
-#: core/templates/mail/html/screen_recording.html:209
-#: core/templates/mail/text/screen_recording.txt:14
+#: core/templates/mail/html/screen_recording.html:201
+#: core/templates/mail/text/screen_recording.txt:15
 msgid "Use the \"Download\" button in the interface "
 msgstr "Usa el botón \"Descargar\" de la interfaz "
 
-#: core/templates/mail/html/screen_recording.html:210
-#: core/templates/mail/text/screen_recording.txt:15
+#: core/templates/mail/html/screen_recording.html:202
+#: core/templates/mail/text/screen_recording.txt:16
 msgid "Save the file to your preferred location"
 msgstr "Guarda el archivo en la ubicación que prefieras"
 
-#: core/templates/mail/html/screen_recording.html:221
-#: core/templates/mail/text/screen_recording.txt:17
+#: core/templates/mail/html/screen_recording.html:213
+#: core/templates/mail/text/screen_recording.txt:18
 msgid "Open"
 msgstr "Abrir"
 
-#: core/templates/mail/html/screen_recording.html:230
-#: core/templates/mail/text/screen_recording.txt:19
+#: core/templates/mail/html/screen_recording.html:222
+#: core/templates/mail/text/screen_recording.txt:20
 #, python-format
 msgid ""
 " If you have any questions or need assistance, please contact our support "
 "team at %(support_email)s. "
-msgstr " Si tienes alguna pregunta o necesitas ayuda, ponte en contacto con nuestro equipo de soporte en %(support_email)s. "
+msgstr ""
+" Si tienes alguna pregunta o necesitas ayuda, ponte en contacto con nuestro "
+"equipo de soporte en %(support_email)s. "
 
-#: core/templates/mail/text/screen_recording.txt:13
+#: core/templates/mail/text/invitation.txt:24
+#, python-format
+msgid "This mail has been sent to %(email)s by %(name)s [%(href)s]"
+msgstr ""
+
+#: core/templates/mail/text/screen_recording.txt:14
 #, python-format
 msgid "Click the \"Open [%(link)s]\" link below "
 msgstr "Haz clic en el enlace \"Abrir [%(link)s]\" que aparece abajo "
 
-#: meet/settings.py:228
+#: meet/settings.py:238
 msgid "English"
 msgstr "Inglés"
 
-#: meet/settings.py:229
+#: meet/settings.py:239
 msgid "French"
 msgstr "Francés"
 
-#: meet/settings.py:230
+#: meet/settings.py:240
 msgid "Dutch"
 msgstr "Neerlandés"
 
-#: meet/settings.py:231
+#: meet/settings.py:241
 msgid "German"
 msgstr "Alemán"
 
-#: meet/settings.py:233
+#: meet/settings.py:242
 msgid "Spanish"
 msgstr "Español"

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-02 10:47+0000\n"
+"POT-Creation-Date: 2026-09-02 22:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: antoine.lebaud@mail.numerique.gouv.fr\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,11 +51,11 @@ msgstr ""
 msgid "File preview"
 msgstr ""
 
-#: core/admin.py:300 core/admin.py:443
+#: core/admin.py:300 core/admin.py:450
 msgid "No owner"
 msgstr "Pas de propriétaire"
 
-#: core/admin.py:303 core/admin.py:446
+#: core/admin.py:303 core/admin.py:453
 msgid "Multiple owners"
 msgstr "Plusieurs propriétaires"
 
@@ -99,11 +99,11 @@ msgstr ""
 msgid "Skipped %(count)s recording(s) with an ineligible status."
 msgstr "%(count)s enregistrement(s) avec un statut inéligible ignoré(s)."
 
-#: core/admin.py:510
+#: core/admin.py:517
 msgid "No scopes"
 msgstr "Aucun scopes"
 
-#: core/admin.py:512
+#: core/admin.py:519
 msgid "Scopes"
 msgstr "Scopes"
 
@@ -111,187 +111,203 @@ msgstr "Scopes"
 msgid "Creator is me"
 msgstr "Je suis le créateur"
 
-#: core/api/serializers.py:89
+#: core/api/serializers.py:108
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Vous devez être administrateur ou propriétaire d'une salle pour y ajouter "
 "des accès."
 
-#: core/api/serializers.py:534
+#: core/api/serializers.py:560
 msgid "This file extension is not allowed."
 msgstr "Cette extension n'est pas autorisée"
 
-#: core/api/viewsets.py:1222
+#: core/api/viewsets.py:1268
 msgid "You have reached the maximum number of files for this type."
 msgstr "Vous avez atteint le nombre maximum de fichiers de ce type"
 
-#: core/models.py:37
+#: core/models.py:38
 msgid "Member"
 msgstr "Membre"
 
-#: core/models.py:38
+#: core/models.py:39
 msgid "Administrator"
 msgstr "Administrateur"
 
-#: core/models.py:39
+#: core/models.py:40
 msgid "Owner"
 msgstr "Propriétaire"
 
-#: core/models.py:55
+#: core/models.py:56
 msgid "Initiated"
 msgstr "Initié"
 
-#: core/models.py:56
+#: core/models.py:57
 msgid "Active"
 msgstr "Actif"
 
-#: core/models.py:57
+#: core/models.py:58
 msgid "Stopped"
 msgstr "Arrêté"
 
-#: core/models.py:58
+#: core/models.py:59
 msgid "Saved"
 msgstr "Enregistré"
 
-#: core/models.py:59
+#: core/models.py:60
 msgid "Aborted"
 msgstr "Abandonné"
 
-#: core/models.py:60
+#: core/models.py:61
 msgid "Failed to Start"
 msgstr "Échec au démarrage"
 
-#: core/models.py:61
+#: core/models.py:62
 msgid "Failed to Stop"
 msgstr "Échec à l'arrêt"
 
-#: core/models.py:62
+#: core/models.py:63
 msgid "Notification succeeded"
 msgstr "Notification réussie"
 
-#: core/models.py:65
+#: core/models.py:66
 msgid "External process successful"
 msgstr "Traitement externe : succès"
 
-#: core/models.py:67
+#: core/models.py:68
 msgid "External process failed"
 msgstr "Traitement externe : erreur"
 
-#: core/models.py:96
+#: core/models.py:97
 msgid "SCREEN_RECORDING"
 msgstr "ENREGISTREMENT_ÉCRAN"
 
-#: core/models.py:97
+#: core/models.py:98
 msgid "TRANSCRIPT"
 msgstr "TRANSCRIPTION"
 
-#: core/models.py:103
+#: core/models.py:104
 msgid "Public Access"
 msgstr "Accès public"
 
-#: core/models.py:104
+#: core/models.py:105
 msgid "Trusted Access"
 msgstr "Accès de confiance"
 
-#: core/models.py:105
+#: core/models.py:106
 msgid "Restricted Access"
 msgstr "Accès restreint"
 
-#: core/models.py:117
+#: core/models.py:118
 msgid "id"
 msgstr "id"
 
-#: core/models.py:118
+#: core/models.py:119
 msgid "primary key for the record as UUID"
 msgstr "clé primaire pour l'enregistrement sous forme d'UUID"
 
-#: core/models.py:124
+#: core/models.py:125
 msgid "created on"
 msgstr "créé le"
 
-#: core/models.py:125
+#: core/models.py:126
 msgid "date and time at which a record was created"
 msgstr "date et heure auxquelles un enregistrement a été créé"
 
-#: core/models.py:130
+#: core/models.py:131
 msgid "updated on"
 msgstr "mis à jour le"
 
-#: core/models.py:131
+#: core/models.py:132
 msgid "date and time at which a record was last updated"
 msgstr ""
 "date et heure auxquelles un enregistrement a été mis à jour pour la dernière "
 "fois"
 
-#: core/models.py:151
-msgid ""
-"Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
-"_ characters."
-msgstr ""
-"Entrez un sub valide. Cette valeur ne peut contenir que des lettres, des "
-"chiffres et les caractères @/./+/-/_."
-
-#: core/models.py:157
+#: core/models.py:150
 msgid "sub"
 msgstr "sub"
 
-#: core/models.py:159
+#: core/models.py:152
 msgid ""
 "Optional for pending users; required upon account activation. 255 characters "
-"or fewer. Letters, numbers, and @/./+/-/_ characters only."
+"or fewer. Printable ASCII characters only."
 msgstr ""
-"Optionnel pour les utilisateurs en attente ; requis lors de l'activation du "
-"compte. 255 caractères maximum. Lettres, chiffres et @/./+/-/_ uniquement."
+"Facultatif pour les utilisateurs en attente ; obligatoire lors de l’activation "
+"du compte. 255 caractères maximum. Caractères ASCII imprimables uniquement."
 
-#: core/models.py:168
+#: core/validators.py:22
+msgid "Enter a valid sub. This value should be printable ASCII only."
+msgstr "Saisissez un sub valide. Cette valeur ne doit contenir que des caractères ASCII imprimables."
+
+#: core/models.py:161
 msgid "identity email address"
 msgstr "adresse e-mail d'identité"
 
-#: core/models.py:173
+#: core/models.py:166
 msgid "admin email address"
 msgstr "adresse e-mail d'administrateur"
 
-#: core/models.py:175
+#: core/models.py:168
 msgid "full name"
 msgstr "nom complet"
 
-#: core/models.py:177
+#: core/models.py:170
 msgid "short name"
 msgstr "nom court"
 
-#: core/models.py:183
+#: core/models.py:176
 msgid "language"
 msgstr "langue"
 
-#: core/models.py:184
+#: core/models.py:177
 msgid "The language in which the user wants to see the interface."
 msgstr "La langue dans laquelle l'utilisateur souhaite voir l'interface."
 
-#: core/models.py:190
+#: core/models.py:183
 msgid "The timezone in which the user wants to see times."
 msgstr "Le fuseau horaire dans lequel l'utilisateur souhaite voir les heures."
 
-#: core/models.py:193
+#: core/models.py:190
+msgid "default room access level"
+msgstr ""
+
+#: core/models.py:192
+msgid ""
+"Access level applied by default to new rooms created by this user. When "
+"empty, the instance default is used."
+msgstr ""
+
+#: core/models.py:199
+#, fuzzy
+#| msgid "Visio room configuration"
+msgid "default room configuration"
+msgstr "Configuration de la salle de visioconférence"
+
+#: core/models.py:201
+msgid "Configurations applied by default to new rooms created by this user."
+msgstr ""
+
+#: core/models.py:205
 msgid "device"
 msgstr "appareil"
 
-#: core/models.py:195
+#: core/models.py:207
 msgid "Whether the user is a device or a real user."
 msgstr "Si l'utilisateur est un appareil ou un utilisateur réel."
 
-#: core/models.py:198
+#: core/models.py:210
 msgid "staff status"
 msgstr "statut du personnel"
 
-#: core/models.py:200
+#: core/models.py:212
 msgid "Whether the user can log into this admin site."
 msgstr "Si l'utilisateur peut se connecter à ce site d'administration."
 
-#: core/models.py:203
+#: core/models.py:215
 msgid "active"
 msgstr "actif"
 
-#: core/models.py:206
+#: core/models.py:218
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
@@ -299,65 +315,65 @@ msgstr ""
 "Si cet utilisateur doit être traité comme actif. Désélectionnez cette option "
 "au lieu de supprimer des comptes."
 
-#: core/models.py:219
+#: core/models.py:231
 msgid "user"
 msgstr "utilisateur"
 
-#: core/models.py:220
+#: core/models.py:232
 msgid "users"
 msgstr "utilisateurs"
 
-#: core/models.py:286
+#: core/models.py:298
 msgid "Resource"
 msgstr "Ressource"
 
-#: core/models.py:287
+#: core/models.py:299
 msgid "Resources"
 msgstr "Ressources"
 
-#: core/models.py:345
+#: core/models.py:357
 msgid "Resource access"
 msgstr "Accès aux ressources"
 
-#: core/models.py:346
+#: core/models.py:358
 msgid "Resource accesses"
 msgstr "Accès aux ressources"
 
-#: core/models.py:352
+#: core/models.py:364
 msgid "Resource access with this User and Resource already exists."
 msgstr ""
 "L'accès à la ressource avec cet utilisateur et cette ressource existe déjà."
 
-#: core/models.py:409
+#: core/models.py:421
 msgid "Visio room configuration"
 msgstr "Configuration de la salle de visioconférence"
 
-#: core/models.py:410
+#: core/models.py:422
 msgid "Values for Visio parameters to configure the room."
 msgstr "Valeurs des paramètres de visioconférence pour configurer la salle."
 
-#: core/models.py:417
+#: core/models.py:429
 msgid "Room PIN code"
 msgstr "Code PIN de la salle"
 
-#: core/models.py:418
+#: core/models.py:430
 msgid "Unique n-digit code that identifies this room in telephony mode."
 msgstr ""
 "Code unique à n chiffres qui identifie cette salle en mode téléphonique."
 
-#: core/models.py:424 core/models.py:578
+#: core/models.py:436 core/models.py:597
 msgid "Room"
 msgstr "Salle"
 
-#: core/models.py:425
+#: core/models.py:437
 msgid "Rooms"
 msgstr "Salles"
 
-#: core/models.py:589
+#: core/models.py:608
 msgid "Worker ID"
 msgstr "ID du Worker"
 
-#: core/models.py:591
+#: core/models.py:610
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
@@ -365,170 +381,170 @@ msgstr ""
 "Entrez un identifiant pour l'enregistrement du Worker. Cet identifiant est "
 "conservé même lorsque le Worker s'arrête, permettant un suivi facile."
 
-#: core/models.py:599
+#: core/models.py:618
 msgid "Recording mode"
 msgstr "Mode d'enregistrement"
 
-#: core/models.py:600
+#: core/models.py:619
 msgid "Defines the mode of recording being called."
 msgstr "Définit le mode d'enregistrement appelé."
 
-#: core/models.py:605 core/models.py:606
+#: core/models.py:624 core/models.py:625
 msgid "Recording options"
 msgstr "Options d'enregistrement"
 
-#: core/models.py:613
+#: core/models.py:632
 msgid "External Process ID"
 msgstr "ID Traitement externe"
 
-#: core/models.py:614
+#: core/models.py:633
 msgid "ID of the external process associated with the recording."
 msgstr "ID du traitement externe associé avec l'enregistrement."
 
-#: core/models.py:620
+#: core/models.py:639
 msgid "Recording"
 msgstr "Enregistrement"
 
-#: core/models.py:621
+#: core/models.py:640
 msgid "Recordings"
 msgstr "Enregistrements"
 
-#: core/models.py:731
+#: core/models.py:750
 msgid "Recording/user relation"
 msgstr "Relation enregistrement/utilisateur"
 
-#: core/models.py:732
+#: core/models.py:751
 msgid "Recording/user relations"
 msgstr "Relations enregistrement/utilisateur"
 
-#: core/models.py:738
+#: core/models.py:757
 msgid "This user is already in this recording."
 msgstr "Cet utilisateur est déjà dans cet enregistrement."
 
-#: core/models.py:744
+#: core/models.py:763
 msgid "This team is already in this recording."
 msgstr "Cette équipe est déjà dans cet enregistrement."
 
-#: core/models.py:750
+#: core/models.py:769
 msgid "Either user or team must be set, not both."
 msgstr "Soit l'utilisateur, soit l'équipe doit être défini, pas les deux."
 
-#: core/models.py:767
+#: core/models.py:786
 msgid "Create rooms"
 msgstr "Créer des salles"
 
-#: core/models.py:768
+#: core/models.py:787
 msgid "List rooms"
 msgstr "Lister les salles"
 
-#: core/models.py:769
+#: core/models.py:788
 msgid "Retrieve room details"
 msgstr "Afficher les détails d’une salle"
 
-#: core/models.py:770
+#: core/models.py:789
 msgid "Update rooms"
 msgstr "Mettre à jour les salles"
 
-#: core/models.py:771
+#: core/models.py:790
 msgid "Delete rooms"
 msgstr "Supprimer les salles"
 
-#: core/models.py:784
+#: core/models.py:803
 msgid "Application name"
 msgstr "Nom de l’application"
 
-#: core/models.py:785
+#: core/models.py:804
 msgid "Descriptive name for this application."
 msgstr "Nom descriptif de cette application."
 
-#: core/models.py:795
+#: core/models.py:814
 msgid "Hashed on Save. Copy it now if this is a new secret."
 msgstr ""
 "Haché lors de l’enregistrement. Copiez-le maintenant s’il s’agit d’un "
 "nouveau secret."
 
-#: core/models.py:806
+#: core/models.py:825
 msgid "Application"
 msgstr "Application"
 
-#: core/models.py:807
+#: core/models.py:826
 msgid "Applications"
 msgstr "Applications"
 
-#: core/models.py:830
+#: core/models.py:849
 msgid "Enter a valid domain"
 msgstr "Saisissez un domaine valide"
 
-#: core/models.py:833
+#: core/models.py:852
 msgid "Domain"
 msgstr "Domaine"
 
-#: core/models.py:834
+#: core/models.py:853
 msgid "Email domain this application can act on behalf of."
 msgstr "Domaine de messagerie au nom duquel cette application peut agir."
 
-#: core/models.py:846
+#: core/models.py:865
 msgid "Application domain"
 msgstr "Domaine d’application"
 
-#: core/models.py:847
+#: core/models.py:866
 msgid "Application domains"
 msgstr "Domaines d’application"
 
-#: core/models.py:865
+#: core/models.py:884
 msgid "Pending"
 msgstr "En attente"
 
-#: core/models.py:866
+#: core/models.py:885
 msgid "Analyzing"
 msgstr ""
 
-#: core/models.py:873
+#: core/models.py:892
 msgid "Ready"
 msgstr "Prêt"
 
-#: core/models.py:879
+#: core/models.py:898
 msgid "Background image"
 msgstr "Image de fond"
 
-#: core/models.py:891
+#: core/models.py:910
 msgid "title"
 msgstr "Titre"
 
-#: core/models.py:915
+#: core/models.py:934
 msgid "Malware detection info when the analysis status is unsafe."
 msgstr ""
 "Information concernant la détection de Malware cand le statut n'est pas sain"
 
-#: core/models.py:920
+#: core/models.py:939
 msgid "File"
 msgstr "Fichier"
 
-#: core/models.py:921
+#: core/models.py:940
 msgid "Files"
 msgstr "Fichiers"
 
-#: core/models.py:1041
+#: core/models.py:1060
 #, fuzzy
 #| msgid "This user is already in this recording."
 msgid "This file is already hard deleted."
 msgstr "Ce fichier a été supprimé."
 
-#: core/models.py:1051
+#: core/models.py:1070
 msgid "To hard delete a file, it must first be soft deleted."
 msgstr ""
 "Pour supprimer définitivement un fichier il doit d'abord avoir été marqué "
 "comme supprimé (soft delete)"
 
-#: core/recording/event/notification.py:123
+#: core/recording/event/notification.py:124
 msgid "Your recording is ready"
 msgstr "Votre enregistrement est prêt"
 
-#: core/recording/event/notification.py:194
+#: core/recording/event/notification.py:195
 msgid "Transcription"
 msgstr "Transcription"
 
-#: core/recording/event/notification.py:204
+#: core/recording/event/notification.py:206
 #, python-brace-format
 msgid "Meeting \"{room}\" on {room_recording_date} at {room_recording_time}"
 msgstr "Réunion \"{room}\" du {room_recording_date} à {room_recording_time}"
@@ -538,25 +554,25 @@ msgstr "Réunion \"{room}\" du {room_recording_date} à {room_recording_time}"
 msgid "Video call in progress: {sender.email} is waiting for you to connect"
 msgstr "Appel vidéo en cours : {sender.email} attend que vous vous connectiez"
 
-#: core/templates/mail/html/invitation.html:159
-#: core/templates/mail/html/screen_recording.html:159
-#: core/templates/mail/text/invitation.txt:3
-#: core/templates/mail/text/screen_recording.txt:3
+#: core/templates/mail/html/invitation.html:151
+#: core/templates/mail/html/screen_recording.html:151
+#: core/templates/mail/text/invitation.txt:4
+#: core/templates/mail/text/screen_recording.txt:4
 msgid "Logo email"
 msgstr "Logo email"
 
-#: core/templates/mail/html/invitation.html:189
-#: core/templates/mail/text/invitation.txt:5
+#: core/templates/mail/html/invitation.html:181
+#: core/templates/mail/text/invitation.txt:6
 msgid "invites you to join an ongoing video call"
 msgstr "vous invite à rejoindre un appel vidéo en cours"
 
-#: core/templates/mail/html/invitation.html:200
-#: core/templates/mail/text/invitation.txt:7
+#: core/templates/mail/html/invitation.html:192
+#: core/templates/mail/text/invitation.txt:8
 msgid "JOIN THE CALL"
 msgstr "REJOINDRE L'APPEL"
 
-#: core/templates/mail/html/invitation.html:227
-#: core/templates/mail/text/invitation.txt:13
+#: core/templates/mail/html/invitation.html:219
+#: core/templates/mail/text/invitation.txt:14
 msgid ""
 "If you can't click the button, copy and paste the URL into your browser to "
 "join the call."
@@ -564,41 +580,47 @@ msgstr ""
 "Si vous ne pouvez pas cliquer sur le bouton, copiez et collez l'URL dans "
 "votre navigateur pour rejoindre l'appel."
 
-#: core/templates/mail/html/invitation.html:235
-#: core/templates/mail/text/invitation.txt:15
+#: core/templates/mail/html/invitation.html:227
+#: core/templates/mail/text/invitation.txt:16
 msgid "Tips for a better experience:"
 msgstr "Conseils pour une meilleure expérience :"
 
-#: core/templates/mail/html/invitation.html:237
-#: core/templates/mail/text/invitation.txt:17
+#: core/templates/mail/html/invitation.html:229
+#: core/templates/mail/text/invitation.txt:18
 msgid "Use Chrome or Firefox for better call quality"
 msgstr "Utilisez Chrome ou Firefox pour une meilleure qualité d'appel"
 
-#: core/templates/mail/html/invitation.html:238
-#: core/templates/mail/text/invitation.txt:18
+#: core/templates/mail/html/invitation.html:230
+#: core/templates/mail/text/invitation.txt:19
 msgid "Test your microphone and camera before joining"
 msgstr "Testez votre microphone et votre caméra avant de rejoindre"
 
-#: core/templates/mail/html/invitation.html:239
-#: core/templates/mail/text/invitation.txt:19
+#: core/templates/mail/html/invitation.html:231
+#: core/templates/mail/text/invitation.txt:20
 msgid "Make sure you have a stable internet connection"
 msgstr "Assurez-vous d'avoir une connexion Internet stable"
 
-#: core/templates/mail/html/invitation.html:248
-#: core/templates/mail/html/screen_recording.html:245
-#: core/templates/mail/text/invitation.txt:21
-#: core/templates/mail/text/screen_recording.txt:23
+#: core/templates/mail/html/invitation.html:240
+#: core/templates/mail/html/screen_recording.html:237
+#: core/templates/mail/text/invitation.txt:22
+#: core/templates/mail/text/screen_recording.txt:24
 #, python-format
 msgid " Thank you for using %(brandname)s. "
 msgstr " Merci d'utiliser %(brandname)s. "
 
-#: core/templates/mail/html/screen_recording.html:188
-#: core/templates/mail/text/screen_recording.txt:6
+#: core/templates/mail/html/invitation.html:271
+#, python-format
+msgid ""
+"This mail has been sent to %(email)s by <a href=\"%(href)s\">%(name)s</a>"
+msgstr ""
+
+#: core/templates/mail/html/screen_recording.html:180
+#: core/templates/mail/text/screen_recording.txt:7
 msgid "Your recording is ready!"
 msgstr "Votre enregistrement est prêt !"
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid ""
 " Your recording of \"%(room_name)s\" on %(recording_date)s at "
@@ -607,14 +629,14 @@ msgstr ""
 " Votre enregistrement de \"%(room_name)s\" du %(recording_date)s à "
 "%(recording_time)s est maintenant prêt à être téléchargé. "
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid " The recording will expire in %(days)s days. "
 msgstr " L'enregistrement expirera dans %(days)s jours. "
 
-#: core/templates/mail/html/screen_recording.html:200
-#: core/templates/mail/text/screen_recording.txt:9
+#: core/templates/mail/html/screen_recording.html:192
+#: core/templates/mail/text/screen_recording.txt:10
 msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
@@ -622,33 +644,33 @@ msgstr ""
 "Le partage de l'enregistrement via lien n'est pas encore disponible. Seuls "
 "les organisateurs peuvent le télécharger."
 
-#: core/templates/mail/html/screen_recording.html:206
-#: core/templates/mail/text/screen_recording.txt:11
+#: core/templates/mail/html/screen_recording.html:198
+#: core/templates/mail/text/screen_recording.txt:12
 msgid "To keep this recording permanently:"
 msgstr "Pour conserver cet enregistrement de façon permanente :"
 
-#: core/templates/mail/html/screen_recording.html:208
+#: core/templates/mail/html/screen_recording.html:200
 #, python-format
 msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 msgstr "Cliquez sur le lien \"<a href=\"%(link)s\">Ouvrir</a>\" ci-dessous "
 
-#: core/templates/mail/html/screen_recording.html:209
-#: core/templates/mail/text/screen_recording.txt:14
+#: core/templates/mail/html/screen_recording.html:201
+#: core/templates/mail/text/screen_recording.txt:15
 msgid "Use the \"Download\" button in the interface "
 msgstr "Utilisez le bouton \"Télécharger\" dans l'interface "
 
-#: core/templates/mail/html/screen_recording.html:210
-#: core/templates/mail/text/screen_recording.txt:15
+#: core/templates/mail/html/screen_recording.html:202
+#: core/templates/mail/text/screen_recording.txt:16
 msgid "Save the file to your preferred location"
 msgstr "Enregistrez le fichier à l'emplacement de votre choix"
 
-#: core/templates/mail/html/screen_recording.html:221
-#: core/templates/mail/text/screen_recording.txt:17
+#: core/templates/mail/html/screen_recording.html:213
+#: core/templates/mail/text/screen_recording.txt:18
 msgid "Open"
 msgstr "Ouvrir"
 
-#: core/templates/mail/html/screen_recording.html:230
-#: core/templates/mail/text/screen_recording.txt:19
+#: core/templates/mail/html/screen_recording.html:222
+#: core/templates/mail/text/screen_recording.txt:20
 #, python-format
 msgid ""
 " If you have any questions or need assistance, please contact our support "
@@ -657,28 +679,33 @@ msgstr ""
 " Si vous avez des questions ou besoin d'assistance, veuillez contacter notre "
 "équipe d'assistance à %(support_email)s. "
 
-#: core/templates/mail/text/screen_recording.txt:13
+#: core/templates/mail/text/invitation.txt:24
+#, python-format
+msgid "This mail has been sent to %(email)s by %(name)s [%(href)s]"
+msgstr ""
+
+#: core/templates/mail/text/screen_recording.txt:14
 #, fuzzy, python-format
 #| msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 msgid "Click the \"Open [%(link)s]\" link below "
 msgstr "Cliquez sur le lien \"<a href=\"%(link)s\">Ouvrir</a>\" ci-dessous "
 
-#: meet/settings.py:228
+#: meet/settings.py:238
 msgid "English"
 msgstr "Anglais"
 
-#: meet/settings.py:229
+#: meet/settings.py:239
 msgid "French"
 msgstr "Français"
 
-#: meet/settings.py:230
+#: meet/settings.py:240
 msgid "Dutch"
 msgstr "Néerlandais"
 
-#: meet/settings.py:231
+#: meet/settings.py:241
 msgid "German"
 msgstr "Allemand"
 
-#: meet/settings.py:233
+#: meet/settings.py:242
 msgid "Spanish"
 msgstr "Espagnol"

--- a/src/backend/locale/nl_NL/LC_MESSAGES/django.po
+++ b/src/backend/locale/nl_NL/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-02 10:47+0000\n"
+"POT-Creation-Date: 2026-09-02 22:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,11 +51,11 @@ msgstr ""
 msgid "File preview"
 msgstr ""
 
-#: core/admin.py:300 core/admin.py:443
+#: core/admin.py:300 core/admin.py:450
 msgid "No owner"
 msgstr "Geen eigenaar"
 
-#: core/admin.py:303 core/admin.py:446
+#: core/admin.py:303 core/admin.py:453
 msgid "Multiple owners"
 msgstr "Meerdere eigenaren"
 
@@ -98,11 +98,11 @@ msgstr "%(count)s opname(s) succesvol gemarkeerd als 'Mislukt bij stoppen'."
 msgid "Skipped %(count)s recording(s) with an ineligible status."
 msgstr "%(count)s opname(s) met een niet-toegestane status overgeslagen."
 
-#: core/admin.py:510
+#: core/admin.py:517
 msgid "No scopes"
 msgstr "Geen scopes"
 
-#: core/admin.py:512
+#: core/admin.py:519
 msgid "Scopes"
 msgstr "Scopes"
 
@@ -110,184 +110,200 @@ msgstr "Scopes"
 msgid "Creator is me"
 msgstr "Maker ben ik"
 
-#: core/api/serializers.py:89
+#: core/api/serializers.py:108
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Je moet beheerder of eigenaar van een ruimte zijn om toegang toe te voegen."
 
-#: core/api/serializers.py:534
+#: core/api/serializers.py:560
 msgid "This file extension is not allowed."
 msgstr "Deze bestandsextensie is niet toegestaan."
 
-#: core/api/viewsets.py:1222
+#: core/api/viewsets.py:1268
 msgid "You have reached the maximum number of files for this type."
 msgstr "Het maximale aantal bestanden voor dit type is bereikt."
 
-#: core/models.py:37
+#: core/models.py:38
 msgid "Member"
 msgstr "Lid"
 
-#: core/models.py:38
+#: core/models.py:39
 msgid "Administrator"
 msgstr "Beheerder"
 
-#: core/models.py:39
+#: core/models.py:40
 msgid "Owner"
 msgstr "Eigenaar"
 
-#: core/models.py:55
+#: core/models.py:56
 msgid "Initiated"
 msgstr "Gestart"
 
-#: core/models.py:56
+#: core/models.py:57
 msgid "Active"
 msgstr "Actief"
 
-#: core/models.py:57
+#: core/models.py:58
 msgid "Stopped"
 msgstr "Gestopt"
 
-#: core/models.py:58
+#: core/models.py:59
 msgid "Saved"
 msgstr "Opgeslagen"
 
-#: core/models.py:59
+#: core/models.py:60
 msgid "Aborted"
 msgstr "Afgebroken"
 
-#: core/models.py:60
+#: core/models.py:61
 msgid "Failed to Start"
 msgstr "Starten mislukt"
 
-#: core/models.py:61
+#: core/models.py:62
 msgid "Failed to Stop"
 msgstr "Stoppen mislukt"
 
-#: core/models.py:62
+#: core/models.py:63
 msgid "Notification succeeded"
 msgstr "Notificatie geslaagd"
 
-#: core/models.py:65
+#: core/models.py:66
 msgid "External process successful"
 msgstr "Externe procedure succesvol"
 
-#: core/models.py:67
+#: core/models.py:68
 msgid "External process failed"
 msgstr "Het externe proces is mislukt."
 
-#: core/models.py:96
+#: core/models.py:97
 msgid "SCREEN_RECORDING"
 msgstr "SCHERM_OPNAME"
 
-#: core/models.py:97
+#: core/models.py:98
 msgid "TRANSCRIPT"
 msgstr "TRANSCRIPT"
 
-#: core/models.py:103
+#: core/models.py:104
 msgid "Public Access"
 msgstr "Openbare toegang"
 
-#: core/models.py:104
+#: core/models.py:105
 msgid "Trusted Access"
 msgstr "Vertrouwde toegang"
 
-#: core/models.py:105
+#: core/models.py:106
 msgid "Restricted Access"
 msgstr "Beperkte toegang"
 
-#: core/models.py:117
+#: core/models.py:118
 msgid "id"
 msgstr "id"
 
-#: core/models.py:118
+#: core/models.py:119
 msgid "primary key for the record as UUID"
 msgstr "primaire sleutel voor het record als UUID"
 
-#: core/models.py:124
+#: core/models.py:125
 msgid "created on"
 msgstr "aangemaakt op"
 
-#: core/models.py:125
+#: core/models.py:126
 msgid "date and time at which a record was created"
 msgstr "datum en tijd waarop een record werd aangemaakt"
 
-#: core/models.py:130
+#: core/models.py:131
 msgid "updated on"
 msgstr "bijgewerkt op"
 
-#: core/models.py:131
+#: core/models.py:132
 msgid "date and time at which a record was last updated"
 msgstr "datum en tijd waarop een record voor het laatst werd bijgewerkt"
 
-#: core/models.py:151
-msgid ""
-"Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
-"_ characters."
-msgstr ""
-"Voer een geldige sub in. Deze waarde mag alleen letters, cijfers en @/./+/-/"
-"_ tekens bevatten."
-
-#: core/models.py:157
+#: core/models.py:150
 msgid "sub"
 msgstr "sub"
 
-#: core/models.py:159
+#: core/models.py:152
 msgid ""
 "Optional for pending users; required upon account activation. 255 characters "
-"or fewer. Letters, numbers, and @/./+/-/_ characters only."
+"or fewer. Printable ASCII characters only."
 msgstr ""
-"Optioneel voor gebruikers in afwachting; vereist bij accountactivering. "
-"Maximum 255 tekens. Alleen letters, cijfers en @/./+/-/_ toegestaan."
+"Optioneel voor gebruikers in afwachting; verplicht bij het activeren van het "
+"account. Maximaal 255 tekens. Alleen afdrukbare ASCII-tekens."
 
-#: core/models.py:168
+#: core/validators.py:22
+msgid "Enter a valid sub. This value should be printable ASCII only."
+msgstr "Voer een geldige sub in. Deze waarde mag alleen afdrukbare ASCII-tekens bevatten."
+
+#: core/models.py:161
 msgid "identity email address"
 msgstr "identiteit e-mailadres"
 
-#: core/models.py:173
+#: core/models.py:166
 msgid "admin email address"
 msgstr "beheerder e-mailadres"
 
-#: core/models.py:175
+#: core/models.py:168
 msgid "full name"
 msgstr "volledige naam"
 
-#: core/models.py:177
+#: core/models.py:170
 msgid "short name"
 msgstr "korte naam"
 
-#: core/models.py:183
+#: core/models.py:176
 msgid "language"
 msgstr "taal"
 
-#: core/models.py:184
+#: core/models.py:177
 msgid "The language in which the user wants to see the interface."
 msgstr "De taal waarin de gebruiker de interface wil zien."
 
-#: core/models.py:190
+#: core/models.py:183
 msgid "The timezone in which the user wants to see times."
 msgstr "De tijdzone waarin de gebruiker tijden wil zien."
 
-#: core/models.py:193
+#: core/models.py:190
+msgid "default room access level"
+msgstr ""
+
+#: core/models.py:192
+msgid ""
+"Access level applied by default to new rooms created by this user. When "
+"empty, the instance default is used."
+msgstr ""
+
+#: core/models.py:199
+#, fuzzy
+#| msgid "Visio room configuration"
+msgid "default room configuration"
+msgstr "Visio-ruimteconfiguratie"
+
+#: core/models.py:201
+msgid "Configurations applied by default to new rooms created by this user."
+msgstr ""
+
+#: core/models.py:205
 msgid "device"
 msgstr "apparaat"
 
-#: core/models.py:195
+#: core/models.py:207
 msgid "Whether the user is a device or a real user."
 msgstr "Of de gebruiker een apparaat is of een echte gebruiker."
 
-#: core/models.py:198
+#: core/models.py:210
 msgid "staff status"
 msgstr "personeelsstatus"
 
-#: core/models.py:200
+#: core/models.py:212
 msgid "Whether the user can log into this admin site."
 msgstr "Of de gebruiker kan inloggen op deze beheersite."
 
-#: core/models.py:203
+#: core/models.py:215
 msgid "active"
 msgstr "actief"
 
-#: core/models.py:206
+#: core/models.py:218
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
@@ -295,64 +311,64 @@ msgstr ""
 "Of deze gebruiker als actief moet worden behandeld. Deselecteer dit in "
 "plaats van accounts te verwijderen."
 
-#: core/models.py:219
+#: core/models.py:231
 msgid "user"
 msgstr "gebruiker"
 
-#: core/models.py:220
+#: core/models.py:232
 msgid "users"
 msgstr "gebruikers"
 
-#: core/models.py:286
+#: core/models.py:298
 msgid "Resource"
 msgstr "Bron"
 
-#: core/models.py:287
+#: core/models.py:299
 msgid "Resources"
 msgstr "Bronnen"
 
-#: core/models.py:345
+#: core/models.py:357
 msgid "Resource access"
 msgstr "Brontoegang"
 
-#: core/models.py:346
+#: core/models.py:358
 msgid "Resource accesses"
 msgstr "Brontoegangsrechten"
 
-#: core/models.py:352
+#: core/models.py:364
 msgid "Resource access with this User and Resource already exists."
 msgstr "Brontoegang met deze gebruiker en bron bestaat al."
 
-#: core/models.py:409
+#: core/models.py:421
 msgid "Visio room configuration"
 msgstr "Visio-ruimteconfiguratie"
 
-#: core/models.py:410
+#: core/models.py:422
 msgid "Values for Visio parameters to configure the room."
 msgstr "Waarden voor Visio-parameters om de ruimte te configureren."
 
-#: core/models.py:417
+#: core/models.py:429
 msgid "Room PIN code"
 msgstr "Pincode van de kamer"
 
-#: core/models.py:418
+#: core/models.py:430
 msgid "Unique n-digit code that identifies this room in telephony mode."
 msgstr ""
 "Unieke n-cijferige code die deze kamer identificeert in telefonie-modus."
 
-#: core/models.py:424 core/models.py:578
+#: core/models.py:436 core/models.py:597
 msgid "Room"
 msgstr "Ruimte"
 
-#: core/models.py:425
+#: core/models.py:437
 msgid "Rooms"
 msgstr "Ruimtes"
 
-#: core/models.py:589
+#: core/models.py:608
 msgid "Worker ID"
 msgstr "Worker ID"
 
-#: core/models.py:591
+#: core/models.py:610
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
@@ -360,152 +376,152 @@ msgstr ""
 "Voer een identificatie in voor de worker-opname. Deze ID blijft behouden, "
 "zelfs wanneer de worker stopt, waardoor eenvoudige tracking mogelijk is."
 
-#: core/models.py:599
+#: core/models.py:618
 msgid "Recording mode"
 msgstr "Opnamemodus"
 
-#: core/models.py:600
+#: core/models.py:619
 msgid "Defines the mode of recording being called."
 msgstr "Definieert de modus van opname die wordt aangeroepen."
 
-#: core/models.py:605 core/models.py:606
+#: core/models.py:624 core/models.py:625
 msgid "Recording options"
 msgstr "Opnameopties"
 
-#: core/models.py:613
+#: core/models.py:632
 msgid "External Process ID"
 msgstr "Externe proces-ID"
 
-#: core/models.py:614
+#: core/models.py:633
 msgid "ID of the external process associated with the recording."
 msgstr "ID van het externe proces dat aan de opname is gekoppeld."
 
-#: core/models.py:620
+#: core/models.py:639
 msgid "Recording"
 msgstr "Opname"
 
-#: core/models.py:621
+#: core/models.py:640
 msgid "Recordings"
 msgstr "Opnames"
 
-#: core/models.py:731
+#: core/models.py:750
 msgid "Recording/user relation"
 msgstr "Opname/gebruiker-relatie"
 
-#: core/models.py:732
+#: core/models.py:751
 msgid "Recording/user relations"
 msgstr "Opname/gebruiker-relaties"
 
-#: core/models.py:738
+#: core/models.py:757
 msgid "This user is already in this recording."
 msgstr "Deze gebruiker is al in deze opname."
 
-#: core/models.py:744
+#: core/models.py:763
 msgid "This team is already in this recording."
 msgstr "Dit team is al in deze opname."
 
-#: core/models.py:750
+#: core/models.py:769
 msgid "Either user or team must be set, not both."
 msgstr "Ofwel gebruiker of team moet worden ingesteld, niet beide."
 
-#: core/models.py:767
+#: core/models.py:786
 msgid "Create rooms"
 msgstr "Ruimtes aanmaken"
 
-#: core/models.py:768
+#: core/models.py:787
 msgid "List rooms"
 msgstr "Ruimtes weergeven"
 
-#: core/models.py:769
+#: core/models.py:788
 msgid "Retrieve room details"
 msgstr "Details van een ruimte ophalen"
 
-#: core/models.py:770
+#: core/models.py:789
 msgid "Update rooms"
 msgstr "Ruimtes bijwerken"
 
-#: core/models.py:771
+#: core/models.py:790
 msgid "Delete rooms"
 msgstr "Ruimtes verwijderen"
 
-#: core/models.py:784
+#: core/models.py:803
 msgid "Application name"
 msgstr "Naam van de applicatie"
 
-#: core/models.py:785
+#: core/models.py:804
 msgid "Descriptive name for this application."
 msgstr "Beschrijvende naam voor deze applicatie."
 
-#: core/models.py:795
+#: core/models.py:814
 msgid "Hashed on Save. Copy it now if this is a new secret."
 msgstr ""
 "Wordt gehasht bij het opslaan. Kopieer het nu als dit een nieuw geheim is."
 
-#: core/models.py:806
+#: core/models.py:825
 msgid "Application"
 msgstr "Applicatie"
 
-#: core/models.py:807
+#: core/models.py:826
 msgid "Applications"
 msgstr "Applicaties"
 
-#: core/models.py:830
+#: core/models.py:849
 msgid "Enter a valid domain"
 msgstr "Voer een geldig domein in"
 
-#: core/models.py:833
+#: core/models.py:852
 msgid "Domain"
 msgstr "Domein"
 
-#: core/models.py:834
+#: core/models.py:853
 msgid "Email domain this application can act on behalf of."
 msgstr "E-maildomein namens welke deze applicatie kan handelen."
 
-#: core/models.py:846
+#: core/models.py:865
 msgid "Application domain"
 msgstr "Applicatiedomein"
 
-#: core/models.py:847
+#: core/models.py:866
 msgid "Application domains"
 msgstr "Applicatiedomeinen"
 
-#: core/models.py:865
+#: core/models.py:884
 msgid "Pending"
 msgstr "In afwachting"
 
-#: core/models.py:866
+#: core/models.py:885
 msgid "Analyzing"
 msgstr ""
 
-#: core/models.py:873
+#: core/models.py:892
 msgid "Ready"
 msgstr "Klaar"
 
-#: core/models.py:879
+#: core/models.py:898
 msgid "Background image"
 msgstr "Achtergrondafbeelding"
 
-#: core/models.py:891
+#: core/models.py:910
 msgid "title"
 msgstr "Titel"
 
-#: core/models.py:915
+#: core/models.py:934
 msgid "Malware detection info when the analysis status is unsafe."
 msgstr "Informatie over malwaredetectie wanneer de analysestatus onveilig is."
 
-#: core/models.py:920
+#: core/models.py:939
 msgid "File"
 msgstr "Bestand"
 
-#: core/models.py:921
+#: core/models.py:940
 msgid "Files"
 msgstr "Bestanden"
 
-#: core/models.py:1041
+#: core/models.py:1060
 msgid "This file is already hard deleted."
 msgstr "Dit bestand is al definitief verwijderd."
 
-#: core/models.py:1051
+#: core/models.py:1070
 #, fuzzy
 #| msgid "To hard delete a file, it must first be soft deleted."
 msgid "To hard delete a file, it must first be soft deleted."
@@ -513,15 +529,15 @@ msgstr ""
 "Om een bestand definitief te verwijderen, moet het eerst zacht verwijderd "
 "zijn."
 
-#: core/recording/event/notification.py:123
+#: core/recording/event/notification.py:124
 msgid "Your recording is ready"
 msgstr "Je opname is klaar"
 
-#: core/recording/event/notification.py:194
+#: core/recording/event/notification.py:195
 msgid "Transcription"
 msgstr "Transcriptie"
 
-#: core/recording/event/notification.py:204
+#: core/recording/event/notification.py:206
 #, python-brace-format
 msgid "Meeting \"{room}\" on {room_recording_date} at {room_recording_time}"
 msgstr ""
@@ -532,25 +548,25 @@ msgstr ""
 msgid "Video call in progress: {sender.email} is waiting for you to connect"
 msgstr "Video-oproep bezig: {sender.email} wacht op je verbinding"
 
-#: core/templates/mail/html/invitation.html:159
-#: core/templates/mail/html/screen_recording.html:159
-#: core/templates/mail/text/invitation.txt:3
-#: core/templates/mail/text/screen_recording.txt:3
+#: core/templates/mail/html/invitation.html:151
+#: core/templates/mail/html/screen_recording.html:151
+#: core/templates/mail/text/invitation.txt:4
+#: core/templates/mail/text/screen_recording.txt:4
 msgid "Logo email"
 msgstr "Logo e-mail"
 
-#: core/templates/mail/html/invitation.html:189
-#: core/templates/mail/text/invitation.txt:5
+#: core/templates/mail/html/invitation.html:181
+#: core/templates/mail/text/invitation.txt:6
 msgid "invites you to join an ongoing video call"
 msgstr "nodigt je uit om deel te nemen aan een lopende video-oproep"
 
-#: core/templates/mail/html/invitation.html:200
-#: core/templates/mail/text/invitation.txt:7
+#: core/templates/mail/html/invitation.html:192
+#: core/templates/mail/text/invitation.txt:8
 msgid "JOIN THE CALL"
 msgstr "NEEM DEEL AAN DE OPROEP"
 
-#: core/templates/mail/html/invitation.html:227
-#: core/templates/mail/text/invitation.txt:13
+#: core/templates/mail/html/invitation.html:219
+#: core/templates/mail/text/invitation.txt:14
 msgid ""
 "If you can't click the button, copy and paste the URL into your browser to "
 "join the call."
@@ -558,41 +574,47 @@ msgstr ""
 "Als je niet op de knop kunt klikken, kopieer en plak dan de URL in je "
 "browser om deel te nemen aan de oproep."
 
-#: core/templates/mail/html/invitation.html:235
-#: core/templates/mail/text/invitation.txt:15
+#: core/templates/mail/html/invitation.html:227
+#: core/templates/mail/text/invitation.txt:16
 msgid "Tips for a better experience:"
 msgstr "Tips voor een betere ervaring:"
 
-#: core/templates/mail/html/invitation.html:237
-#: core/templates/mail/text/invitation.txt:17
+#: core/templates/mail/html/invitation.html:229
+#: core/templates/mail/text/invitation.txt:18
 msgid "Use Chrome or Firefox for better call quality"
 msgstr "Gebruik Chrome of Firefox voor betere gesprekskwaliteit"
 
-#: core/templates/mail/html/invitation.html:238
-#: core/templates/mail/text/invitation.txt:18
+#: core/templates/mail/html/invitation.html:230
+#: core/templates/mail/text/invitation.txt:19
 msgid "Test your microphone and camera before joining"
 msgstr "Test je microfoon en camera voordat je deelneemt"
 
-#: core/templates/mail/html/invitation.html:239
-#: core/templates/mail/text/invitation.txt:19
+#: core/templates/mail/html/invitation.html:231
+#: core/templates/mail/text/invitation.txt:20
 msgid "Make sure you have a stable internet connection"
 msgstr "Zorg ervoor dat je een stabiele internetverbinding hebt"
 
-#: core/templates/mail/html/invitation.html:248
-#: core/templates/mail/html/screen_recording.html:245
-#: core/templates/mail/text/invitation.txt:21
-#: core/templates/mail/text/screen_recording.txt:23
+#: core/templates/mail/html/invitation.html:240
+#: core/templates/mail/html/screen_recording.html:237
+#: core/templates/mail/text/invitation.txt:22
+#: core/templates/mail/text/screen_recording.txt:24
 #, python-format
 msgid " Thank you for using %(brandname)s. "
 msgstr " Bedankt voor het gebruik van %(brandname)s. "
 
-#: core/templates/mail/html/screen_recording.html:188
-#: core/templates/mail/text/screen_recording.txt:6
+#: core/templates/mail/html/invitation.html:271
+#, python-format
+msgid ""
+"This mail has been sent to %(email)s by <a href=\"%(href)s\">%(name)s</a>"
+msgstr ""
+
+#: core/templates/mail/html/screen_recording.html:180
+#: core/templates/mail/text/screen_recording.txt:7
 msgid "Your recording is ready!"
 msgstr "Je opname is klaar!"
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid ""
 " Your recording of \"%(room_name)s\" on %(recording_date)s at "
@@ -601,14 +623,14 @@ msgstr ""
 " Je opname van \"%(room_name)s\" op %(recording_date)s om %(recording_time)s "
 "is nu klaar om te downloaden. "
 
-#: core/templates/mail/html/screen_recording.html:195
-#: core/templates/mail/text/screen_recording.txt:8
+#: core/templates/mail/html/screen_recording.html:187
+#: core/templates/mail/text/screen_recording.txt:9
 #, python-format
 msgid " The recording will expire in %(days)s days. "
 msgstr " De opname verloopt over %(days)s dagen. "
 
-#: core/templates/mail/html/screen_recording.html:200
-#: core/templates/mail/text/screen_recording.txt:9
+#: core/templates/mail/html/screen_recording.html:192
+#: core/templates/mail/text/screen_recording.txt:10
 msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
@@ -616,33 +638,33 @@ msgstr ""
 "Het delen van de opname via een link is nog niet beschikbaar. Alleen "
 "organisatoren kunnen deze downloaden."
 
-#: core/templates/mail/html/screen_recording.html:206
-#: core/templates/mail/text/screen_recording.txt:11
+#: core/templates/mail/html/screen_recording.html:198
+#: core/templates/mail/text/screen_recording.txt:12
 msgid "To keep this recording permanently:"
 msgstr "Om deze opname permanent te bewaren:"
 
-#: core/templates/mail/html/screen_recording.html:208
+#: core/templates/mail/html/screen_recording.html:200
 #, python-format
 msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 msgstr "Klik op de \"<a href=\"%(link)s\">Openen</a>\"-link hieronder "
 
-#: core/templates/mail/html/screen_recording.html:209
-#: core/templates/mail/text/screen_recording.txt:14
+#: core/templates/mail/html/screen_recording.html:201
+#: core/templates/mail/text/screen_recording.txt:15
 msgid "Use the \"Download\" button in the interface "
 msgstr "Gebruik de \"Download\"-knop in de interface "
 
-#: core/templates/mail/html/screen_recording.html:210
-#: core/templates/mail/text/screen_recording.txt:15
+#: core/templates/mail/html/screen_recording.html:202
+#: core/templates/mail/text/screen_recording.txt:16
 msgid "Save the file to your preferred location"
 msgstr "Sla het bestand op naar je gewenste locatie"
 
-#: core/templates/mail/html/screen_recording.html:221
-#: core/templates/mail/text/screen_recording.txt:17
+#: core/templates/mail/html/screen_recording.html:213
+#: core/templates/mail/text/screen_recording.txt:18
 msgid "Open"
 msgstr "Openen"
 
-#: core/templates/mail/html/screen_recording.html:230
-#: core/templates/mail/text/screen_recording.txt:19
+#: core/templates/mail/html/screen_recording.html:222
+#: core/templates/mail/text/screen_recording.txt:20
 #, python-format
 msgid ""
 " If you have any questions or need assistance, please contact our support "
@@ -651,28 +673,33 @@ msgstr ""
 " Als je vragen hebt of hulp nodig hebt, neem dan contact op met ons support "
 "team via %(support_email)s. "
 
-#: core/templates/mail/text/screen_recording.txt:13
+#: core/templates/mail/text/invitation.txt:24
+#, python-format
+msgid "This mail has been sent to %(email)s by %(name)s [%(href)s]"
+msgstr ""
+
+#: core/templates/mail/text/screen_recording.txt:14
 #, fuzzy, python-format
 #| msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 msgid "Click the \"Open [%(link)s]\" link below "
 msgstr "Klik op de \"<a href=\"%(link)s\">Openen</a>\"-link hieronder "
 
-#: meet/settings.py:228
+#: meet/settings.py:238
 msgid "English"
 msgstr "Engels"
 
-#: meet/settings.py:229
+#: meet/settings.py:239
 msgid "French"
 msgstr "Frans"
 
-#: meet/settings.py:230
+#: meet/settings.py:240
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: meet/settings.py:231
+#: meet/settings.py:241
 msgid "German"
 msgstr "Duits"
 
-#: meet/settings.py:233
+#: meet/settings.py:242
 msgid "Spanish"
 msgstr "Spaans"


### PR DESCRIPTION
The user `sub` field was rejecting some ASCII characters that are
actually valid according to the OIDC spec.

Loosen the validation to accept the full ASCII range except control
characters, so the field is compliant with the RFC and works with
any spec-compliant identity provider.

Based on the Stack Overflow discussion in question 279832.

Closes #1609.