### PR TITLE
📈(frontend) include LiveKit SIDs in the connection analytics event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 
 ### Changed
 
+- 📈(frontend) include LiveKit SIDs in the connection analytics event
 - 🔇(backend) silence expected 401 warnings on /me
 - 🔇(backend) silence noisy request summary info logs
 

--- a/src/frontend/src/features/rooms/livekit/components/ConnectionObserver.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ConnectionObserver.tsx
@@ -71,20 +71,30 @@ export const ConnectionObserver = () => {
   useEffect(() => {
     if (!isAnalyticsEnabled) return
 
-    const handleConnection = () => {
+    const handleConnection = async () => {
       // Preserve original connection timestamp across reconnections to measure
       // total session duration from first connect to final disconnect.
       if (connectionStartTimeRef.current != null) return
       connectionStartTimeRef.current = Date.now()
-      void captureMediaEvent('connection-event', {})
+      const participantSid = room.localParticipant.sid
+      const roomSid = await room.getSid().catch(() => undefined)
+      void captureMediaEvent('connection-event', {
+        livekit_room_sid: roomSid,
+        livekit_participant_sid: participantSid,
+      })
     }
 
     const handleReconnect = () => {
       captureEvent('reconnect-event')
     }
 
-    const handleReconnected = () => {
-      captureEvent('reconnected-event')
+    const handleReconnected = async () => {
+      const participantSid = room.localParticipant.sid
+      const roomSid = await room.getSid().catch(() => undefined)
+      captureEvent('reconnected-event', {
+        livekit_room_sid: roomSid,
+        livekit_participant_sid: participantSid,
+      })
     }
 
     const handleSignalingConnect = () => {


### PR DESCRIPTION
Attach the LiveKit SIDs (room and participant) to the connection analytics event.

Makes it easier to debug problematic sessions and to correlate a room session with the corresponding LiveKit logs.
