### PR TITLE
✨(frontend) align feedback buttons with rating card

### DIFF
--- a/src/frontend/src/features/rooms/components/Rating.tsx
+++ b/src/frontend/src/features/rooms/components/Rating.tsx
@@ -16,7 +16,7 @@ const Card = styled('div', {
     borderRadius: '0.25rem',
     boxShadow: '',
     width: '100%',
-    maxWidth: '380px',
+    maxWidth: '410px',
     minHeight: '196px',
   },
 })
@@ -229,7 +229,7 @@ const ConfirmationMessage = ({ onNext }: { onNext: () => void }) => {
   return (
     <Card
       style={{
-        maxWidth: '380px',
+        maxWidth: '410px',
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',

--- a/src/frontend/src/features/rooms/routes/Feedback.tsx
+++ b/src/frontend/src/features/rooms/routes/Feedback.tsx
@@ -24,7 +24,8 @@ const Heading = styled('h1', {
 })
 
 const buttonClass = css({
-  width: { base: '100%', xsm: 'auto' },
+  width: '100%',
+  flex: 1,
 })
 
 enum DisconnectReasonKey {
@@ -64,7 +65,7 @@ const FeedbackRoute = () => {
           <Heading>{t(`feedback.heading.${reasonKey || 'normal'}`)}</Heading>
           <Stack
             direction={{ base: 'column', xsm: 'row' }}
-            width={{ base: '100%', xsm: 'auto' }}
+            width="100%"
             maxWidth="410px"
           >
             {showBackButton && (


### PR DESCRIPTION
Match the button row width to the rating card (100%, max 410px) and make both buttons share it equally so their edges line up with the card.

