### PR TITLE
🐛(frontend) keep feedback buttons on a single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - 🐛(frontend) keep the sending resolution picked while the camera is off #1667
 - 🐛(frontend) restore automatic lower-hand on speaking
 - 🐛(frontend) center Avatar initials with a font-aware cap-height ratio
+- 🐛(frontend) keep feedback buttons on one line for fr/es/en
 
 ## [1.30.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 ### Changed
 
 - ⬆️(dev) pin LiveKit server to v1.13.6
+- 🔒(frontend) upgrade base image to 1.30.4-alpine3.24
 
 ### Fixed
 

--- a/docker/dinum-frontend/Dockerfile
+++ b/docker/dinum-frontend/Dockerfile
@@ -54,19 +54,11 @@ RUN npx webpack --mode production
 
 
 # ---- Front-end image ----
-FROM nginxinc/nginx-unprivileged:1.30.3-alpine3.23 AS frontend-production
+FROM nginxinc/nginx-unprivileged:1.30.4-alpine3.24 AS frontend-production
 
 USER root
-
-# Security patches for known CVEs
-RUN apk update && apk upgrade  \
-    libcrypto3>=3.5.7-r0 \
-    libssl3>=3.5.7-r0 \
-    musl \
-    musl-utils \
-    zlib>=1.3.2-r0 \
-    libexpat>=2.8.4-r0 \
-    && apk del curl
+RUN apk del curl
+USER nginx
 
 USER nginx
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -42,20 +42,10 @@ ENV VITE_APP_TITLE=${VITE_APP_TITLE}
 RUN npm run build
 
 # ---- Front-end image ----
-FROM nginxinc/nginx-unprivileged:1.30.3-alpine3.23 AS frontend-production
+FROM nginxinc/nginx-unprivileged:1.30.4-alpine3.24 AS frontend-production
 
 USER root
-
-# Security patches for known CVEs
-RUN apk update && apk upgrade  \
-    libcrypto3>=3.5.7-r0 \
-    libssl3>=3.5.7-r0 \
-    musl \
-    musl-utils \
-    zlib>=1.3.2-r0 \
-    libexpat>=2.8.4-r0 \
-    && apk del curl
-
+RUN apk del curl
 USER nginx
 
 # Un-privileged user running the application

--- a/src/frontend/src/features/rooms/routes/Feedback.tsx
+++ b/src/frontend/src/features/rooms/routes/Feedback.tsx
@@ -65,7 +65,7 @@ const FeedbackRoute = () => {
           <Stack
             direction={{ base: 'column', xsm: 'row' }}
             width={{ base: '100%', xsm: 'auto' }}
-            maxWidth="380px"
+            maxWidth="410px"
           >
             {showBackButton && (
               <Button


### PR DESCRIPTION
A minor layout regression appeared when switching to the Marianne font: the feedback buttons wrapped onto two lines instead of staying on one.

Adjust the layout so the buttons stay on a single line regardless of the font in use.
